### PR TITLE
Add `ConsolidatedTarget`

### DIFF
--- a/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		0D6ED2396B7AA4FCCB10F093 /* XCBreakpointList.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7C28A43616AE9FC78C05EE0 /* XCBreakpointList.swift */; };
 		0D85907F40BB6B647D855A72 /* SetTargetDependenciesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7832C26060C56DE2EAB1A1 /* SetTargetDependenciesTests.swift */; };
 		0F1A9B6BE970BA80097FCE6F /* PBXCopyFilesBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 958D118534D347C200B0701A /* PBXCopyFilesBuildPhase.swift */; };
+		0F37C560BE3496D2719954C1 /* Generator+ConsolidateTargets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 122794255D948CE01F06B5CA /* Generator+ConsolidateTargets.swift */; };
 		0F988C99D14D5314D5DE55AE /* CoreMotion.swift in Sources */ = {isa = PBXBuildFile; fileRef = B41944A58347442213CC45E6 /* CoreMotion.swift */; };
 		109B975FBDD50CF17D56A1EF /* _BazelForcedCompile_.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61C1B860E7015FBB3750A95 /* _BazelForcedCompile_.swift */; };
 		1238A9F19DF8C3E8C044C69C /* Generator+AddTargets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 865D483D2084AABC408B35CD /* Generator+AddTargets.swift */; };
@@ -97,6 +98,7 @@
 		4974B9AC4C2E129CC6088A1A /* Generator+CreateXcodeProj.swift in Sources */ = {isa = PBXBuildFile; fileRef = 703888D148E8FEB96A8F9716 /* Generator+CreateXcodeProj.swift */; };
 		4978BBDA23E2108C6410D537 /* XCScheme+Runnable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A6A84F2CC6A006E28720D2B /* XCScheme+Runnable.swift */; };
 		4A2573A7CE96E1ECA318EBA8 /* Generator+CreateXCSharedData.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDFD9E80A2C5CD8C7FD9857D /* Generator+CreateXCSharedData.swift */; };
+		4C9B7B38FF5ECE3142DB2E35 /* ConsolidatedTargetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22E436CA9D5D1BCA7C5E800B /* ConsolidatedTargetTests.swift */; };
 		4D10A242113D5E0A454F043B /* Dump.swift in Sources */ = {isa = PBXBuildFile; fileRef = 173203DBAEA88407DBBF109D /* Dump.swift */; };
 		4D2097EFFBD4914896E87BA8 /* _HashTable+Testing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87C0073B2B714F5319BE5A11 /* _HashTable+Testing.swift */; };
 		4E28CB9358C8A9F9182DA0E8 /* _Hashtable+Header.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20573500FA17CDB30A03469A /* _Hashtable+Header.swift */; };
@@ -425,6 +427,7 @@
 		0F33013AF820E4A2208AA350 /* OrderedDictionary+Equatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderedDictionary+Equatable.swift"; sourceTree = "<group>"; };
 		117052ABC66769C11B7F397A /* XCScheme+BuildAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCScheme+BuildAction.swift"; sourceTree = "<group>"; };
 		11EF80F5B25255A95D7D8D66 /* OrderedDictionary+Values.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderedDictionary+Values.swift"; sourceTree = "<group>"; };
+		122794255D948CE01F06B5CA /* Generator+ConsolidateTargets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Generator+ConsolidateTargets.swift"; sourceTree = "<group>"; };
 		1311F2E17F171A48A8E3B180 /* Dictionary+Enumerate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+Enumerate.swift"; sourceTree = "<group>"; };
 		133D091B34B3EB60A9400C02 /* PBXShellScriptBuildPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXShellScriptBuildPhase.swift; sourceTree = "<group>"; };
 		173203DBAEA88407DBBF109D /* Dump.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Dump.swift; sourceTree = "<group>"; };
@@ -442,6 +445,7 @@
 		20573500FA17CDB30A03469A /* _Hashtable+Header.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "_Hashtable+Header.swift"; sourceTree = "<group>"; };
 		2062B3E1312EAF079BC5E26C /* OrderedSet+Invariants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderedSet+Invariants.swift"; sourceTree = "<group>"; };
 		20A47D52C1A48A1ED498719F /* XcodeProj.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcodeProj.swift; sourceTree = "<group>"; };
+		22E436CA9D5D1BCA7C5E800B /* ConsolidatedTargetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsolidatedTargetTests.swift; sourceTree = "<group>"; };
 		230BF7ABCF5D7C48951A8641 /* XcodeProj+CustomDump.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XcodeProj+CustomDump.swift"; sourceTree = "<group>"; };
 		25072DE452FF8EC4AC148C4A /* GeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneratorTests.swift; sourceTree = "<group>"; };
 		2597D69F32EE134D35CA5EED /* Path+Extras.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Path+Extras.swift"; sourceTree = "<group>"; };
@@ -824,6 +828,7 @@
 				57369B9A38B6DCB2216526AE /* Generator.swift */,
 				E8EA3706E06DFF6DBA1DCBE0 /* Generator+AddBazelDependenciesTarget.swift */,
 				865D483D2084AABC408B35CD /* Generator+AddTargets.swift */,
