### PR TITLE
Revert "Ensure target merge src is present in Xcode (#1903)"

### DIFF
--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -448,8 +448,6 @@ actual targets: {}
         dest_label = bazel_labels.normalize_label(dest_target.label)
         if src_label in unfocused_labels or dest_label in unfocused_labels:
             continue
-        if not merge.src.id in focused_targets:
-            continue
         raw_target_merge_dests.setdefault(merge.dest, []).append(merge.src.id)
 
     target_merge_dests = {}


### PR DESCRIPTION
Fixes https://github.com/MobileNativeFoundation/rules_xcodeproj/issues/1912#issuecomment-1484594604.

This reverts commit ed31d6916858f3099ba1a95750f5309913370a8d.