### PR TITLE
Collect impl_deps for objc_library to generate Xcode Target

### DIFF
--- a/xcodeproj/internal/default_automatic_target_processing_aspect.bzl
+++ b/xcodeproj/internal/default_automatic_target_processing_aspect.bzl
@@ -90,6 +90,10 @@ def _default_automatic_target_processing_aspect_impl(target, ctx):
     elif ctx.rule.kind == "objc_library":
         xcode_targets = {
             "deps": [target_type.compile, None],
+            # Issues like https://github.com/bazelbuild/bazel/issues/17646 made some Bazel users 
+            # to fork Bazel and add implementation_deps attribute for objc_library_rule.
+            # TODO: Add link to changes for more context
+            # handle case when objc_library rule has attribute implementation_deps
             "implementation_deps": [target_type.compile],
             "runtime_deps": [target_type.compile],
         }

--- a/xcodeproj/internal/default_automatic_target_processing_aspect.bzl
+++ b/xcodeproj/internal/default_automatic_target_processing_aspect.bzl
@@ -93,7 +93,6 @@ def _default_automatic_target_processing_aspect_impl(target, ctx):
             # Issues like https://github.com/bazelbuild/bazel/issues/17646 made some Bazel users 
             # to fork Bazel and add implementation_deps attribute for objc_library_rule.
             # TODO: Add link to changes for more context
-            # handle case when objc_library rule has attribute implementation_deps
             "implementation_deps": [target_type.compile],
             "runtime_deps": [target_type.compile],
         }

--- a/xcodeproj/internal/default_automatic_target_processing_aspect.bzl
+++ b/xcodeproj/internal/default_automatic_target_processing_aspect.bzl
@@ -90,6 +90,7 @@ def _default_automatic_target_processing_aspect_impl(target, ctx):
     elif ctx.rule.kind == "objc_library":
         xcode_targets = {
             "deps": [target_type.compile, None],
+            "implementation_deps": [target_type.compile],
             "runtime_deps": [target_type.compile],
         }
         non_arc_srcs = ["non_arc_srcs"]


### PR DESCRIPTION
Issues like https://github.com/bazelbuild/bazel/issues/17646 made some bazel users to fork Bazel and propagate `implementation_deps` of `objc_library` to `cc_library` (cc_library consuming implementation deps is already in bazel). 

This change lets rules_xcodeproj handle case when `objc_library` rule has attribute `implementation_deps`. 