+				122794255D948CE01F06B5CA /* Generator+ConsolidateTargets.swift */,
 				EBD705CC770A884D5A78D17D /* Generator+CreateFilesAndGroups.swift */,
 				C9558541CFD5066169CA9773 /* Generator+CreateProducts.swift */,
 				9522A589868D9D2C515C4822 /* Generator+CreateProject.swift */,
@@ -1064,6 +1069,7 @@
 				DACBE49740AB347EFAE8EC00 /* AddTargetsTests.swift */,
 				35445591FE5C7D2FCEF9533F /* BUILD */,
 				08416B4EDA557D797F63BB4F /* BuildSettingConditionalTests.swift */,
+				22E436CA9D5D1BCA7C5E800B /* ConsolidatedTargetTests.swift */,
 				A42EAB1A5AEF651AF8F6F865 /* CreateFilesAndGroupsTests.swift */,
 				A40EB7581064768B08E6C529 /* CreateProductsTest.swift */,
 				6A9607F1AB28FE727DED4651 /* CreateProjectTests.swift */,
@@ -1828,6 +1834,7 @@
 				F9312E0C5F409E17F509CC96 /* _BazelForcedCompile_.swift in Sources */,
 				75B34A42A3528868C8D25993 /* AddTargetsTests.swift in Sources */,
 				0A22A35B5C2350A27CA5A895 /* BuildSettingConditionalTests.swift in Sources */,
+				4C9B7B38FF5ECE3142DB2E35 /* ConsolidatedTargetTests.swift in Sources */,
 				6BEEFB6F9ABBD9DE61F18D20 /* CreateFilesAndGroupsTests.swift in Sources */,
 				72A3C7DA6BF74DE5F2EFC28C /* CreateProductsTest.swift in Sources */,
 				8D60F9D1D81FEDCE8DDF6B73 /* CreateProjectTests.swift in Sources */,
@@ -1882,6 +1889,7 @@
 				0BFA0A77F5504DCED931F795 /* FilePathResolver.swift in Sources */,
 				D5282EE65E49263620CA8490 /* Generator+AddBazelDependenciesTarget.swift in Sources */,
 				1238A9F19DF8C3E8C044C69C /* Generator+AddTargets.swift in Sources */,
+				0F37C560BE3496D2719954C1 /* Generator+ConsolidateTargets.swift in Sources */,
 				6BEA8E1A797CD3E05D0BAE40 /* Generator+CreateFilesAndGroups.swift in Sources */,
 				E573DCC118186C0FAB27ECD3 /* Generator+CreateProducts.swift in Sources */,
 				51F268CB997C75D3FFBE5DA7 /* Generator+CreateProject.swift in Sources */,

