### PR TITLE
Ensure target merge src is present in Xcode

### DIFF
--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -449,9 +449,12 @@ actual targets: {}
         if src_label in unfocused_labels or dest_label in unfocused_labels:
             continue
 
-        # Exclude targets not in either focused or unfocused targets from
-        # potential merges since they're excluded from Xcode.
-        merge_src_is_xcode_target = merge.src.id in focused_targets or merge.src.id in unfocused_targets
+        # Exclude targets not in focused nor unfocused targets from
+        # potential merges since they're not possible Xcode targets.
+        merge_src_is_xcode_target = (
+            merge.src.id in focused_targets or
+            merge.src.id in unfocused_targets
+        )
         if not merge_src_is_xcode_target:
             continue
         raw_target_merge_dests.setdefault(merge.dest, []).append(merge.src.id)

--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -448,6 +448,12 @@ actual targets: {}
         dest_label = bazel_labels.normalize_label(dest_target.label)
         if src_label in unfocused_labels or dest_label in unfocused_labels:
             continue
+
+        # Exclude targets not in either focused or unfocused targets from
+        # potential merges since they're excluded from Xcode.
+        merge_src_is_xcode_target = merge.src.id in focused_targets or merge.src.id in unfocused_targets
+        if not merge_src_is_xcode_target:
+            continue
         raw_target_merge_dests.setdefault(merge.dest, []).append(merge.src.id)
 
     target_merge_dests = {}


### PR DESCRIPTION
## Summary
Fix the case where `len(src_ids) > 1` considers a merge not possible despite one or more of the sources being not present in Xcode already because of `should_create_xcode_target = False` or otherwise.

Redo https://github.com/MobileNativeFoundation/rules_xcodeproj/pull/1903 since it was reverted in https://github.com/MobileNativeFoundation/rules_xcodeproj/pull/1923. Compared to the past change, this expands the check to see if it's in either set of considerable Xcode targets before excluding from potential merges. Work towards https://github.com/MobileNativeFoundation/rules_xcodeproj/issues/1724.

## Testing
Tested with the following in `examples/integration/BUILD.bazel`:
```Starlark
    focused_targets = ["//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC"]
    ...
    top_level_targets = [
        top_level_target(
            label = "//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC",
            target_environments = ["simulator"],
        ),
    ]
```

|Before|Before (with https://github.com/MobileNativeFoundation/rules_xcodeproj/pull/1903 to validate initial issue)|After (this PR)|
|---|---|---|
|<img width="1942" alt="Screenshot 2023-03-29 at 11 40 51 AM" src="https://user-images.githubusercontent.com/5728070/228628388-9c9a5f21-9d49-46a1-89c2-2afd78a0bac9.png">|<img width="1942" alt="Screenshot 2023-03-29 at 12 00 30 PM" src="https://user-images.githubusercontent.com/5728070/228628408-76aeb1f7-37b7-475e-b62c-5b7b641778a9.png">|<img width="1942" alt="Screenshot 2023-03-29 at 11 58 30 AM" src="https://user-images.githubusercontent.com/5728070/228628428-3bf93fab-d1b6-4b49-933b-9aebb367bc14.png">|