### PR TITLE
Fix BwB debugging of framework targets

### DIFF
--- a/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/swift_debug_settings.py
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/swift_debug_settings.py
@@ -4,12 +4,13 @@
 
 import lldb
 
+# Order matters, it needs to be from the most nested to the least
 _BUNDLE_EXTENSIONS = [
-    ".app",
-    ".appex",
-    ".bundle",
     ".framework",
     ".xctest",
+    ".appex",
+    ".bundle",
+    ".app",
 ]
 
 _SETTINGS = {

--- a/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/swift_debug_settings.py
+++ b/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/swift_debug_settings.py
@@ -4,12 +4,13 @@
 
 import lldb
 
+# Order matters, it needs to be from the most nested to the least
 _BUNDLE_EXTENSIONS = [
-    ".app",
-    ".appex",
-    ".bundle",
     ".framework",
     ".xctest",
+    ".appex",
+    ".bundle",
+    ".app",
 ]
 
 _SETTINGS = {

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/swift_debug_settings.py
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/swift_debug_settings.py
@@ -4,12 +4,13 @@
 
 import lldb
 
+# Order matters, it needs to be from the most nested to the least
 _BUNDLE_EXTENSIONS = [
-    ".app",
-    ".appex",
-    ".bundle",
     ".framework",
     ".xctest",
+    ".appex",
+    ".bundle",
+    ".app",
 ]
 
 _SETTINGS = {

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/swift_debug_settings.py
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/swift_debug_settings.py
@@ -4,12 +4,13 @@
 
 import lldb
 
+# Order matters, it needs to be from the most nested to the least
 _BUNDLE_EXTENSIONS = [
-    ".app",
-    ".appex",
-    ".bundle",
     ".framework",
     ".xctest",
+    ".appex",
+    ".bundle",
+    ".app",
 ]
 
 _SETTINGS = {

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/swift_debug_settings.py
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/swift_debug_settings.py
@@ -4,12 +4,13 @@
 
 import lldb
 
+# Order matters, it needs to be from the most nested to the least
 _BUNDLE_EXTENSIONS = [
-    ".app",
-    ".appex",
-    ".bundle",
     ".framework",
     ".xctest",
+    ".appex",
+    ".bundle",
+    ".app",
 ]
 
 _SETTINGS = {

--- a/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/swift_debug_settings.py
+++ b/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/swift_debug_settings.py
@@ -4,12 +4,13 @@
 
 import lldb
 
+# Order matters, it needs to be from the most nested to the least
 _BUNDLE_EXTENSIONS = [
-    ".app",
-    ".appex",
-    ".bundle",
     ".framework",
     ".xctest",
+    ".appex",
+    ".bundle",
+    ".app",
 ]
 
 _SETTINGS = {

--- a/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/swift_debug_settings.py
+++ b/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/swift_debug_settings.py
@@ -4,12 +4,13 @@
 
 import lldb
 
+# Order matters, it needs to be from the most nested to the least
 _BUNDLE_EXTENSIONS = [
-    ".app",
-    ".appex",
-    ".bundle",
     ".framework",
     ".xctest",
+    ".appex",
+    ".bundle",
+    ".app",
 ]
 
 _SETTINGS = {

--- a/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/swift_debug_settings.py
+++ b/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/swift_debug_settings.py
@@ -4,12 +4,13 @@
 
 import lldb
 
+# Order matters, it needs to be from the most nested to the least
 _BUNDLE_EXTENSIONS = [
-    ".app",
-    ".appex",
-    ".bundle",
     ".framework",
     ".xctest",
+    ".appex",
+    ".bundle",
+    ".app",
 ]
 
 _SETTINGS = {

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/swift_debug_settings.py
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/swift_debug_settings.py
@@ -4,12 +4,13 @@
 
 import lldb
 
+# Order matters, it needs to be from the most nested to the least
 _BUNDLE_EXTENSIONS = [
-    ".app",
-    ".appex",
-    ".bundle",
     ".framework",
     ".xctest",
+    ".appex",
+    ".bundle",
+    ".app",
 ]
 
 _SETTINGS = {

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/swift_debug_settings.py
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/swift_debug_settings.py
@@ -4,12 +4,13 @@
 
 import lldb
 
+# Order matters, it needs to be from the most nested to the least
 _BUNDLE_EXTENSIONS = [
-    ".app",
-    ".appex",
-    ".bundle",
     ".framework",
     ".xctest",
+    ".appex",
+    ".bundle",
+    ".app",
 ]
 
 _SETTINGS = {

--- a/tools/generator/src/Generator/CreateFilesAndGroups.swift
+++ b/tools/generator/src/Generator/CreateFilesAndGroups.swift
@@ -832,12 +832,13 @@ EOF
 
 import lldb
 
+# Order matters, it needs to be from the most nested to the least
 _BUNDLE_EXTENSIONS = [
-    ".app",
-    ".appex",
-    ".bundle",
     ".framework",
     ".xctest",
+    ".appex",
+    ".bundle",
+    ".app",
 ]
 
 _SETTINGS = \#(lldbSettingsMapJSON)

--- a/tools/generator/test/Fixtures.swift
+++ b/tools/generator/test/Fixtures.swift
@@ -1229,12 +1229,13 @@ EOF
 
 import lldb
 
+# Order matters, it needs to be from the most nested to the least
 _BUNDLE_EXTENSIONS = [
-    ".app",
-    ".appex",
-    ".bundle",
     ".framework",
     ".xctest",
+    ".appex",
+    ".bundle",
+    ".app",
 ]
 
 _SETTINGS = {


### PR DESCRIPTION
The settings key was coming back as `"arm64-apple-ios15.0.0-simulator App.app/Frameworks/UIFramework.framework/UIFramework"` instead of `"arm64-apple-ios15.0.0-simulator UIFramework.framework/UIFramework"`.