### PR TITLE
Apply `redundantSelf` rule for `swiftformat`

### DIFF
--- a/examples/ios_app/ExampleTests/ExampleTests.swift
+++ b/examples/ios_app/ExampleTests/ExampleTests.swift
@@ -20,7 +20,7 @@ class ExampleTests: XCTestCase {
 
     func testPerformanceExample() throws {
         // This is an example of a performance test case.
-        self.measure {
+        measure {
             // Put the code you want to measure the time of here.
         }
     }

--- a/tools/generator/src/DTO/BuildSetting.swift
+++ b/tools/generator/src/DTO/BuildSetting.swift
@@ -31,7 +31,7 @@ extension BuildSetting {
 
 extension Dictionary where Value == BuildSetting {
     /// Converts the build settings to `[String: Any]`.
-    var asDictionary: [Key: Any] { self.mapValues { $0.asAny } }
+    var asDictionary: [Key: Any] { mapValues { $0.asAny } }
 }
 
 // MARK: - Decodable

--- a/tools/generator/src/Extensions/Path+Extensions.swift
+++ b/tools/generator/src/Extensions/Path+Extensions.swift
@@ -15,11 +15,11 @@ extension Path {
     var isLocalizedContainer: Bool { self.extension == "lproj" }
 
     var isBazelBuildFile: Bool {
-        self.lastComponent == "BUILD" || self.lastComponent == "BUILD.bazel"
+        lastComponent == "BUILD" || lastComponent == "BUILD.bazel"
     }
 
     var explicitFileType: String? {
-        self.isBazelBuildFile ? Xcode.filetype(extension: "py") : nil
+        isBazelBuildFile ? Xcode.filetype(extension: "py") : nil
     }
 
     var lastKnownFileType: String? {

--- a/tools/generator/src/Extensions/Sorting.swift
+++ b/tools/generator/src/Extensions/Sorting.swift
@@ -46,7 +46,7 @@ extension Sequence {
     func sortedLocalizedStandard(
         _ keyPath: KeyPath<Element, String>
     ) -> [Element] {
-        return self.sorted(by: Self.sortByLocalizedStandard(keyPath))
+        return sorted(by: Self.sortByLocalizedStandard(keyPath))
     }
 }
 
@@ -71,7 +71,7 @@ extension Sequence where Element == PBXBuildFile {
 extension Array where Element: PBXFileElement {
     mutating func sortGroupedLocalizedStandard() {
         let fileSort = Self.sortByLocalizedStandard(\.namePathSortString)
-        self.sort { lhs, rhs in
+        sort { lhs, rhs in
             let lhsSortOrder = lhs.sortOrder
             let rhsSortOrder = rhs.sortOrder
             if lhsSortOrder != rhsSortOrder {
@@ -107,8 +107,7 @@ where Key == ConsolidatedTarget.Key, Value: PBXFileReference {
     func sortedLocalizedStandard() -> [PBXFileReference] {
         let sort = [PBXFileReferenceByTargetKey]
             .sortByLocalizedStandard(\.sortString)
-        return self
-            .map(PBXFileReferenceByTargetKey.init)
+        return map(PBXFileReferenceByTargetKey.init)
             .sorted(by: sort)
             .map(\.file)
     }

--- a/tools/generator/src/Generator/AddTargets.swift
+++ b/tools/generator/src/Generator/AddTargets.swift
@@ -476,7 +476,7 @@ Watch application product reference with key \(key) not found in `products`
 
 private extension Sequence where Element == FilePath {
     var excludingHeaders: [Element] {
-        self.filter { !$0.path.isHeader }
+        filter { !$0.path.isHeader }
     }
 }
 


### PR DESCRIPTION
`swiftformat --config .swiftformat --rules redundantSelf --verbose .`