### PR TITLE
Add support for ios_*_test_suite targets as top level targets

### DIFF
--- a/xcodeproj/internal/target_id.bzl
+++ b/xcodeproj/internal/target_id.bzl
@@ -37,10 +37,11 @@ def _longest_common_prefix(labels):
     return res
 
 def calculate_replacement_label(*, id, replacement_labels):
-    """Calculates a single replacement label for a given id and list of replacement labels
+    """Calculates a single replacement label for a given id and list of \
+    replacement labels.
 
-    It considers the list of labels received plus the label contained in the id itself, then it finds
-    the longest common prefix between those
+    It considers the list of labels received plus the label contained in the id
+    itself, then it finds the longest common prefix between those.
 
     Args:
         id: An id that uniquely represents a target (see `get_id`)

--- a/xcodeproj/internal/target_id.bzl
+++ b/xcodeproj/internal/target_id.bzl
@@ -17,11 +17,13 @@ def get_id(*, label, configuration):
 def _longest_common_prefix(labels):
     if not labels:
         return None
+
     # Assume the shortest string is the answer
     res = labels[0]
     for s in labels:
         if len(s) < len(res):
             res = s
+
     # Compare one character at a time with the rest,
     # as soon as any difference is found the result holds the longest common prefix
     index = 0
@@ -48,10 +50,10 @@ def calculate_replacement_label(*, id, replacement_labels):
         The longest common prefix between the list of labels and the label contained in the id,
         if a longest common prefix is not found the label contained in the id is returned
     """
-    id_label = id.split(" ")[0] # This assumes the id follows the creation pattern in `get_id`
+    id_label = id.split(" ")[0]  # This assumes the id follows the creation pattern in `get_id`
 
     res = _longest_common_prefix(
-        [id_label] + ["%s" % label for label in replacement_labels]
+        [id_label] + ["%s" % label for label in replacement_labels],
     )
     if not res:
         return None

--- a/xcodeproj/internal/target_id.bzl
+++ b/xcodeproj/internal/target_id.bzl
@@ -1,5 +1,7 @@
 """Functions dealing with Target IDs."""
 
+load(":bazel_labels.bzl", "bazel_labels")
+
 def get_id(*, label, configuration):
     """Generates a unique identifier for a target.
 
@@ -11,6 +13,51 @@ def get_id(*, label, configuration):
         An opaque string that uniquely identifies the target.
     """
     return "{} {}".format(label, configuration)
+
+def _longest_common_prefix(labels):
+    if not labels:
+        return None
+    # Assume the shortest string is the answer
+    res = labels[0]
+    for s in labels:
+        if len(s) < len(res):
+            res = s
+    # Compare one character at a time with the rest,
+    # as soon as any difference is found the result holds the longest common prefix
+    index = 0
+    for c in res.elems():
+        for label in labels:
+            if label[index] != c:
+                return res[:index]
+        index += 1
+
+    # If the above never returns the shortest string is the result
+    return res
+
+def calculate_replacement_label(*, id, replacement_labels):
+    """Calculates a single replacement label for a given id and list of replacement labels
+
+    It considers the list of labels received plus the label contained in the id itself, then it finds
+    the longest common prefix between those
+
+    Args:
+        id: An id that uniquely represents a target (see `get_id`)
+        replacement_labels: A list of replacement labels
+
+    Returns:
+        The longest common prefix between the list of labels and the label contained in the id,
+        if a longest common prefix is not found the label contained in the id is returned
+    """
+    id_label = id.split(" ")[0] # This assumes the id follows the creation pattern in `get_id`
+
+    res = _longest_common_prefix(
+        [id_label] + ["%s" % label for label in replacement_labels]
+    )
+    if not res:
+        return None
+
+    res = bazel_labels.normalize_label(res)
+    return Label(res)
 
 def write_target_ids_list(*, actions, name, target_dtos):
     """Writes the list of target IDs for a set of `xcode_target`s to a file.

