### PR TITLE
Allow additional user `-Xcc` swiftcopts

### DIFF
--- a/test/internal/opts/process_compiler_opts_tests.bzl
+++ b/test/internal/opts/process_compiler_opts_tests.bzl
@@ -340,8 +340,14 @@ def process_compiler_opts_test_suite(name):
             "ios",
             "-Xcc",
             "-weird",
+            "-Xcc",
+            "-user-flag",
             "-Xwrapped-swift",
             "-passthrough",
+        ],
+        user_swiftcopts = [
+            "-Xcc",
+            "-user-flag",
         ],
         expected_build_settings = {
             "OTHER_CFLAGS": [
@@ -366,7 +372,9 @@ def process_compiler_opts_test_suite(name):
 -passthrough \
 -passthrough \
 -keep-me=something.swift \
--passthrough\
+-passthrough \
+-Xcc \
+-user-flag\
 """,
         },
     )


### PR DESCRIPTION
Part of #1240.

Allows for manually specifying modulemaps, which is needed for manually crafting mixed language modules.