### PR TITLE
Ensure target merge src is present in Xcode

### DIFF
--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -448,6 +448,8 @@ actual targets: {}
         dest_label = bazel_labels.normalize_label(dest_target.label)
         if src_label in unfocused_labels or dest_label in unfocused_labels:
             continue
+        if not merge.src.id in focused_targets:
+            continue
         raw_target_merge_dests.setdefault(merge.dest, []).append(merge.src.id)
 
     target_merge_dests = {}


### PR DESCRIPTION
Fix the case where `len(src_ids) > 1` considers a merge not possible despite one or more of the sources being not present in Xcode already because of `should_create_xcode_target = False` or otherwise.