### PR TITLE
Stop adding folder-nested generated files to `extra_files`

### DIFF
--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/generated.xcfilelist
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/generated.xcfilelist
@@ -182,7 +182,6 @@ $(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-0/bin/external/rules_xcodeproj_generated/g
 $(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-0/bin/external/rules_xcodeproj_generated/generator/generator-params/watchOSAppUITests.32.link.params
 $(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/Lib/Lib.swift
 $(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/WidgetExtension/Intents.swift
-$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/iOSApp/Resources/ExampleResources/bucket/deps.txt
 $(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer-Swift.h
 $(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer.h
 $(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer_objc_modulemap-module.modulemap
@@ -190,14 +189,12 @@ $(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/iOSApp/So
 $(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-10/bin/Lib/Lib.swift
 $(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-10/bin/WidgetExtension/Intents.swift
 $(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-10/bin/iOSApp/Resources/ExampleNestedResources/ExampleNestedResources-intermediates/ExampleNestedResources.bundle
-$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-10/bin/iOSApp/Resources/ExampleResources/bucket/deps.txt
 $(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-10/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer-Swift.h
 $(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-10/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer.h
 $(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-10/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer_objc_modulemap-module.modulemap
 $(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-10/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer_swift_modulemap-module.modulemap
 $(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/Lib/Lib.swift
 $(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/WidgetExtension/Intents.swift
-$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Resources/ExampleResources/bucket/deps.txt
 $(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer-Swift.h
 $(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer.h
 $(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer_objc_modulemap-module.modulemap
@@ -206,7 +203,6 @@ $(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/
 $(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-7/bin/Lib/Lib.swift
 $(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-7/bin/WidgetExtension/Intents.swift
 $(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-7/bin/iOSApp/Resources/ExampleNestedResources/ExampleNestedResources-intermediates/ExampleNestedResources.bundle
-$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-7/bin/iOSApp/Resources/ExampleResources/bucket/deps.txt
 $(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-7/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer-Swift.h
 $(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-7/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer.h
 $(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-7/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer_objc_modulemap-module.modulemap

--- a/examples/integration/test/fixtures/bwb_project_spec.json
+++ b/examples/integration/test/fixtures/bwb_project_spec.json
@@ -213,11 +213,6 @@
             "t": "g"
         },
         {
-            "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/iOSApp/Resources/ExampleResources/bucket/deps.txt",
-            "i": false,
-            "t": "g"
-        },
-        {
             "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer-Swift.h",
             "t": "g"
         },
@@ -244,11 +239,6 @@
             "t": "g"
         },
         {
-            "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-10/bin/iOSApp/Resources/ExampleResources/bucket/deps.txt",
-            "i": false,
-            "t": "g"
-        },
-        {
             "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-10/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer-Swift.h",
             "t": "g"
         },
@@ -268,11 +258,6 @@
             "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Resources/ExampleResources/bucket",
             "f": true,
             "g": true,
-            "t": "g"
-        },
-        {
-            "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Resources/ExampleResources/bucket/deps.txt",
-            "i": false,
             "t": "g"
         },
         {
@@ -299,11 +284,6 @@
             "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-7/bin/iOSApp/Resources/ExampleResources/bucket",
             "f": true,
             "g": true,
-            "t": "g"
-        },
-        {
-            "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-7/bin/iOSApp/Resources/ExampleResources/bucket/deps.txt",
-            "i": false,
             "t": "g"
         },
         {

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/generated.xcfilelist
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/generated.xcfilelist
@@ -190,7 +190,6 @@ $(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-0/bin/external/rules_xcodeproj_generated/g
 $(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-0/bin/external/rules_xcodeproj_generated/generator/generator-params/watchOSAppUITests.43.link.params
 $(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/Lib/Lib.swift
 $(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/WidgetExtension/Intents.swift
-$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/iOSApp/Resources/ExampleResources/bucket/deps.txt
 $(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer-Swift.h
 $(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer.h
 $(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer_objc_modulemap-module.modulemap
@@ -198,14 +197,12 @@ $(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/iOSApp/So
 $(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-10/bin/Lib/Lib.swift
 $(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-10/bin/WidgetExtension/Intents.swift
 $(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-10/bin/iOSApp/Resources/ExampleNestedResources/ExampleNestedResources-intermediates/ExampleNestedResources.bundle
-$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-10/bin/iOSApp/Resources/ExampleResources/bucket/deps.txt
 $(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-10/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer-Swift.h
 $(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-10/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer.h
 $(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-10/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer_objc_modulemap-module.modulemap
 $(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-10/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer_swift_modulemap-module.modulemap
 $(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/Lib/Lib.swift
 $(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/WidgetExtension/Intents.swift
-$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Resources/ExampleResources/bucket/deps.txt
 $(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer-Swift.h
 $(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer.h
 $(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer_objc_modulemap-module.modulemap
@@ -214,7 +211,6 @@ $(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/
 $(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-7/bin/Lib/Lib.swift
 $(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-7/bin/WidgetExtension/Intents.swift
 $(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-7/bin/iOSApp/Resources/ExampleNestedResources/ExampleNestedResources-intermediates/ExampleNestedResources.bundle
-$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-7/bin/iOSApp/Resources/ExampleResources/bucket/deps.txt
 $(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-7/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer-Swift.h
 $(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-7/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer.h
 $(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-7/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer_objc_modulemap-module.modulemap

--- a/examples/integration/test/fixtures/bwx_project_spec.json
+++ b/examples/integration/test/fixtures/bwx_project_spec.json
@@ -201,11 +201,6 @@
             "t": "g"
         },
         {
-            "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/iOSApp/Resources/ExampleResources/bucket/deps.txt",
-            "i": false,
-            "t": "g"
-        },
-        {
             "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer-Swift.h",
             "t": "g"
         },
@@ -219,11 +214,6 @@
         },
         {
             "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer_swift_modulemap-module.modulemap",
-            "t": "g"
-        },
-        {
-            "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-10/bin/iOSApp/Resources/ExampleResources/bucket/deps.txt",
-            "i": false,
             "t": "g"
         },
         {
@@ -243,11 +233,6 @@
             "t": "g"
         },
         {
-            "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Resources/ExampleResources/bucket/deps.txt",
-            "i": false,
-            "t": "g"
-        },
-        {
             "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer-Swift.h",
             "t": "g"
         },
@@ -261,11 +246,6 @@
         },
         {
             "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer_swift_modulemap-module.modulemap",
-            "t": "g"
-        },
-        {
-            "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-7/bin/iOSApp/Resources/ExampleResources/bucket/deps.txt",
-            "i": false,
             "t": "g"
         },
         {

--- a/test/internal/target/process_top_level_properties_tests.bzl
+++ b/test/internal/target/process_top_level_properties_tests.bzl
@@ -31,7 +31,6 @@ def _process_top_level_properties_test_impl(ctx):
             path = ctx.attr.expected_bundle_path,
             type = "g",
             is_folder = False,
-            include_in_navigator = True,
             force_group_creation = False,
         ) if ctx.attr.expected_bundle_path else None,
         properties.bundle_file_path,

--- a/tools/generator/src/DTO/FilePath.swift
+++ b/tools/generator/src/DTO/FilePath.swift
@@ -11,20 +11,17 @@ struct FilePath: Hashable, Decodable {
     let type: PathType
     var path: Path
     var isFolder: Bool
-    let includeInNavigator: Bool
     var forceGroupCreation: Bool
 
     fileprivate init(
         type: PathType,
         path: Path,
         isFolder: Bool,
-        includeInNavigator: Bool,
         forceGroupCreation: Bool
     ) {
         self.type = type
         self.path = path
         self.isFolder = isFolder
-        self.includeInNavigator = includeInNavigator
         self.forceGroupCreation = forceGroupCreation
     }
 
@@ -34,7 +31,6 @@ struct FilePath: Hashable, Decodable {
         case path = "_"
         case type = "t"
         case isFolder = "f"
-        case includeInNavigator = "i"
         case forceGroupCreation = "g"
     }
 
@@ -44,7 +40,6 @@ struct FilePath: Hashable, Decodable {
             type = .project
             self.path = path
             isFolder = false
-            includeInNavigator = true
             forceGroupCreation = false
             return
         }
@@ -55,8 +50,6 @@ struct FilePath: Hashable, Decodable {
             ?? .project
         isFolder = try container.decodeIfPresent(Bool.self, forKey: .isFolder)
             ?? false
-        includeInNavigator = try container
-            .decodeIfPresent(Bool.self, forKey: .includeInNavigator) ?? true
         forceGroupCreation = try container
             .decodeIfPresent(Bool.self, forKey: .forceGroupCreation) ?? false
     }
@@ -66,14 +59,12 @@ extension FilePath {
     static func project(
         _ path: Path,
         isFolder: Bool = false,
-        includeInNavigator: Bool = true,
         forceGroupCreation: Bool = false
     ) -> FilePath {
         return FilePath(
             type: .project,
             path: path,
             isFolder: isFolder,
-            includeInNavigator: includeInNavigator,
             forceGroupCreation: forceGroupCreation
         )
     }
@@ -81,14 +72,12 @@ extension FilePath {
     static func external(
         _ path: Path,
         isFolder: Bool = false,
-        includeInNavigator: Bool = true,
         forceGroupCreation: Bool = false
     ) -> FilePath {
         return FilePath(
             type: .external,
             path: path,
             isFolder: isFolder,
-            includeInNavigator: includeInNavigator,
             forceGroupCreation: forceGroupCreation
         )
     }
@@ -96,14 +85,12 @@ extension FilePath {
     static func generated(
         _ path: Path,
         isFolder: Bool = false,
-        includeInNavigator: Bool = true,
         forceGroupCreation: Bool = false
     ) -> FilePath {
         return FilePath(
             type: .generated,
             path: path,
             isFolder: isFolder,
-            includeInNavigator: includeInNavigator,
             forceGroupCreation: forceGroupCreation
         )
     }
@@ -111,14 +98,12 @@ extension FilePath {
     static func `internal`(
         _ path: Path,
         isFolder: Bool = false,
-        includeInNavigator: Bool = true,
         forceGroupCreation: Bool = false
     ) -> FilePath {
         return FilePath(
             type: .internal,
             path: path,
             isFolder: isFolder,
-            includeInNavigator: includeInNavigator,
             forceGroupCreation: forceGroupCreation
         )
     }
@@ -130,7 +115,6 @@ extension FilePath {
             type: type,
             path: path.parent().normalize(),
             isFolder: false,
-            includeInNavigator: includeInNavigator,
             forceGroupCreation: forceGroupCreation
         )
     }
@@ -181,7 +165,6 @@ func + (lhs: FilePath, rhs: String) -> FilePath {
         type: lhs.type,
         path: path,
         isFolder: false,
-        includeInNavigator: lhs.includeInNavigator,
         forceGroupCreation: lhs.forceGroupCreation
     )
 }

--- a/tools/generator/src/Generator/CreateFilesAndGroups.swift
+++ b/tools/generator/src/Generator/CreateFilesAndGroups.swift
@@ -426,13 +426,7 @@ extension Generator {
 
         var rootElements: [PBXFileElement] = []
         var nonDirectFolderLikeFilePaths: Set<FilePath> = []
-        var nonIncludedFiles: Set<FilePath> = []
         for fullFilePath in allInputPaths {
-            guard fullFilePath.includeInNavigator else {
-                nonIncludedFiles.insert(fullFilePath)
-                continue
-            }
-
             var filePath: FilePath
             var lastElement: PBXFileElement?
             switch fullFilePath.type {
@@ -555,7 +549,7 @@ extension Generator {
             .map { FilePathResolver.resolveExternal($0.path) }
 
         let generatedFilePaths = fileListFileFilePaths
-            .filter { $0.type == .generated && !$0.isFolder } + nonIncludedFiles
+            .filter { $0.type == .generated && !$0.isFolder }
 
         let generatedPaths = generatedFilePaths
             .map { FilePathResolver.resolveGenerated($0.path) }

--- a/tools/generator/test/Fixtures.swift
+++ b/tools/generator/test/Fixtures.swift
@@ -40,7 +40,6 @@ enum Fixtures {
             "a/imported.a",
             "a/module.modulemap",
             "a/StaticFram.framework",
-            .generated("v/a.txt", includeInNavigator: false),
         ],
         schemeAutogenerationMode: .auto,
         customXcodeSchemes: [],
@@ -1062,7 +1061,6 @@ $(BAZEL_OUT)/B3.link.params
 $(BAZEL_OUT)/a/b/module.modulemap
 $(BAZEL_OUT)/a1b2c/bin/t.c
 $(BAZEL_OUT)/d.link.params
-$(BAZEL_OUT)/v/a.txt
 $(BAZEL_OUT)/z/A.link.params
 
 """)

--- a/xcodeproj/internal/files.bzl
+++ b/xcodeproj/internal/files.bzl
@@ -7,7 +7,6 @@ def file_path(
         *,
         path = None,
         is_folder = False,
-        include_in_navigator = True,
         force_group_creation = False):
     """Converts a `File` into a `FilePath` Swift DTO value.
 
@@ -15,8 +14,6 @@ def file_path(
         file: A `File`.
         path: A path string to use instead of `file.path`.
         is_folder: Whether the path is to a folder.
-        include_in_navigator: Whether to include the file in the Project
-            navigator.
         force_group_creation: Whether to force the creation of all intermediate
             groups in the generated project for the file. If this is `True`,
             then no folder type optimizations will be used.
@@ -40,20 +37,17 @@ def file_path(
         return generated_file_path(
             path = path,
             is_folder = is_folder,
-            include_in_navigator = include_in_navigator,
             force_group_creation = force_group_creation,
         )
     if file.owner.workspace_name:
         return external_file_path(
             path = path,
             is_folder = is_folder,
-            include_in_navigator = include_in_navigator,
             force_group_creation = force_group_creation,
         )
     return project_file_path(
         path = path,
         is_folder = is_folder,
-        include_in_navigator = include_in_navigator,
         force_group_creation = force_group_creation,
     )
 
@@ -210,13 +204,11 @@ def raw_file_path(
         *,
         path,
         is_folder,
-        include_in_navigator,
         force_group_creation):
     return struct(
         path = path,
         type = type,
         is_folder = is_folder,
-        include_in_navigator = include_in_navigator,
         force_group_creation = force_group_creation,
     )
 
@@ -224,7 +216,6 @@ def external_file_path(
         path,
         *,
         is_folder = False,
-        include_in_navigator = True,
         force_group_creation = False):
     return raw_file_path(
         # Type: "e" == `.external`
@@ -232,7 +223,6 @@ def external_file_path(
         # Path, removing `external/` prefix
         path = path[9:],
         is_folder = is_folder,
-        include_in_navigator = include_in_navigator,
         force_group_creation = force_group_creation,
     )
 
@@ -240,7 +230,6 @@ def generated_file_path(
         path,
         *,
         is_folder = False,
-        include_in_navigator = True,
         force_group_creation = False):
     return raw_file_path(
         # Type: "g" == `.generated`
@@ -248,7 +237,6 @@ def generated_file_path(
         # Path, removing `bazel-out/` prefix
         path = path[10:],
         is_folder = is_folder,
-        include_in_navigator = include_in_navigator,
         force_group_creation = force_group_creation,
     )
 
@@ -268,14 +256,12 @@ def project_file_path(
         path,
         *,
         is_folder = False,
-        include_in_navigator = True,
         force_group_creation = False):
     return raw_file_path(
         # Type: "p" == `.project`
         type = "p",
         path = path,
         is_folder = is_folder,
-        include_in_navigator = include_in_navigator,
         force_group_creation = force_group_creation,
     )
 
@@ -308,9 +294,6 @@ def file_path_to_dto(file_path):
 
     if file_path.type != "p":
         ret["t"] = file_path.type
-
-    if not file_path.include_in_navigator:
-        ret["i"] = False
 
     if file_path.force_group_creation:
         ret["g"] = True

--- a/xcodeproj/internal/resources.bzl
+++ b/xcodeproj/internal/resources.bzl
@@ -95,8 +95,7 @@ def _add_structured_resources_to_bundle(
         *,
         nested_path,
         files,
-        generated,
-        extra_files):
+        generated):
     if nested_path:
         inner_dir = nested_path.split("/")[0]
     else:
@@ -138,8 +137,7 @@ def _add_structured_resources(
         bundle_path,
         nested_path,
         files,
-        generated,
-        extra_files):
+        generated):
     bundle = resource_bundle_targets.get(bundle_path)
 
     if bundle:
@@ -152,7 +150,6 @@ def _add_structured_resources(
             nested_path = nested_path,
             files = files,
             generated = generated,
-            extra_files = extra_files,
         )
     else:
         _add_structured_resources_to_bundle(
@@ -160,7 +157,6 @@ def _add_structured_resources(
             nested_path = join_paths_ignoring_empty(bundle_path, nested_path),
             files = files,
             generated = generated,
-            extra_files = extra_files,
         )
 
 def _add_processed_resources(
@@ -214,8 +210,7 @@ def _add_unprocessed_resources(
         parent_bundle_paths,
         bundle_metadata,
         generated,
-        xccurrentversions,
-        extra_files):
+        xccurrentversions):
     for parent_dir, _, files in resources:
         if not parent_dir:
             _add_resources_to_bundle(
@@ -243,7 +238,6 @@ def _add_unprocessed_resources(
             nested_path = nested_path,
             files = files,
             generated = generated,
-            extra_files = extra_files,
         )
 
 # API
@@ -315,7 +309,6 @@ def collect_resources(
                 bundle_metadata = bundle_metadata,
                 generated = generated,
                 xccurrentversions = xccurrentversions,
-                extra_files = extra_files,
             )
         else:
             _add_processed_resources(

--- a/xcodeproj/internal/resources.bzl
+++ b/xcodeproj/internal/resources.bzl
@@ -131,9 +131,6 @@ def _add_structured_resources_to_bundle(
         )
         bundle.resources.append(fp)
 
-        if not file.is_source:
-            extra_files.append(file_path(file, include_in_navigator = False))
-
 def _add_structured_resources(
         *,
         root_bundle,

--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -195,7 +195,6 @@ def _process_extra_files(
                 type = fp.type,
                 path = _normalize_path(fp.path),
                 is_folder = fp.is_folder,
-                include_in_navigator = fp.include_in_navigator,
                 force_group_creation = fp.force_group_creation,
             )
             for fp in extra_files


### PR DESCRIPTION
`generated.xcfilelist` only needs to include files that are in the navigator, and actually only those that are referenced in `PBXBuildFile`s.

This also removes the need for `file_path.include_in_navigator`.