### PR TITLE
Remove `file_path.is_folder`

### DIFF
--- a/examples/integration/test/fixtures/bwb_project_spec.json
+++ b/examples/integration/test/fixtures/bwb_project_spec.json
@@ -71,6 +71,31 @@
             "INTEGRATION_TEST_ENV_VAR": "TRUE"
         }
     ],
+    "F": [
+        {
+            "_": "examples_ios_app_external/bundles/Utils.bundle",
+            "t": "e"
+        },
+        {
+            "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/iOSApp/Resources/ExampleResources/bucket",
+            "t": "g"
+        },
+        {
+            "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-10/bin/iOSApp/Resources/ExampleResources/bucket",
+            "t": "g"
+        },
+        {
+            "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Resources/ExampleResources/bucket",
+            "t": "g"
+        },
+        {
+            "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-7/bin/iOSApp/Resources/ExampleResources/bucket",
+            "t": "g"
+        },
+        "iOSApp/Resources/ExampleNestedResources/dir",
+        "iOSApp/Resources/ExampleResources/nested",
+        "iOSApp/Resources/OnlyStructuredResources/Nested"
+    ],
     "R": "@//test/fixtures:xcodeproj_bwb",
     "a": [
         "//iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTests.__internal__.__test_bundle applebin_ios-ios_x86_64-dbg-STABLE-13",
@@ -153,11 +178,6 @@
             "t": "e"
         },
         {
-            "_": "examples_ios_app_external/bundles/Utils.bundle",
-            "f": true,
-            "t": "e"
-        },
-        {
             "_": "applebin_tvos-tvos_arm64-dbg-STABLE-26/bin/Lib/exported-symbols.lds",
             "t": "g"
         },
@@ -206,11 +226,6 @@
             "t": "g"
         },
         {
-            "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/iOSApp/Resources/ExampleResources/bucket",
-            "f": true,
-            "t": "g"
-        },
-        {
             "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer-Swift.h",
             "t": "g"
         },
@@ -231,11 +246,6 @@
             "t": "g"
         },
         {
-            "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-10/bin/iOSApp/Resources/ExampleResources/bucket",
-            "f": true,
-            "t": "g"
-        },
-        {
             "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-10/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer-Swift.h",
             "t": "g"
         },