--- a/xcodeproj/internal/target_id.bzl
+++ b/xcodeproj/internal/target_id.bzl
@@ -54,7 +54,7 @@ def calculate_replacement_label(*, id, replacement_labels):
     id_label = id.split(" ")[0]  # This assumes the id follows the creation pattern in `get_id`
 
     res = _longest_common_prefix(
-        [id_label] + ["%s" % label for label in replacement_labels],
+        [id_label] + [bazel_labels.normalize_label(label) for label in replacement_labels],
     )
     if not res:
         return None

--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -26,7 +26,7 @@ load(":platforms.bzl", "platforms")
 load(":project_options.bzl", "project_options_to_dto")
 load(":providers.bzl", "XcodeProjInfo")
 load(":resource_target.bzl", "process_resource_bundles")
-load(":target_id.bzl", "write_target_ids_list", "calculate_replacement_label")
+load(":target_id.bzl", "calculate_replacement_label", "write_target_ids_list")
 load(":xcode_targets.bzl", "xcode_targets")
 
 # Utility
@@ -1492,10 +1492,11 @@ configurations: {}""".format(", ".join(xcode_configurations)))
 
     # Finds ids associated with multiple labels
     multiple_replacement_labels = {
-        r.id: [x.label for x in replacement_labels_infos if x.id == r.id] # all labels associated with this id
+        r.id: [x.label for x in replacement_labels_infos if x.id == r.id]  # all labels associated with this id
         for r in replacement_labels_infos
-        if len([s.id for s in replacement_labels_infos if s.id == r.id]) > 1 # Check to only consider ids associated with multiple labels
+        if len([s.id for s in replacement_labels_infos if s.id == r.id]) > 1  # Check to only consider ids associated with multiple labels
     }
+
     # Ensures the id <=> label relationship is 1-1
     replacement_labels = {}
     for r in replacement_labels_infos:

--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -1490,23 +1490,19 @@ configurations: {}""".format(", ".join(xcode_configurations)))
         transitive = [info.replacement_labels for info in infos],
     ).to_list()
 
-    # Finds ids associated with multiple labels
-    multiple_replacement_labels = {
-        r.id: [x.label for x in replacement_labels_infos if x.id == r.id]  # all labels associated with this id
-        for r in replacement_labels_infos
-        if len([s.id for s in replacement_labels_infos if s.id == r.id]) > 1  # Check to only consider ids associated with multiple labels
-    }
-
-    # Ensures the id <=> label relationship is 1-1
-    replacement_labels = {}
+    raw_replacement_labels = {}
     for r in replacement_labels_infos:
-        if r.id in multiple_replacement_labels:
-            replacement_labels[r.id] = calculate_replacement_label(
-                id = r.id,
-                replacement_labels = multiple_replacement_labels[r.id],
-            )
+        raw_replacement_labels.setdefault(r.id, []).append(r.label)
+
+    replacement_labels = {}
+    for id, labels in raw_replacement_labels.items():
+        if len(labels) > 1:
+            replacement_labels[id] = calculate_replacement_label(
+                 id = id,
+                 replacement_labels = labels,
+             )
         else:
