### PR TITLE
Fix target merging with multiple frameworks

### DIFF
--- a/tools/generator/src/Generator/CreateFilesAndGroups.swift
+++ b/tools/generator/src/Generator/CreateFilesAndGroups.swift
@@ -654,8 +654,14 @@ EOF
                     xcodeGeneratedFiles[filePath] = target.product.path
                 }
                 if let filePath = target.outputs.swift?.module {
-                    xcodeGeneratedFiles[filePath] = target
-                        .xcodeSwiftModuleFilePath(filePath)
+                    let value = target.xcodeSwiftModuleFilePath(filePath)
+                    if let existingValue = xcodeGeneratedFiles[filePath] {
+                        throw PreconditionError(message: """
+Tried to set `xcodeGeneratedFiles[\(filePath)]` to `\(value)`, but it already \
+was set to `\(existingValue)`.
+""")
+                    }
+                    xcodeGeneratedFiles[filePath] = value
                 }
             }
         case .bazel:

--- a/xcodeproj/internal/xcode_targets.bzl
+++ b/xcodeproj/internal/xcode_targets.bzl
@@ -90,7 +90,6 @@ def _make(
         _package_bin_dir = package_bin_dir,
         _platform = platform,
         _is_testonly = is_testonly,
-        _is_swift = is_swift,
         _test_host = test_host,
         _build_settings = struct(**build_settings),
         _search_paths = search_paths,
@@ -106,6 +105,7 @@ def _make(
         product = product,
         linker_inputs = linker_inputs,
         inputs = inputs,
+        is_swift = is_swift,
         outputs = outputs,
         infoplist = infoplist,
         transitive_dependencies = transitive_dependencies,
@@ -132,7 +132,7 @@ def _to_dto(
     if xcode_target._is_testonly:
         dto["is_testonly"] = True
 
-    if not xcode_target._is_swift:
+    if not xcode_target.is_swift:
         dto["is_swift"] = False
 
     if is_unfocused_dependency:


### PR DESCRIPTION
Before this change, we would allow `swift_library` targets to merge into multiple `*_framework` targets. This would mess up search paths in BwX mode.

This change also allows for more target merges, if they aren't `swift_library` targets, since we don't have to worry about swiftmodule search paths for those targets.