### PR TITLE
Fix handling of bzlmod external targets

### DIFF
--- a/xcodeproj/internal/bazel_integration_files/bazel_build.sh
+++ b/xcodeproj/internal/bazel_integration_files/bazel_build.sh
@@ -126,7 +126,7 @@ touch "$build_marker"
 
 # Collect indexstore filelists
 
-readonly outputgroup_regex='([^\ ]+) @?(.*)//(.*):(.*) ([^\ ]+)$'
+readonly outputgroup_regex='([^\ ]+) @{0,2}(.*)//(.*):(.*) ([^\ ]+)$'
 
 indexstores_filelists=()
 for output_group in "${output_groups[@]}"; do


### PR DESCRIPTION
Closes #1925.

Our regex wasn’t account for the fact that external repos under bzlmod would have a `@@` prefix instead of a single `@`.