### PR TITLE
Support targets not having any static libraries

### DIFF
--- a/xcodeproj/internal/compilation_providers.bzl
+++ b/xcodeproj/internal/compilation_providers.bzl
@@ -93,16 +93,17 @@ def _to_objc(objc, cc_info):
     linkopts = []
     for input in cc_info.linking_context.linker_inputs.to_list():
         for library in input.libraries:
+            link_inputs.extend(input.additional_inputs)
+            linkopts.extend(input.user_link_flags)
+
             # TODO: Account for all of the different linking strategies
             # here: https://github.com/bazelbuild/bazel/blob/986ef7b68d61b1573d9c2bb1200585d07ad24691/src/main/java/com/google/devtools/build/lib/rules/cpp/CcLinkingHelper.java#L951-L1009
             static_library = (library.static_library or
                               library.pic_static_library)
-
-            libraries.append(static_library)
-            link_inputs.extend(input.additional_inputs)
-            linkopts.extend(input.user_link_flags)
-            if library.alwayslink:
-                force_load_libraries.append(static_library)
+            if static_library:
+                libraries.append(static_library)
+                if library.alwayslink:
+                    force_load_libraries.append(static_library)
 
     return apple_common.new_objc_provider(
         force_load_library = depset(

--- a/xcodeproj/internal/linker_input_files.bzl
+++ b/xcodeproj/internal/linker_input_files.bzl
@@ -96,6 +96,8 @@ def _compute_primary_static_library(
                 # here: https://github.com/bazelbuild/bazel/blob/986ef7b68d61b1573d9c2bb1200585d07ad24691/src/main/java/com/google/devtools/build/lib/rules/cpp/CcLinkingHelper.java#L951-L1009
                 static_library = (library.static_library or
                                   library.pic_static_library)
+                if not static_library:
+                    continue
                 if static_library.is_source:
                     continue
                 return static_library
@@ -207,6 +209,8 @@ def _extract_top_level_values(
                 # here: https://github.com/bazelbuild/bazel/blob/986ef7b68d61b1573d9c2bb1200585d07ad24691/src/main/java/com/google/devtools/build/lib/rules/cpp/CcLinkingHelper.java#L951-L1009
                 static_library = (library.static_library or
                                   library.pic_static_library)
+                if not static_library:
+                    continue
                 static_libraries.append(static_library)
 
         # Dedup libraries
@@ -263,6 +267,8 @@ def _collect_libraries(
                 # here: https://github.com/bazelbuild/bazel/blob/986ef7b68d61b1573d9c2bb1200585d07ad24691/src/main/java/com/google/devtools/build/lib/rules/cpp/CcLinkingHelper.java#L951-L1009
                 static_library = (library.static_library or
                                   library.pic_static_library)
+                if not static_library:
+                    continue
                 if static_library.is_source:
                     continue
                 libraries.append(static_library)


### PR DESCRIPTION
Part of #1922.

This is the case for dynamic libraries. For now these targets don’t create Xcode targets, but work in both BwX and BwB mode.