-            replacement_labels[r.id] = r.label
+            replacement_labels[id] = labels[0]
 
     (
         targets,

--- a/xcodeproj/internal/xcodeprojinfo.bzl
+++ b/xcodeproj/internal/xcodeprojinfo.bzl
@@ -266,15 +266,6 @@ def _skip_target(
         if attr in deps_attrs and info.xcode_target
     ]
 
-    test_suite_replacement_labels = []
-    if ctx.rule.kind == "test_suite":
-        for info in valid_transitive_infos:
-            for xcode_target in info.xcode_targets.to_list():
-                if xcode_target.id.count(".__internal__.__test_bundle"):
-                    test_suite_replacement_labels.append(
-                        struct(id = xcode_target.id, label = target.label),
-                    )
-
     return _target_info_fields(
         args = memory_efficient_depset(
             [
@@ -331,7 +322,7 @@ def _skip_target(
             [
                 struct(id = info.xcode_target.id, label = target.label)
                 for info in deps_transitive_infos
-            ] + test_suite_replacement_labels,
+            ],
             transitive = [
                 info.replacement_labels
                 for info in valid_transitive_infos

--- a/xcodeproj/internal/xcodeprojinfo.bzl
+++ b/xcodeproj/internal/xcodeprojinfo.bzl
@@ -71,6 +71,7 @@ _BUILD_TEST_RULES = {
     "macos_build_test": None,
     "tvos_build_test": None,
     "watchos_build_test": None,
+    "test_suite": None,
 }
 
 def _should_skip_target(*, ctx, target):
@@ -259,6 +260,15 @@ def _skip_target(
         if attr in deps_attrs and info.xcode_target
     ]
 
+    test_suite_replacement_labels = []
+    if ctx.rule.kind == "test_suite":
+        for info in valid_transitive_infos:
+            for xcode_target in info.xcode_targets.to_list():
+                if xcode_target.id.count(".__internal__.__test_bundle"):
+                    test_suite_replacement_labels.append(
+                        struct(id = xcode_target.id, label = target.label),
+                    )
+
     return _target_info_fields(
         args = memory_efficient_depset(
             [
@@ -315,7 +325,7 @@ def _skip_target(
             [
                 struct(id = info.xcode_target.id, label = target.label)
                 for info in deps_transitive_infos
-            ],
+            ] + test_suite_replacement_labels,
             transitive = [
                 info.replacement_labels
                 for info in valid_transitive_infos

--- a/xcodeproj/internal/xcodeprojinfo.bzl
+++ b/xcodeproj/internal/xcodeprojinfo.bzl
@@ -74,6 +74,10 @@ _BUILD_TEST_RULES = {
     "test_suite": None,
 }
 
+_TEST_SUITE_RULES = {
+    "test_suite": None,
+}
+
 def _should_skip_target(*, ctx, target):
     """Determines if the given target should be skipped for target generation.
 
@@ -88,6 +92,8 @@ def _should_skip_target(*, ctx, target):
         `True` if `target` should be skipped for target generation.
     """
     if ctx.rule.kind in _BUILD_TEST_RULES:
+        return True
+    if ctx.rule.kind in _TEST_SUITE_RULES:
         return True
 
     if AppleBinaryInfo in target and not hasattr(ctx.rule.attr, "deps"):


### PR DESCRIPTION
Resolves https://github.com/MobileNativeFoundation/rules_xcodeproj/issues/1956

- [ ] TBD: Add tests (both for integration and rules_ios)

Initial intend was to add support for `test_suite` rules and map each runner in `runners` to targets in Xcode, this is doable but it creates indexing issues due to two targets sharing paths. Ended up changing the approach to simply skip the runners (like it's done for non-suite rules already) and let Xcode be the runner, only propagating the bundle. This is probably similar to how Tulsi handled this based on the [docs](https://github.com/bazelbuild/rules_apple/blob/master/doc/rules-ios.md#ios_unit_test):

>Builds and bundles an iOS Unit .xctest test bundle. Runs the tests using the provided test runner when invoked with bazel test. When using Tulsi to run tests built with this target, runner will not be used since Xcode is the test runner in that case.

The only catch here is that `replacement _labels` will contain many underlying labels associated with the same target ID. So added logic to unify that and bring back a `id <=> label` 1-1 relationship, e.g., if these are found in this id => labels mapping exists in the replacement labels:
```py
{
  "@//tests/macos/xcodeproj:Single-Application-RunnableTestSuite.__internal__.__test_bundle applebin_ios-ios_sim_arm64-dbg-ST-d1716b12dfa6": [
    Label("//tests/macos/xcodeproj:Single-Application-RunnableTestSuite_iPad-Air-2__16.2"), 
    Label("//tests/macos/xcodeproj:Single-Application-RunnableTestSuite_iPhone-13-Pro__16.2")
  ]
}
```

Then the longest common value between the labels and the label contained in the id will be used to bring back a 1-1 relationship:
```py
{
  "@//tests/macos/xcodeproj:Single-Application-RunnableTestSuite.__internal__.__test_bundle applebin_ios-ios_sim_arm64-dbg-ST-d1716b12dfa6": Label("@//tests/macos/xcodeproj:Single-Application-RunnableTestSuite"),
}
```