### PR TITLE
Remove unused Swift declarations in `tools/generator/...`

### DIFF
--- a/tools/generator/src/DTO/BuildSetting.swift
+++ b/tools/generator/src/DTO/BuildSetting.swift
@@ -98,19 +98,6 @@ extension BuildSetting: ExpressibleByArrayLiteral {
 
 // MARK: - Convenience
 
-extension BuildSetting {
-    func contains(_ value: String) -> Bool {
-        switch self {
-        case let .array(array):
-            return array.contains(value)
-        case let .string(string):
-            return string == value
-        case .bool:
-            return false
-        }
-    }
-}
-
 extension Dictionary where Value == BuildSetting {
     mutating func set(_ key: Key, to value: Bool) {
         self[key] = .bool(value)

--- a/tools/generator/src/Extensions/XcodeScheme+Extensions.swift
+++ b/tools/generator/src/Extensions/XcodeScheme+Extensions.swift
@@ -19,20 +19,6 @@ extension XcodeScheme.TargetWithID: Comparable {
     }
 }
 
-// MARK: LabelAndConfiguration
-
-extension XcodeScheme {
-    struct LabelAndConfiguration: Equatable, Hashable {
-        let label: BazelLabel
-        let configuration: String
-
-        init(_ label: BazelLabel, _ configuration: String) {
-            self.label = label
-            self.configuration = configuration
-        }
-    }
-}
-
 // MARK: Resolve TargetIDs
 
 extension XcodeScheme {
@@ -43,22 +29,6 @@ Target \(missingLabel) was not found in the transitive dependencies of \(runnerL
 supported in Scheme definitions)? Check that \(missingLabel) is spelled correctly, and if it is, \
 add it or a target that depends on it to \(runnerLabel)'s `top_level_targets` attribute.
 """
-    }
-
-    private struct TopLevelInfo {
-        var labels: Set<BazelLabel> = []
-        var targetIDs: Set<TargetID> = []
-        var platforms: Set<Platform> = []
-
-        mutating func insert(
-            label: BazelLabel,
-            targetID: TargetID,
-            platforms: Set<Platform>
-        ) {
-            labels.insert(label)
-            targetIDs.insert(targetID)
-            self.platforms.formUnion(platforms)
-        }
     }
 
     /// Determines the mapping of `BazelLabel` to the `TargetID` values based

--- a/tools/generator/src/Generator/SetTargetConfigurations.swift
+++ b/tools/generator/src/Generator/SetTargetConfigurations.swift
@@ -664,44 +664,6 @@ private extension Dictionary where Value == BuildSetting {
     mutating func prepend(
         onKey key: Key,
         onlyIfSet: Bool = false,
-        _ content: String
-    ) throws {
-        let maybeBuildSetting = self[key]
-
-        let buildSetting: Value
-        if let maybeBuildSetting = maybeBuildSetting {
-            buildSetting = maybeBuildSetting
-        } else {
-            guard !onlyIfSet else {
-                return
-            }
-            buildSetting = .string("")
-        }
-
-        switch buildSetting {
-        case let .string(existing):
-            let new: String
-            if content.isEmpty {
-                new = existing
-            } else if existing.isEmpty {
-                new = content
-            } else {
-                new = "\(content) \(existing)"
-            }
-            guard !new.isEmpty else {
-                return
-            }
-            self[key] = .string(new)
-        default:
-            throw PreconditionError(message: """
-Build setting for \(key) is not a string: \(buildSetting)
-""")
-        }
-    }
-
-    mutating func prepend(
-        onKey key: Key,
-        onlyIfSet: Bool = false,
         _ content: [String]
     ) throws {
         let maybeBuildSetting = self[key]


### PR DESCRIPTION
This was found with SwiftLint's upcoming improved dead code analysis.

Let me know if some of this stuff should be kept for future use.

Signed-off-by: JP Simard <jp@jpsim.com>