--- a/test/fixtures/generator/bwb_spec.json
+++ b/test/fixtures/generator/bwb_spec.json
@@ -210,6 +210,7 @@
                 "srcs": [
                     "tools/generator/test/AddTargetsTests.swift",
                     "tools/generator/test/BuildSettingConditionalTests.swift",
+                    "tools/generator/test/ConsolidatedTargetTests.swift",
                     "tools/generator/test/CreateFilesAndGroupsTests.swift",
                     "tools/generator/test/CreateProductsTest.swift",
                     "tools/generator/test/CreateProjectTests.swift",
@@ -481,6 +482,7 @@
                     "tools/generator/src/FilePathResolver.swift",
                     "tools/generator/src/Generator+AddBazelDependenciesTarget.swift",
                     "tools/generator/src/Generator+AddTargets.swift",
+                    "tools/generator/src/Generator+ConsolidateTargets.swift",
                     "tools/generator/src/Generator+CreateFilesAndGroups.swift",
                     "tools/generator/src/Generator+CreateProducts.swift",
                     "tools/generator/src/Generator+CreateProject.swift",

--- a/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
@@ -109,6 +109,7 @@
 		5506B4252CAAE4E99A1F6305 /* Xcode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85719B580D4DD168206038E1 /* Xcode.swift */; };
 		5882D06AA8D8637C76C6DC33 /* UserNotifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04CD2B0E70289D9F162FA3E1 /* UserNotifications.swift */; };
 		5984E222D27493D3C041A945 /* XCScheme+PathRunnable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 710E99FC78CD9522F4418635 /* XCScheme+PathRunnable.swift */; };
+		59E7A071C1A3448B297846D4 /* ConsolidatedTargetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0FEDB45F02638177A108FC /* ConsolidatedTargetTests.swift */; };
 		5D9D9A876397501E294EE0DB /* Generator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E366C31F049809D80BD7CF3D /* Generator.swift */; };
 		5E86FF5B228AE32DAB9CE44A /* BuildSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9570F5DB90273906103037E /* BuildSettings.swift */; };
 		5F50664E006EE645FFC8B076 /* CreateXcodeProjTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BC5B799900C53A6F581CF62 /* CreateXcodeProjTests.swift */; };
@@ -261,6 +262,7 @@
 		FBC1C2F7977EC950A5A8FBFC /* Generator+ProcessTargetMerges.swift in Sources */ = {isa = PBXBuildFile; fileRef = C57109CEAC1C92656CA79300 /* Generator+ProcessTargetMerges.swift */; };
 		FBD6CC5399F54335BAC4AD08 /* XCSwiftPackageProductDependency.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2432A0EDFA23A5A28222A6E /* XCSwiftPackageProductDependency.swift */; };
 		FC8F414E5E27000A18EA2767 /* BuildSettingConditional.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7331459DA932906C5CB4EF4 /* BuildSettingConditional.swift */; };
+		FD0DD65DE147F3E4255D23CE /* Generator+ConsolidateTargets.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB0EE19B56421A19598F7BFA /* Generator+ConsolidateTargets.swift */; };
 		FE0441491AA47513CF076348 /* XCScheme+BuildableReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = C38B898A6742977CE8C0E174 /* XCScheme+BuildableReference.swift */; };
 		FFBF629A61596A5CC71D8612 /* FilePathResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91FAEBD49D872651BA24005E /* FilePathResolver.swift */; };
 /* End PBXBuildFile section */
