### PR TITLE
Fix command to update docs

### DIFF
--- a/docs/BUILD
+++ b/docs/BUILD
@@ -50,7 +50,7 @@ done
 
 diff_test(
     name = "diff_test",
-    failure_message = "\nPlease update the docs by running\n    bazel run --noenable_bzlmod //docs:update",
+    failure_message = "\nPlease update the docs by running\n    ./docs/update_docs.sh",
     file1 = "bazel.generated.md",
     file2 = "bazel.md",
     tags = ["manual"],


### PR DESCRIPTION
Without `--noenable_bzlmod`, running the command fails with the following error:

```
ERROR: Skipping '//docs:update': error loading package 'docs': Unable to find package for @[unknown repo 'io_bazel_stardoc' requested from @]//stardoc:stardoc.bzl: The repository '@[unknown repo 'io_bazel_stardoc' requested from @]' could not be resolved: No repository visible as '@io_bazel_stardoc' from main repository.
```