### PR TITLE
Improve error message when decoding fails

### DIFF
--- a/tools/generator/src/Generator/Main.swift
+++ b/tools/generator/src/Generator/Main.swift
@@ -136,7 +136,7 @@ ERROR: build_mode wasn't one of the supported values: xcode, bazel
             } catch let error as DecodingError {
                 // Return a more detailed error message
                 throw PreconditionError(message: """
-While decoding "\(path)", encountered an error:
+Error decoding "\(path)":
 \(error.message)
 """)
             }

--- a/tools/generator/src/Generator/Main.swift
+++ b/tools/generator/src/Generator/Main.swift
@@ -135,7 +135,10 @@ ERROR: build_mode wasn't one of the supported values: xcode, bazel
                 return try decoder.decode(type, from: path.read())
             } catch let error as DecodingError {
                 // Return a more detailed error message
-                throw PreconditionError(message: error.message)
+                throw PreconditionError(message: """
+While decoding "\(path)", encountered an error:
+\(error.message)
+""")
             }
         }.value
     }


### PR DESCRIPTION
New error looks like this:

```
ERROR: Internal precondition failure:
Error decoding "bazel-out/darwin_x86_64-dbg-ST-18efdd23c365/bin/external/rules_xcodeproj_generated/generator/generator_xccurrentversions":
At codingPath []: The given data was not valid JSON.
Please file a bug report at https://github.com/MobileNativeFoundation/rules_xcodeproj/issues/new?template=bug.md
```