@@ -633,6 +635,7 @@
 		E8BB71068908E1D8FA3058CB /* OrderedDictionary+ExpressibleByDictionaryLiteral.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderedDictionary+ExpressibleByDictionaryLiteral.swift"; sourceTree = "<group>"; };
 		E95084ACBED4858D5559E399 /* Generator+CreateXCSchemes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Generator+CreateXCSchemes.swift"; sourceTree = "<group>"; };
 		E9A234AB51A97D97EE651298 /* OrderedSet+Partial SetAlgebra+Basics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderedSet+Partial SetAlgebra+Basics.swift"; sourceTree = "<group>"; };
+		EB0EE19B56421A19598F7BFA /* Generator+ConsolidateTargets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Generator+ConsolidateTargets.swift"; sourceTree = "<group>"; };
 		EC5DDE735367F49D1F8347A4 /* Target+Testing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Target+Testing.swift"; sourceTree = "<group>"; };
 		ECF2375E72B499C63E3F5AD9 /* ReferenceGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReferenceGenerator.swift; sourceTree = "<group>"; };
 		EE02F42B39232603B27F1E90 /* CoreLocation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreLocation.swift; sourceTree = "<group>"; };
@@ -643,6 +646,7 @@
 		F4E71029096D6AC34B84A74A /* BuildSettingConditionalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildSettingConditionalTests.swift; sourceTree = "<group>"; };
 		F52B40BE9E5A13756AD20F88 /* DTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DTO.swift; sourceTree = "<group>"; };
 		F989E51F5A4A6F6C61A92D70 /* _HashTable+Bucket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "_HashTable+Bucket.swift"; sourceTree = "<group>"; };
+		FA0FEDB45F02638177A108FC /* ConsolidatedTargetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsolidatedTargetTests.swift; sourceTree = "<group>"; };
 		FA83272F166637CFAFC4C79C /* OrderedDictionary+Hashable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderedDictionary+Hashable.swift"; sourceTree = "<group>"; };
 		FAD042334686EC625458D787 /* XCWorkspace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCWorkspace.swift; sourceTree = "<group>"; };
 		FB78F15F8AFA4FD268CBC7BD /* KeyedDecodingContainer+Additions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KeyedDecodingContainer+Additions.swift"; sourceTree = "<group>"; };
@@ -786,6 +790,7 @@
 				37060CBDC54D48ADDEEA0274 /* AddTargetsTests.swift */,
 				A8C917E9D54ACB73DF3F6EAA /* BUILD */,
 				F4E71029096D6AC34B84A74A /* BuildSettingConditionalTests.swift */,
+				FA0FEDB45F02638177A108FC /* ConsolidatedTargetTests.swift */,
 				06589BA8CA823F86E64B2417 /* CreateFilesAndGroupsTests.swift */,
 				798455D7A824BAB585C1E8EB /* CreateProductsTest.swift */,
 				E200ED9999C2E4E55C7EC34E /* CreateProjectTests.swift */,
@@ -1164,6 +1169,7 @@
 				E366C31F049809D80BD7CF3D /* Generator.swift */,
 				B7814D507469A5ED9AA17B0B /* Generator+AddBazelDependenciesTarget.swift */,
 				79EFC55270A7F9C95452FF71 /* Generator+AddTargets.swift */,
+				EB0EE19B56421A19598F7BFA /* Generator+ConsolidateTargets.swift */,
 				F328B736C7AF330724A15666 /* Generator+CreateFilesAndGroups.swift */,
 				CB3A0C56E6309EC169805A89 /* Generator+CreateProducts.swift */,
 				4B0489BBEB7C17EFEB6AE185 /* Generator+CreateProject.swift */,