@@ -249,11 +259,6 @@
         },
         {
             "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-10/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer_swift_modulemap-module.modulemap",
-            "t": "g"
-        },
-        {
-            "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Resources/ExampleResources/bucket",
-            "f": true,
             "t": "g"
         },
         {
@@ -274,11 +279,6 @@
         },
         {
             "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-7/bin/iOSApp/Resources/ExampleNestedResources/ExampleNestedResources-intermediates/ExampleNestedResources.bundle",
-            "t": "g"
-        },
-        {
-            "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-7/bin/iOSApp/Resources/ExampleResources/bucket",
-            "f": true,
             "t": "g"
         },
         {
@@ -344,25 +344,13 @@
         "iOSApp/Resources/ExampleNestedResources/Assets.xcassets",
         "iOSApp/Resources/ExampleNestedResources/BUILD",
         "iOSApp/Resources/ExampleNestedResources/Info.plist",
-        {
-            "_": "iOSApp/Resources/ExampleNestedResources/dir",
-            "f": true
-        },
         "iOSApp/Resources/ExampleNestedResources/en.lproj/Localizable.strings",
         "iOSApp/Resources/ExampleNestedResources/es.lproj/Localizable.strings",
         "iOSApp/Resources/ExampleResources/Assets.xcassets",
         "iOSApp/Resources/ExampleResources/BUILD",
         "iOSApp/Resources/ExampleResources/Info.plist",
-        {
-            "_": "iOSApp/Resources/ExampleResources/nested",
-            "f": true
-        },
         "iOSApp/Resources/OnlyStructuredResources/BUILD",
         "iOSApp/Resources/OnlyStructuredResources/Info.plist",
-        {
-            "_": "iOSApp/Resources/OnlyStructuredResources/Nested",
-            "f": true
-        },
         "iOSApp/Source/AltIcons/AltIcon-60.alticon/AltIcon-60@2x.png",
         "iOSApp/Source/AltIcons/AltIcon-60.alticon/AltIcon-60@3x.png",
         "iOSApp/Source/BUILD",

--- a/examples/integration/test/fixtures/bwb_targets_spec.json
+++ b/examples/integration/test/fixtures/bwb_targets_spec.json
@@ -10097,6 +10097,13 @@
         ],
         "i": {
             "e": "iOSApp/Source/ios app.entitlements",
+            "f": [
+                {
+                    "_": "com_google_google_maps/GoogleMaps.xcframework/ios-arm64/GoogleMaps.framework/Resources/GoogleMaps.bundle",
+                    "t": "e"
+                },
+                "iOSApp/Source/nested"
+            ],
             "r": [
                 "iOSApp/Source/PreviewContent/Preview Assets.xcassets",
                 "iOSApp/Source/AltIcons/AltIcon-60.alticon/AltIcon-60@2x.png",
@@ -10107,15 +10114,6 @@
                 "iOSApp/Source/Model.xcdatamodeld/Model2.xcdatamodel/contents",
                 "iOSApp/Source/en.lproj/Localizable.strings",
                 "iOSApp/Source/es.lproj/Localizable.strings",
-                {
-                    "_": "com_google_google_maps/GoogleMaps.xcframework/ios-arm64/GoogleMaps.framework/Resources/GoogleMaps.bundle",
-                    "f": true,
-                    "t": "e"
-                },
-                {
-                    "_": "iOSApp/Source/nested",
-                    "f": true
-                },
                 "iOSApp/Source/en.lproj/unprocessed.json",
                 "iOSApp/Source/es.lproj/unprocessed.json"
             ],
@@ -10325,6 +10323,13 @@
         ],
         "i": {
             "e": "iOSApp/Source/ios app.entitlements",
+            "f": [
+                {
+                    "_": "com_google_google_maps/GoogleMaps.xcframework/ios-arm64/GoogleMaps.framework/Resources/GoogleMaps.bundle",
+                    "t": "e"
+                },
+                "iOSApp/Source/nested"
+            ],
             "r": [
                 "iOSApp/Source/AltIcons/AltIcon-60.alticon/AltIcon-60@2x.png",
                 "iOSApp/Source/AltIcons/AltIcon-60.alticon/AltIcon-60@3x.png",
@@ -10334,15 +10339,6 @@
                 "iOSApp/Source/Model.xcdatamodeld/Model2.xcdatamodel/contents",
                 "iOSApp/Source/en.lproj/Localizable.strings",
                 "iOSApp/Source/es.lproj/Localizable.strings",
-                {
-                    "_": "com_google_google_maps/GoogleMaps.xcframework/ios-arm64/GoogleMaps.framework/Resources/GoogleMaps.bundle",
-                    "f": true,
-                    "t": "e"
-                },
-                {
-                    "_": "iOSApp/Source/nested",
-                    "f": true
-                },
                 "iOSApp/Source/en.lproj/unprocessed.json",
                 "iOSApp/Source/es.lproj/unprocessed.json"
             ],
@@ -10552,6 +10548,13 @@
         ],
         "i": {
             "e": "iOSApp/Source/ios app.entitlements",
+            "f": [
+                {
+                    "_": "com_google_google_maps/GoogleMaps.xcframework/ios-arm64_x86_64-simulator/GoogleMaps.framework/Resources/GoogleMaps.bundle",
+                    "t": "e"
+                },
+                "iOSApp/Source/nested"
+            ],
             "r": [
                 "iOSApp/Source/PreviewContent/Preview Assets.xcassets",
                 "iOSApp/Source/AltIcons/AltIcon-60.alticon/AltIcon-60@2x.png",
@@ -10562,15 +10565,6 @@
                 "iOSApp/Source/Launch.storyboard",
                 "iOSApp/Source/en.lproj/Localizable.strings",
                 "iOSApp/Source/es.lproj/Localizable.strings",
-                {
-                    "_": "com_google_google_maps/GoogleMaps.xcframework/ios-arm64_x86_64-simulator/GoogleMaps.framework/Resources/GoogleMaps.bundle",
-                    "f": true,
-                    "t": "e"
-                },
-                {
-                    "_": "iOSApp/Source/nested",
-                    "f": true
-                },
                 "iOSApp/Source/en.lproj/unprocessed.json",
                 "iOSApp/Source/es.lproj/unprocessed.json"
             ],
@@ -10779,6 +10773,13 @@
         ],
         "i": {
             "e": "iOSApp/Source/ios app.entitlements",
+            "f": [
+                {
+                    "_": "com_google_google_maps/GoogleMaps.xcframework/ios-arm64_x86_64-simulator/GoogleMaps.framework/Resources/GoogleMaps.bundle",
+                    "t": "e"
+                },
+                "iOSApp/Source/nested"
+            ],
             "r": [
                 "iOSApp/Source/AltIcons/AltIcon-60.alticon/AltIcon-60@2x.png",
                 "iOSApp/Source/AltIcons/AltIcon-60.alticon/AltIcon-60@3x.png",
@@ -10788,15 +10789,6 @@
                 "iOSApp/Source/Launch.storyboard",
                 "iOSApp/Source/en.lproj/Localizable.strings",
                 "iOSApp/Source/es.lproj/Localizable.strings",
-                {
-                    "_": "com_google_google_maps/GoogleMaps.xcframework/ios-arm64_x86_64-simulator/GoogleMaps.framework/Resources/GoogleMaps.bundle",
-                    "f": true,
-                    "t": "e"
-                },
-                {
-                    "_": "iOSApp/Source/nested",
-                    "f": true
-                },
                 "iOSApp/Source/en.lproj/unprocessed.json",
                 "iOSApp/Source/es.lproj/unprocessed.json"
             ],
@@ -10976,10 +10968,9 @@
         ],
         "h": "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-dbg-STABLE-13",
         "i": {
-            "r": [
+            "f": [
                 {
                     "_": "examples_ios_app_external/bundles/Utils.bundle",
-                    "f": true,
                     "t": "e"
                 }
             ],
@@ -11158,10 +11149,9 @@
         ],
         "h": "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-opt-STABLE-15",
         "i": {
-            "r": [
+            "f": [
                 {
                     "_": "examples_ios_app_external/bundles/Utils.bundle",
-                    "f": true,
                     "t": "e"
                 }
             ],
@@ -11373,13 +11363,14 @@
         ],
         "h": "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-dbg-STABLE-13",
         "i": {
-            "r": [
-                "iOSApp/Resources/ExampleResources/Assets.xcassets",
+            "f": [
                 {
                     "_": "examples_ios_app_external/bundles/Utils.bundle",
-                    "f": true,
                     "t": "e"
                 }
+            ],
+            "r": [
+                "iOSApp/Resources/ExampleResources/Assets.xcassets"
             ],
             "s": [
                 "iOSApp/Test/SwiftUnitTests/SwiftUnitTests.swift"
@@ -11594,13 +11585,14 @@
         ],
         "h": "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-opt-STABLE-15",
         "i": {
-            "r": [
-                "iOSApp/Resources/ExampleResources/Assets.xcassets",
+            "f": [
                 {
                     "_": "examples_ios_app_external/bundles/Utils.bundle",
-                    "f": true,
                     "t": "e"
                 }
+            ],
+            "r": [
+                "iOSApp/Resources/ExampleResources/Assets.xcassets"
             ],
             "s": [
                 "iOSApp/Test/SwiftUnitTests/SwiftUnitTests.swift"

--- a/examples/integration/test/fixtures/bwx_targets_spec.json
+++ b/examples/integration/test/fixtures/bwx_targets_spec.json
@@ -8660,19 +8660,17 @@
         },
         "c": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4",
         "i": {
+            "f": [
+                "iOSApp/Resources/ExampleNestedResources/dir",
+                {
+                    "_": "examples_ios_app_external/bundles/Utils.bundle",
+                    "t": "e"
+                }
+            ],
             "r": [
                 "iOSApp/Resources/ExampleNestedResources/Assets.xcassets",
                 "iOSApp/Resources/ExampleNestedResources/en.lproj/Localizable.strings",
-                "iOSApp/Resources/ExampleNestedResources/es.lproj/Localizable.strings",
-                {
-                    "_": "iOSApp/Resources/ExampleNestedResources/dir",
-                    "f": true
-                },
-                {
-                    "_": "examples_ios_app_external/bundles/Utils.bundle",
-                    "f": true,
-                    "t": "e"
-                }
+                "iOSApp/Resources/ExampleNestedResources/es.lproj/Localizable.strings"
             ]
         },
         "l": "//iOSApp/Resources/ExampleNestedResources:ExampleNestedResources",
@@ -8702,20 +8700,18 @@
         },
         "c": "ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-10",
         "i": {
+            "f": [
+                "iOSApp/Resources/ExampleNestedResources/dir",
+                {
+                    "_": "examples_ios_app_external/bundles/Utils.bundle",
+                    "t": "e"
+                }
+            ],
             "r": [
                 "iOSApp/Resources/ExampleNestedResources/Assets.xcassets",
                 {
                     "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-10/bin/iOSApp/Resources/ExampleNestedResources/ExampleNestedResources-intermediates/ExampleNestedResources.bundle",
                     "t": "g"
-                },
-                {
-                    "_": "iOSApp/Resources/ExampleNestedResources/dir",
-                    "f": true
-                },
-                {
-                    "_": "examples_ios_app_external/bundles/Utils.bundle",
-                    "f": true,
-                    "t": "e"
                 }
             ]
         },
@@ -8749,19 +8745,17 @@
         },
         "c": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
         "i": {
+            "f": [
+                "iOSApp/Resources/ExampleNestedResources/dir",
+                {
+                    "_": "examples_ios_app_external/bundles/Utils.bundle",
+                    "t": "e"
+                }
+            ],
             "r": [
                 "iOSApp/Resources/ExampleNestedResources/Assets.xcassets",
                 "iOSApp/Resources/ExampleNestedResources/en.lproj/Localizable.strings",
-                "iOSApp/Resources/ExampleNestedResources/es.lproj/Localizable.strings",
-                {
-                    "_": "iOSApp/Resources/ExampleNestedResources/dir",
-                    "f": true
-                },
-                {
-                    "_": "examples_ios_app_external/bundles/Utils.bundle",
-                    "f": true,
-                    "t": "e"
-                }
+                "iOSApp/Resources/ExampleNestedResources/es.lproj/Localizable.strings"
             ]
         },
         "l": "//iOSApp/Resources/ExampleNestedResources:ExampleNestedResources",
@@ -8791,20 +8785,18 @@
         },
         "c": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-7",
         "i": {
+            "f": [
+                "iOSApp/Resources/ExampleNestedResources/dir",
+                {
+                    "_": "examples_ios_app_external/bundles/Utils.bundle",
+                    "t": "e"
+                }
+            ],
             "r": [
                 "iOSApp/Resources/ExampleNestedResources/Assets.xcassets",
                 {
                     "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-7/bin/iOSApp/Resources/ExampleNestedResources/ExampleNestedResources-intermediates/ExampleNestedResources.bundle",
                     "t": "g"
-                },
-                {
-                    "_": "iOSApp/Resources/ExampleNestedResources/dir",
-                    "f": true
-                },
-                {
-                    "_": "examples_ios_app_external/bundles/Utils.bundle",
-                    "f": true,
-                    "t": "e"
                 }
             ]
         },
@@ -8841,17 +8833,15 @@
             "//iOSApp/Resources/ExampleNestedResources:ExampleNestedResources ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4"
         ],
         "i": {
-            "r": [
-                "iOSApp/Resources/ExampleResources/Assets.xcassets",
-                {
-                    "_": "iOSApp/Resources/ExampleResources/nested",
-                    "f": true
-                },
+            "f": [
+                "iOSApp/Resources/ExampleResources/nested",
                 {
                     "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/iOSApp/Resources/ExampleResources/bucket",
-                    "f": true,
                     "t": "g"
                 }
+            ],
+            "r": [
+                "iOSApp/Resources/ExampleResources/Assets.xcassets"
             ]
         },
         "l": "//iOSApp/Resources/ExampleResources:ExampleResources",
@@ -8887,17 +8877,15 @@
             "//iOSApp/Resources/ExampleNestedResources:ExampleNestedResources ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-10"
         ],
         "i": {
-            "r": [
-                "iOSApp/Resources/ExampleResources/Assets.xcassets",
-                {
-                    "_": "iOSApp/Resources/ExampleResources/nested",
-                    "f": true
-                },
+            "f": [
+                "iOSApp/Resources/ExampleResources/nested",
                 {
                     "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-10/bin/iOSApp/Resources/ExampleResources/bucket",
-                    "f": true,
                     "t": "g"
                 }
+            ],
+            "r": [
+                "iOSApp/Resources/ExampleResources/Assets.xcassets"
             ]
         },
         "l": "//iOSApp/Resources/ExampleResources:ExampleResources",
@@ -8936,17 +8924,15 @@
             "//iOSApp/Resources/ExampleNestedResources:ExampleNestedResources ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1"
         ],
         "i": {
-            "r": [
-                "iOSApp/Resources/ExampleResources/Assets.xcassets",
-                {
-                    "_": "iOSApp/Resources/ExampleResources/nested",
-                    "f": true
-                },
+            "f": [
+                "iOSApp/Resources/ExampleResources/nested",
                 {
                     "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Resources/ExampleResources/bucket",
-                    "f": true,
                     "t": "g"
                 }
+            ],
+            "r": [
+                "iOSApp/Resources/ExampleResources/Assets.xcassets"
             ]
         },
         "l": "//iOSApp/Resources/ExampleResources:ExampleResources",
@@ -8982,17 +8968,15 @@
             "//iOSApp/Resources/ExampleNestedResources:ExampleNestedResources ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-7"
         ],
         "i": {
-            "r": [
-                "iOSApp/Resources/ExampleResources/Assets.xcassets",
-                {
-                    "_": "iOSApp/Resources/ExampleResources/nested",
-                    "f": true
-                },
+            "f": [
+                "iOSApp/Resources/ExampleResources/nested",
                 {
                     "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-7/bin/iOSApp/Resources/ExampleResources/bucket",
-                    "f": true,
                     "t": "g"
                 }
+            ],
+            "r": [
+                "iOSApp/Resources/ExampleResources/Assets.xcassets"
             ]
         },
         "l": "//iOSApp/Resources/ExampleResources:ExampleResources",
@@ -9028,11 +9012,8 @@
         },
         "c": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
         "i": {
-            "r": [
-                {
-                    "_": "iOSApp/Resources/OnlyStructuredResources/Nested",
-                    "f": true
-                }
+            "f": [
+                "iOSApp/Resources/OnlyStructuredResources/Nested"
             ]
         },
         "l": "//iOSApp/Resources/OnlyStructuredResources:OnlyStructuredResources",
@@ -9062,11 +9043,8 @@
         },
         "c": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-7",
         "i": {
-            "r": [
-                {
-                    "_": "iOSApp/Resources/OnlyStructuredResources/Nested",
-                    "f": true
-                }
+            "f": [
+                "iOSApp/Resources/OnlyStructuredResources/Nested"
             ]
         },
         "l": "//iOSApp/Resources/OnlyStructuredResources:OnlyStructuredResources",
@@ -10483,6 +10461,13 @@
         ],
         "i": {
             "e": "iOSApp/Source/ios app.entitlements",
+            "f": [
+                {
+                    "_": "com_google_google_maps/GoogleMaps.xcframework/ios-arm64/GoogleMaps.framework/Resources/GoogleMaps.bundle",
+                    "t": "e"
+                },
+                "iOSApp/Source/nested"
+            ],
             "r": [
                 "iOSApp/Source/PreviewContent/Preview Assets.xcassets",
                 "iOSApp/Source/AltIcons/AltIcon-60.alticon/AltIcon-60@2x.png",
@@ -10493,15 +10478,6 @@
                 "iOSApp/Source/Model.xcdatamodeld/Model2.xcdatamodel/contents",
                 "iOSApp/Source/en.lproj/Localizable.strings",
                 "iOSApp/Source/es.lproj/Localizable.strings",
-                {
-                    "_": "com_google_google_maps/GoogleMaps.xcframework/ios-arm64/GoogleMaps.framework/Resources/GoogleMaps.bundle",
-                    "f": true,
-                    "t": "e"
-                },
-                {
-                    "_": "iOSApp/Source/nested",
-                    "f": true
-                },
                 "iOSApp/Source/en.lproj/unprocessed.json",
                 "iOSApp/Source/es.lproj/unprocessed.json"
             ],
@@ -10698,6 +10674,13 @@
         ],
         "i": {
             "e": "iOSApp/Source/ios app.entitlements",
+            "f": [
+                {
+                    "_": "com_google_google_maps/GoogleMaps.xcframework/ios-arm64/GoogleMaps.framework/Resources/GoogleMaps.bundle",
+                    "t": "e"
+                },
+                "iOSApp/Source/nested"
+            ],
             "r": [
                 "iOSApp/Source/AltIcons/AltIcon-60.alticon/AltIcon-60@2x.png",
                 "iOSApp/Source/AltIcons/AltIcon-60.alticon/AltIcon-60@3x.png",
@@ -10707,15 +10690,6 @@
                 "iOSApp/Source/Model.xcdatamodeld/Model2.xcdatamodel/contents",
                 "iOSApp/Source/en.lproj/Localizable.strings",
                 "iOSApp/Source/es.lproj/Localizable.strings",
-                {
-                    "_": "com_google_google_maps/GoogleMaps.xcframework/ios-arm64/GoogleMaps.framework/Resources/GoogleMaps.bundle",
-                    "f": true,
-                    "t": "e"
-                },
-                {
-                    "_": "iOSApp/Source/nested",
-                    "f": true
-                },
                 "iOSApp/Source/en.lproj/unprocessed.json",
                 "iOSApp/Source/es.lproj/unprocessed.json"
             ],
@@ -10912,6 +10886,13 @@
         ],
         "i": {
             "e": "iOSApp/Source/ios app.entitlements",
+            "f": [
+                {
+                    "_": "com_google_google_maps/GoogleMaps.xcframework/ios-arm64_x86_64-simulator/GoogleMaps.framework/Resources/GoogleMaps.bundle",
+                    "t": "e"
+                },
+                "iOSApp/Source/nested"
+            ],
             "r": [
                 "iOSApp/Source/PreviewContent/Preview Assets.xcassets",
                 "iOSApp/Source/AltIcons/AltIcon-60.alticon/AltIcon-60@2x.png",
@@ -10922,15 +10903,6 @@
                 "iOSApp/Source/Launch.storyboard",
                 "iOSApp/Source/en.lproj/Localizable.strings",
                 "iOSApp/Source/es.lproj/Localizable.strings",
-                {
-                    "_": "com_google_google_maps/GoogleMaps.xcframework/ios-arm64_x86_64-simulator/GoogleMaps.framework/Resources/GoogleMaps.bundle",
-                    "f": true,
-                    "t": "e"
-                },
-                {
-                    "_": "iOSApp/Source/nested",
-                    "f": true
-                },
                 "iOSApp/Source/en.lproj/unprocessed.json",
                 "iOSApp/Source/es.lproj/unprocessed.json"
             ],
@@ -11126,6 +11098,13 @@
         ],
         "i": {
             "e": "iOSApp/Source/ios app.entitlements",
+            "f": [
+                {
+                    "_": "com_google_google_maps/GoogleMaps.xcframework/ios-arm64_x86_64-simulator/GoogleMaps.framework/Resources/GoogleMaps.bundle",
+                    "t": "e"
+                },
+                "iOSApp/Source/nested"
+            ],
             "r": [
                 "iOSApp/Source/AltIcons/AltIcon-60.alticon/AltIcon-60@2x.png",
                 "iOSApp/Source/AltIcons/AltIcon-60.alticon/AltIcon-60@3x.png",
@@ -11135,15 +11114,6 @@
                 "iOSApp/Source/Launch.storyboard",
                 "iOSApp/Source/en.lproj/Localizable.strings",
                 "iOSApp/Source/es.lproj/Localizable.strings",
-                {
-                    "_": "com_google_google_maps/GoogleMaps.xcframework/ios-arm64_x86_64-simulator/GoogleMaps.framework/Resources/GoogleMaps.bundle",
-                    "f": true,
-                    "t": "e"
-                },
-                {
-                    "_": "iOSApp/Source/nested",
-                    "f": true
-                },
                 "iOSApp/Source/en.lproj/unprocessed.json",
                 "iOSApp/Source/es.lproj/unprocessed.json"
             ],
@@ -11308,10 +11278,9 @@
         ],
         "h": "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-dbg-STABLE-13",
         "i": {
-            "r": [
+            "f": [
                 {
                     "_": "examples_ios_app_external/bundles/Utils.bundle",
-                    "f": true,
                     "t": "e"
                 }
             ],
@@ -11474,10 +11443,9 @@
         ],
         "h": "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-opt-STABLE-15",
         "i": {
-            "r": [
+            "f": [
                 {
                     "_": "examples_ios_app_external/bundles/Utils.bundle",
-                    "f": true,
                     "t": "e"
                 }
             ],
@@ -11673,13 +11641,14 @@
         ],
         "h": "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-dbg-STABLE-13",
         "i": {
-            "r": [
-                "iOSApp/Resources/ExampleResources/Assets.xcassets",
+            "f": [
                 {
                     "_": "examples_ios_app_external/bundles/Utils.bundle",
-                    "f": true,
                     "t": "e"
                 }
+            ],
+            "r": [
+                "iOSApp/Resources/ExampleResources/Assets.xcassets"
             ],
             "s": [
                 "iOSApp/Test/SwiftUnitTests/SwiftUnitTests.swift"
@@ -11875,13 +11844,14 @@
         ],
         "h": "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-opt-STABLE-15",
         "i": {
-            "r": [
-                "iOSApp/Resources/ExampleResources/Assets.xcassets",
+            "f": [
                 {
                     "_": "examples_ios_app_external/bundles/Utils.bundle",
-                    "f": true,
                     "t": "e"
                 }
+            ],
+            "r": [
+                "iOSApp/Resources/ExampleResources/Assets.xcassets"
             ],
             "s": [
                 "iOSApp/Test/SwiftUnitTests/SwiftUnitTests.swift"

--- a/test/internal/target/process_top_level_properties_tests.bzl
+++ b/test/internal/target/process_top_level_properties_tests.bzl
@@ -30,7 +30,6 @@ def _process_top_level_properties_test_impl(ctx):
         struct(
             path = ctx.attr.expected_bundle_path,
             type = "g",
-            is_folder = False,
         ) if ctx.attr.expected_bundle_path else None,
         properties.bundle_file_path,
         "bundle_file_path",

--- a/tools/generator/src/DTO/FilePath.swift
+++ b/tools/generator/src/DTO/FilePath.swift
@@ -30,16 +30,16 @@ struct FilePath: Hashable, Decodable {
     enum CodingKeys: String, CodingKey {
         case path = "_"
         case type = "t"
-        case isFolder = "f"
     }
 
     init(from decoder: Decoder) throws {
+        isFolder = false
+        forceGroupCreation = false
+
         // A plain string is interpreted as a source file
         if let path = try? decoder.singleValueContainer().decode(Path.self) {
             type = .project
             self.path = path
-            isFolder = false
-            forceGroupCreation = false
             return
         }
 
@@ -47,9 +47,6 @@ struct FilePath: Hashable, Decodable {
         path = try container.decode(Path.self, forKey: .path)
         type = try container.decodeIfPresent(PathType.self, forKey: .type)
             ?? .project
-        isFolder = try container.decodeIfPresent(Bool.self, forKey: .isFolder)
-            ?? false
-        forceGroupCreation = isFolder
     }
 }
 

--- a/tools/generator/src/DTO/Inputs.swift
+++ b/tools/generator/src/DTO/Inputs.swift
@@ -69,8 +69,10 @@ extension Inputs: Decodable {
         nonArcSrcs = try container.decodeFilePaths(.nonArcSrcs)
         hdrs = try container.decodeFilePaths(.hdrs)
         pch = try container.decodeIfPresent(FilePath.self, forKey: .pch)
-        resources = try container.decodeFilePaths(.resources)
-            .union(try container.decodeFolderFilePaths(.folderResources))
+        resources = try Set(
+            container.decodeFilePaths(.resources) +
+            container.decodeFolderFilePaths(.folderResources)
+        )
         entitlements = try container
             .decodeIfPresent(FilePath.self, forKey: .entitlements)
     }
@@ -85,12 +87,12 @@ private extension KeyedDecodingContainer where K == Inputs.CodingKeys {
         return try decodeIfPresent(Set<FilePath>.self, forKey: key) ?? []
     }
 
-    func decodeFolderFilePaths(_ key: K) throws -> Set<FilePath> {
+    func decodeFolderFilePaths(_ key: K) throws -> [FilePath] {
         var folders = try decodeIfPresent([FilePath].self, forKey: key) ?? []
         for i in folders.indices {
             folders[i].isFolder = true
             folders[i].forceGroupCreation = true
         }
-        return Set(folders)
+        return folders
     }
 }

--- a/tools/generator/src/DTO/Project.swift
+++ b/tools/generator/src/DTO/Project.swift
@@ -104,8 +104,10 @@ extension Project: Decodable {
         envs = try container
             .decodeIfPresent([TargetID: [String: String]].self, forKey: .envs)
             ?? [:]
-        extraFiles = try container.decodeFilePaths(.extraFiles)
-            .union(try container.decodeFolderFilePaths(.extraFolders))
+        extraFiles = try Set(
+            container.decodeFilePaths(.extraFiles) +
+            container.decodeFolderFilePaths(.extraFolders)
+        )
         schemeAutogenerationMode = try container
             .decodeIfPresent(
                 SchemeAutogenerationMode.self,
@@ -146,16 +148,16 @@ extension Project.Options: Decodable {
 }
 
 private extension KeyedDecodingContainer where K == Project.CodingKeys {
-    func decodeFilePaths(_ key: K) throws -> Set<FilePath> {
-        return try decodeIfPresent(Set<FilePath>.self, forKey: key) ?? []
+    func decodeFilePaths(_ key: K) throws -> [FilePath] {
+        return try decodeIfPresent([FilePath].self, forKey: key) ?? []
     }
 
-    func decodeFolderFilePaths(_ key: K) throws -> Set<FilePath> {
+    func decodeFolderFilePaths(_ key: K) throws -> [FilePath] {
         var folders = try decodeIfPresent([FilePath].self, forKey: key) ?? []
         for i in folders.indices {
             folders[i].isFolder = true
             folders[i].forceGroupCreation = true
         }
-        return Set(folders)
+        return folders
     }
 }

--- a/xcodeproj/internal/files.bzl
+++ b/xcodeproj/internal/files.bzl
@@ -2,23 +2,17 @@
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
 
-def file_path(
-        file,
-        *,
-        path = None,
-        is_folder = False):
+def file_path(file, *, path = None):
     """Converts a `File` into a `FilePath` Swift DTO value.
 
     Args:
         file: A `File`.
         path: A path string to use instead of `file.path`.
-        is_folder: Whether the path is to a folder.
 
     Returns:
         A `struct` containing the following fields:
 
         *   `path`: The file path.
-        *   `is_folder`: `True` if the path is a folder.
         *   `type`: Maps to `FilePath.FileType`:
             *   "p" for `.project`
             *   "e" for `.external`
@@ -32,16 +26,13 @@ def file_path(
     if not file.is_source:
         return generated_file_path(
             path = path,
-            is_folder = is_folder,
         )
     if file.owner.workspace_name:
         return external_file_path(
             path = path,
-            is_folder = is_folder,
         )
     return project_file_path(
         path = path,
-        is_folder = is_folder,
     )
 
 def build_setting_path(
@@ -192,39 +183,26 @@ def normalized_file_path(file, *, folder_type_extensions):
 
     return file_path(file)
 
-def raw_file_path(
-        type,
-        *,
-        path,
-        is_folder):
+def raw_file_path(type, *, path):
     return struct(
         path = path,
         type = type,
-        is_folder = is_folder,
     )
 
-def external_file_path(
-        path,
-        *,
-        is_folder = False):
+def external_file_path(path):
     return raw_file_path(
         # Type: "e" == `.external`
         type = "e",
         # Path, removing `external/` prefix
         path = path[9:],
-        is_folder = is_folder,
     )
 
-def generated_file_path(
-        path,
-        *,
-        is_folder = False):
+def generated_file_path(path):
     return raw_file_path(
         # Type: "g" == `.generated`
         type = "g",
         # Path, removing `bazel-out/` prefix
         path = path[10:],
-        is_folder = is_folder,
     )
 
 def is_external_path(path):
@@ -239,15 +217,11 @@ def is_generated_file_path(fp):
 def is_relative_path(path):
     return not path.startswith("/") and not path.startswith("__BAZEL_")
 
-def project_file_path(
-        path,
-        *,
-        is_folder = False):
+def project_file_path(path):
     return raw_file_path(
         # Type: "p" == `.project`
         type = "p",
         path = path,
-        is_folder = is_folder,
     )
 
 # TODO: Refactor all of file_path stuff to a module
@@ -273,9 +247,6 @@ def file_path_to_dto(file_path):
         return None
 
     ret = {}
-
-    if file_path.is_folder:
-        ret["f"] = True
 
     if file_path.type != "p":
         ret["t"] = file_path.type

--- a/xcodeproj/internal/input_files.bzl
+++ b/xcodeproj/internal/input_files.bzl
@@ -355,6 +355,7 @@ def _collect_input_files(
     label = target.label
 
     resources = None
+    folder_resources = None
     resource_bundles = None
     resource_bundle_dependencies = None
     xccurrentversions = None
@@ -408,6 +409,8 @@ def _collect_input_files(
             resource_bundle_dependencies = resources_result.dependencies
         if resources_result.resources:
             resources = depset(resources_result.resources)
+        if resources_result.folder_resources:
+            folder_resources = depset(resources_result.folder_resources)
     else:
         resource_bundle_labels = depset(
             transitive = [
@@ -678,6 +681,7 @@ def _collect_input_files(
         has_c_sources = bool(c_srcs),
         has_cxx_sources = bool(cxx_srcs),
         resources = resources,
+        folder_resources = folder_resources,
         resource_bundles = depset(
             resource_bundles,
             transitive = [
@@ -761,6 +765,7 @@ def _from_resource_bundle(bundle):
         has_c_sources = False,
         has_cxx_sources = False,
         resources = depset(bundle.resources),
+        folder_resources = depset(bundle.folder_resources),
         resource_bundles = depset(),
         resource_bundle_dependencies = bundle.dependencies,
         entitlements = None,
@@ -837,6 +842,7 @@ def _merge_input_files(*, transitive_infos, extra_generated = None):
         has_c_sources = False,
         has_cxx_sources = False,
         resources = None,
+        folder_resources = None,
         resource_bundles = depset(
             transitive = [
                 info.inputs.resource_bundles

--- a/xcodeproj/internal/xcode_targets.bzl
+++ b/xcodeproj/internal/xcode_targets.bzl
@@ -191,6 +191,7 @@ def _to_xcode_target_inputs(inputs):
         has_c_sources = inputs.has_c_sources,
         has_cxx_sources = inputs.has_cxx_sources,
         resources = inputs.resources,
+        folder_resources = inputs.folder_resources,
         resource_bundle_dependencies = inputs.resource_bundle_dependencies,
         generated = inputs.generated,
         indexstores = inputs.indexstores,
@@ -332,6 +333,7 @@ def _merge_xcode_target_inputs(*, src, dest):
         has_c_sources = src.has_c_sources,
         has_cxx_sources = src.has_cxx_sources,
         resources = dest.resources,
+        folder_resources = dest.folder_resources,
         resource_bundle_dependencies = dest.resource_bundle_dependencies,
         generated = dest.generated,
         indexstores = dest.indexstores,
@@ -779,6 +781,13 @@ def _inputs_to_dto(inputs):
             ret,
             "r",
             [file_path_to_dto(fp) for fp in inputs.resources.to_list()],
+        )
+
+    if inputs.folder_resources:
+        set_if_true(
+            ret,
+            "f",
+            [file_path_to_dto(fp) for fp in inputs.folder_resources.to_list()],
         )
 
     return ret


### PR DESCRIPTION
Instead we send over folder file paths in their own attributes, and apply `isFolder` in `generator`.

This is progress towards being able to remove the `file_path` construct on the Starlark side entirely.