### PR TITLE
Improve `normalized_file_path` efficiency

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -16,9 +16,10 @@ bazel_dep(
     version = "2.0.0",
     repo_name = "build_bazel_rules_apple",
 )
+
 bazel_dep(
     name = "buildifier_prebuilt",
-    version = "6.0.0.1",
+    version = "6.1.0",
     dev_dependency = True,
 )
 bazel_dep(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -47,10 +47,10 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "buildifier_prebuilt",
-    sha256 = "f7093a960a8c3471552764892ce12cb62d9b72600fa4c8b08b2090c45db05ce8",
-    strip_prefix = "buildifier-prebuilt-6.0.0.1",
+    sha256 = "e46c16180bc49487bfd0f1ffa7345364718c57334fa0b5b67cb5f27eba10f309",
+    strip_prefix = "buildifier-prebuilt-6.1.0",
     urls = [
-        "https://github.com/keith/buildifier-prebuilt/archive/6.0.0.1.tar.gz",
+        "https://github.com/keith/buildifier-prebuilt/archive/refs/tags/6.1.0.tar.gz",
     ],
 )
 

--- a/examples/integration/iOSApp/Resources/ExampleResources/BUILD
+++ b/examples/integration/iOSApp/Resources/ExampleResources/BUILD
@@ -6,8 +6,8 @@ apple_resource_bundle(
     bundle_id = "com.example.resources",
     infoplists = ["Info.plist"],
     resources = glob(["Assets.xcassets/**"]) + [
-        "//iOSApp/Resources/ExampleNestedResources",
         ":deps_txt",
+        "//iOSApp/Resources/ExampleNestedResources",
     ],
     structured_resources = ["nested/hello.txt"],
     visibility = ["//iOSApp:__subpackages__"],

--- a/xcodeproj/internal/bazel_integration_files/BUILD
+++ b/xcodeproj/internal/bazel_integration_files/BUILD
@@ -18,8 +18,8 @@ filegroup(
 filegroup(
     name = "bazel_integration_files",
     srcs = [
-        ":swiftc",
         ":rsync_excludes",
+        ":swiftc",
     ] + glob(
         ["**/*"],
         exclude = _BASE_FILES + [

--- a/xcodeproj/internal/files.bzl
+++ b/xcodeproj/internal/files.bzl
@@ -169,17 +169,17 @@ def parsed_file_path(path):
     else:
         return project_file_path(path)
 
-RESOURCES_FOLDER_TYPE_EXTENSIONS = {
-    ".bundle": None,
-    ".docc": None,
-    ".framework": None,
-    ".scnassets": None,
-    ".xcassets": None,
-}
+RESOURCES_FOLDER_TYPE_EXTENSIONS = [
+    ".bundle",
+    ".docc",
+    ".framework",
+    ".scnassets",
+    ".xcassets",
+]
 
-FRAMEWORK_EXTENSIONS = {
-    ".framework": None,
-}
+FRAMEWORK_EXTENSIONS = [
+    ".framework",
+]
 
 def normalized_file_path(file, *, folder_type_extensions):
     """Converts a `File` into a `FilePath` Swift DTO value, leaving off \

--- a/xcodeproj/internal/files.bzl
+++ b/xcodeproj/internal/files.bzl
@@ -169,7 +169,7 @@ def parsed_file_path(path):
     else:
         return project_file_path(path)
 
-_FOLDER_TYPE_EXTENSIONS = {
+RESOURCES_FOLDER_TYPE_EXTENSIONS = {
     ".bundle": None,
     ".docc": None,
     ".framework": None,
@@ -177,19 +177,24 @@ _FOLDER_TYPE_EXTENSIONS = {
     ".xcassets": None,
 }
 
-def normalized_file_path(file):
+FRAMEWORK_EXTENSIONS = {
+    ".framework": None,
+}
+
+def normalized_file_path(file, *, folder_type_extensions):
     """Converts a `File` into a `FilePath` Swift DTO value, leaving off \
     unnecessary components under folder types.
 
     Args:
         file: A `File`.
+        folder_type_extensions: The extensions to check for folder types.
 
     Returns:
         A value as returned from `file_path`.
     """
     path = file.path
 
-    for extension in _FOLDER_TYPE_EXTENSIONS:
+    for extension in folder_type_extensions:
         prefix, ext, _ = path.partition(extension)
         if not ext:
             continue

--- a/xcodeproj/internal/resources.bzl
+++ b/xcodeproj/internal/resources.bzl
@@ -5,6 +5,7 @@ load("@bazel_skylib//lib:paths.bzl", "paths")
 load(":configuration.bzl", "calculate_configuration")
 load(
     ":files.bzl",
+    "RESOURCES_FOLDER_TYPE_EXTENSIONS",
     "file_path",
     "join_paths_ignoring_empty",
     "normalized_file_path",
@@ -58,7 +59,10 @@ def _process_resource(
             #   Folder Type detection.
             return None
 
-    return normalized_file_path(file)
+    return normalized_file_path(
+        file,
+        folder_type_extensions = RESOURCES_FOLDER_TYPE_EXTENSIONS,
+    )
 
 def _add_resources_to_bundle(
         *,

--- a/xcodeproj/internal/xcode_targets.bzl
+++ b/xcodeproj/internal/xcode_targets.bzl
@@ -6,6 +6,7 @@ load("@bazel_skylib//lib:structs.bzl", "structs")
 load(":collections.bzl", "set_if_true", "uniq")
 load(
     ":files.bzl",
+    "FRAMEWORK_EXTENSIONS",
     "build_setting_path",
     "file_path",
     "file_path_to_dto",
@@ -907,7 +908,12 @@ def _product_to_dto(product):
         dto,
         "a",
         [
-            file_path_to_dto(normalized_file_path(file))
+            file_path_to_dto(
+                normalized_file_path(
+                    file,
+                    folder_type_extensions = FRAMEWORK_EXTENSIONS,
+                ),
+            )
             for file in product._additional_files.to_list()
         ],
     )


### PR DESCRIPTION
We don’t need to check every folder type extension for every case. This was noticed as a hot spot in Starlark profiles.