### PR TITLE
Upgrade rules_apple to 2.2.0

### DIFF
--- a/xcodeproj/repositories.bzl
+++ b/xcodeproj/repositories.bzl
@@ -127,8 +127,8 @@ def xcodeproj_rules_dependencies(
 
         is_bazel_6 = hasattr(apple_common, "link_multi_arch_static_library")
         if is_bazel_6:
-            rules_apple_sha256 = "3e2c7ae0ddd181c4053b6491dad1d01ae29011bc322ca87eea45957c76d3a0c3"
-            rules_apple_version = "2.1.0"
+            rules_apple_sha256 = "9e26307516c4d5f2ad4aee90ac01eb8cd31f9b8d6ea93619fc64b3cbc81b0944"
+            rules_apple_version = "2.2.0"
         else:
             rules_apple_sha256 = "f94e6dddf74739ef5cb30f000e13a2a613f6ebfa5e63588305a71fce8a8a9911"
             rules_apple_version = "1.1.3"


### PR DESCRIPTION
Not bumping in `MODULE.bazel` because we don’t require any of the changes.