@@ -1601,6 +1607,7 @@
 			files = (
 				D1FF2A2A272865879D4B94D2 /* AddTargetsTests.swift in Sources */,
 				130CE1601B9654CC0320CD9C /* BuildSettingConditionalTests.swift in Sources */,
+				59E7A071C1A3448B297846D4 /* ConsolidatedTargetTests.swift in Sources */,
 				250DE90578C454256F39C418 /* CreateFilesAndGroupsTests.swift in Sources */,
 				D28AD805F11C60A1A2CEBE5A /* CreateProductsTest.swift in Sources */,
 				0B06F16B6814BDD36D863BDF /* CreateProjectTests.swift in Sources */,
@@ -1661,6 +1668,7 @@
 				FFBF629A61596A5CC71D8612 /* FilePathResolver.swift in Sources */,
 				B4802E4831269430B81CE573 /* Generator+AddBazelDependenciesTarget.swift in Sources */,
 				7179F32217C3BEEA636F5051 /* Generator+AddTargets.swift in Sources */,
+				FD0DD65DE147F3E4255D23CE /* Generator+ConsolidateTargets.swift in Sources */,
 				BF3A961C3C9160CDB03BBAD5 /* Generator+CreateFilesAndGroups.swift in Sources */,
 				ED5F0F0FA5A045D7F75F3815 /* Generator+CreateProducts.swift in Sources */,
 				7EFB7F70225BBBE18BD502FD /* Generator+CreateProject.swift in Sources */,

--- a/test/fixtures/generator/bwx_spec.json
+++ b/test/fixtures/generator/bwx_spec.json
@@ -205,6 +205,7 @@
                 "srcs": [
                     "tools/generator/test/AddTargetsTests.swift",
                     "tools/generator/test/BuildSettingConditionalTests.swift",
+                    "tools/generator/test/ConsolidatedTargetTests.swift",
                     "tools/generator/test/CreateFilesAndGroupsTests.swift",
                     "tools/generator/test/CreateProductsTest.swift",
                     "tools/generator/test/CreateProjectTests.swift",
@@ -456,6 +457,7 @@
                     "tools/generator/src/FilePathResolver.swift",
                     "tools/generator/src/Generator+AddBazelDependenciesTarget.swift",
                     "tools/generator/src/Generator+AddTargets.swift",
+                    "tools/generator/src/Generator+ConsolidateTargets.swift",
                     "tools/generator/src/Generator+CreateFilesAndGroups.swift",
                     "tools/generator/src/Generator+CreateProducts.swift",
                     "tools/generator/src/Generator+CreateProject.swift",

--- a/tools/generator/src/Generator+ConsolidateTargets.swift
+++ b/tools/generator/src/Generator+ConsolidateTargets.swift
@@ -1,0 +1,208 @@
+import OrderedCollections
+import XcodeProj
+
+/// Collects multiple Bazel targets (see `Target`) that can be represented by
+/// a single Xcode target (see `PBXNativeTarget`).
+///
+/// In a Bazel build graph there might be multiple configurations of the
+/// same label (e.g. macOS and iOS flavors of the same `swift_library`).
+/// Xcode can represent these various configurations as a single target,
+/// using build settings, and conditionals on build settings, to account
+/// for the differences.
+struct ConsolidatedTarget: Equatable {
+    let name: String
+    let label: String
+    let product: ConsolidatedTargetProduct
+    let isSwift: Bool
+    let resourceBundles: Set<FilePath>
+    let inputs: ConsolidatedTargetInputs
+    let linkerInputs: ConsolidatedTargetLinkerInputs
+    let outputs: ConsolidatedTargetOutputs
+
+    /// The `Set` of `FilePath`s that each target references above the baseline.
+    ///
+    /// The baseline is all `FilePath`s that each target references. A reference
+    /// in this case is anything that the `EXCLUDED_SOURCE_FILE_NAMES` and
+    /// `INCLUDED_SOURCE_FILE_NAMES` apply to.
+    let uniqueFiles: [TargetID: Set<FilePath>]
+
+    let targets: [TargetID: Target]
+
+    /// There are a couple places that want to use the "best" target for a
+    /// value (i.e. the one most likely to be built), so we store the sorted
+    /// targets as an optimization.
+    let sortedTargets: [Target]
+}
+
+extension ConsolidatedTarget {
+    init(targets: [TargetID: Target]) {
+        self.targets = targets
+        let aTarget = self.targets.first!.value
+
+        name = aTarget.name
+        label = aTarget.label
+        product = ConsolidatedTargetProduct(
+            name: aTarget.product.name,
+            type: aTarget.product.type,
+            basename: aTarget.product.path.path.lastComponent,
+            paths: Set(targets.values.map(\.product.path))
+        )
+        isSwift = aTarget.isSwift
+
+        var resourceBundles: Set<FilePath> = []
+        targets.values.forEach { resourceBundles.formUnion($0.resourceBundles) }
+        self.resourceBundles = resourceBundles
+
+        sortedTargets = targets
+            .sorted { lhs, rhs in
+                return lhs.value.buildSettingConditional <
+                    rhs.value.buildSettingConditional
+            }
+            .map { $1 }
+        inputs = Self.consolidateInputs(targets: sortedTargets)
+        linkerInputs = Self.consolidateLinkerInputs(targets: sortedTargets)
+
+        var baselineFiles: Set<FilePath> = aTarget.allExcludableFiles
+        for target in targets.values {
+            baselineFiles.formIntersection(target.allExcludableFiles)
+        }
+
+        var uniqueFiles: [TargetID: Set<FilePath>] = [:]
+        for (id, target) in targets {
+            uniqueFiles[id] = target.allExcludableFiles
+                .subtracting(baselineFiles)
+        }
+        self.uniqueFiles = uniqueFiles
+
+        outputs = ConsolidatedTargetOutputs(
+            hasOutputs: self.targets.values.contains { $0.outputs.hasOutputs },
+            hasSwiftOutputs: self.targets.values
+                .contains { $0.outputs.hasSwiftOutputs }
+        )
+    }
+
+    private static func consolidateInputs(
+        targets: [Target]
+    ) -> ConsolidatedTargetInputs {
+        return ConsolidatedTargetInputs(
+            srcs: consolidateFiles(targets.map(\.inputs.srcs)),
+            nonArcSrcs: consolidateFiles(targets.map(\.inputs.nonArcSrcs)),
+            hdrs: targets.reduce(into: []) { all, target in
+                return all.formUnion(target.inputs.hdrs)
+            },
+            resources: targets.reduce(into: []) { all, target in
+                return all.formUnion(target.inputs.resources)
+            }
+        )
+    }
+
+    private static func consolidateLinkerInputs(
+        targets: [Target]
+    ) -> ConsolidatedTargetLinkerInputs {
+        return ConsolidatedTargetLinkerInputs(
+            staticFrameworks: consolidateFiles(
+                targets.map(\.linkerInputs.staticFrameworks)
+            ),
+            dynamicFrameworks: consolidateFiles(
+                targets.map(\.linkerInputs.dynamicFrameworks)
+            )
+        )
+    }
+
+    private static func consolidateFiles(_ files: [[FilePath]]) -> [FilePath] {
+        guard !files.isEmpty else {
+            return []
+        }
+
+        // First generate the baseline
+        var baselineFiles = OrderedSet(files[0])
+        for files in files {
+            baselineFiles.formIntersection(files)
+        }
+
+        var consolidatedFiles = baselineFiles
+
+        // For each array of `files`, insert them into `consolidatedFiles`,
+        // preserving relative order
+        for files in files {
+            var consolidatedIdx = 0
+            var filesIdx = 0
+            while consolidatedIdx < consolidatedFiles.count &&
+                    filesIdx < files.count
+            {
+                let file = files[filesIdx]
+                filesIdx += 1
+
+                guard consolidatedFiles[consolidatedIdx] != file else {
+                    consolidatedIdx += 1
+                    continue
+                }
+
+                if baselineFiles.contains(file) {
+                    // We need to adjust out index based on where the file
+                    // exists in the baseline
+                    let foundIndex = consolidatedFiles.firstIndex(of: file)!
+                    if foundIndex > consolidatedIdx {
+                        consolidatedIdx = foundIndex + 1
+                    }
+                    continue
+                }
+
+                let (inserted, _) = consolidatedFiles.insert(
+                    file,
+                    at: consolidatedIdx
+                )
+                if inserted {
+                    consolidatedIdx += 1
+                }
+            }
+
+            if filesIdx < files.count {
+                consolidatedFiles.append(contentsOf: files[filesIdx...])
+            }
+        }
+
+        return consolidatedFiles.elements
+    }
+}
+
+struct ConsolidatedTargetProduct: Equatable {
+    let name: String
+    let type: PBXProductType
+    let basename: String
+    let paths: Set<FilePath>
+}
+
+struct ConsolidatedTargetInputs: Equatable {
+    let srcs: [FilePath]
+    let nonArcSrcs: [FilePath]
+    let hdrs: Set<FilePath>
+    let resources: Set<FilePath>
+}
+
+struct ConsolidatedTargetLinkerInputs: Equatable {
+    let staticFrameworks: [FilePath]
+    let dynamicFrameworks: [FilePath]
+}
+
+struct ConsolidatedTargetOutputs: Equatable {
+    let hasOutputs: Bool
+    let hasSwiftOutputs: Bool
+}
+
+// MARK: - Private extensions
+
+private extension Target {
+    var allExcludableFiles: Set<FilePath> {
+        var files = inputs.all
+        files.formUnion(linkerInputs.allExcludableFiles)
+        files.formUnion(resourceBundles)
+        return files
+    }
+}
+
+private extension LinkerInputs {
+    var allExcludableFiles: Set<FilePath> {
+        return Set(dynamicFrameworks)
+    }
+}

--- a/tools/generator/test/ConsolidatedTargetTests.swift
+++ b/tools/generator/test/ConsolidatedTargetTests.swift
@@ -1,0 +1,119 @@
+import CustomDump
+import XCTest
+
+@testable import generator
+
+final class ConsolidatedTargetTests: XCTestCase {
+    static let targets: [TargetID: Target] = [
+        "A": Target.mock(
+            platform: .simulator(),
+            product: .init(type: .staticLibrary, name: "T", path: "A"),
+            inputs: .init(
+                srcs: ["a", "0", "-"],
+                nonArcSrcs: ["aa"],
+                hdrs: ["123"],
+                resources: ["bbb"]
+            ),
+            linkerInputs: .init(
+                staticFrameworks: ["z", "00", "x"],
+                dynamicFrameworks: ["yy"]
+            )
+        ),
+        "B": Target.mock(
+            platform: .device(),
+            product: .init(type: .staticLibrary, name: "T", path: "B"),
+            inputs: .init(
+                srcs: ["a", "1", "-"],
+                nonArcSrcs: ["aa", "cc"],
+                hdrs: ["456"],
+                resources: ["aaa", "bbb"]
+            ),
+            linkerInputs: .init(
+                staticFrameworks: ["z", "11", "x"],
+                dynamicFrameworks: ["xx", "yy"]
+            )
+        ),
+        "C": Target.mock(
+            platform: .macOS(),
+            product: .init(type: .staticLibrary, name: "T", path: "C"),
+            inputs: .init(
+                srcs: ["a", "2", "-"],
+                nonArcSrcs: ["aa", "bb"],
+                hdrs: ["789"],
+                resources: ["ccc", "bbb"]
+            ),
+            linkerInputs: .init(
+                staticFrameworks: ["z", "22", "x"],
+                dynamicFrameworks: ["yy", "zz"]
+            )
+        ),
+    ]
+
+    func test_inputs() {
+        // Arrange
+
+        let targets = Self.targets
+        let expectedInputs = ConsolidatedTargetInputs(
+            // Conditionals in middle
+            srcs: ["a", "1", "0", "2", "-"],
+            // Conditionals at the end
+            nonArcSrcs: ["aa", "cc", "bb"],
+            hdrs: ["123", "456", "789"],
+            // Conditionals at the start
+            resources: ["aaa", "ccc", "bbb"]
+        )
+
+        // Act
+
+        let consolidatedTarget = ConsolidatedTarget(targets: targets)
+
+        // Assert
+
+        XCTAssertNoDifference(consolidatedTarget.inputs, expectedInputs)
+    }
+
+    func test_linkerInputs() {
+        // Arrange
+
+        let targets = Self.targets
+        let expectedLinkerInputs = ConsolidatedTargetLinkerInputs(
+            // Conditionals in middle
+            staticFrameworks: ["z", "11", "00", "22", "x"],
+            // Conditionals on the outsides
+            dynamicFrameworks: ["xx", "yy", "zz"]
+        )
+
+        // Act
+
+        let consolidatedTarget = ConsolidatedTarget(targets: targets)
+
+        // Assert
+
+        XCTAssertNoDifference(
+            consolidatedTarget.linkerInputs,
+            expectedLinkerInputs
+        )
+    }
+
+    func test_uniqueFiles() {
+        // Arrange
+
+        let targets = Self.targets
+        let expectedUniqueFiles: [TargetID: Set<FilePath>] = [
+            "A": ["0", "123"],
+            "B": ["1", "456", "cc", "aaa", "xx"],
+            "C": ["2", "789", "bb", "ccc", "zz"],
+        ]
+
+        // Act
+
+        let consolidatedTarget = ConsolidatedTarget(targets: targets)
+
+        // Assert
+
+        XCTAssertNoDifference(
+            consolidatedTarget.uniqueFiles,
+            expectedUniqueFiles
+        )
+    }
+}


### PR DESCRIPTION
`ConsolidatedTarget` will be used in place of `Target` throughout most of the generator (e.g. `DisambiguatedTarget` will have a `ConsolidatedTarget` instead of a `Target`). It represents a single Xcode target, but multiple configurations of the same Bazel target.