### PR TITLE
Remove `contains{External,Generated}Files()`

### DIFF
--- a/tools/generator/src/Generator/CreateFilesAndGroups.swift
+++ b/tools/generator/src/Generator/CreateFilesAndGroups.swift
@@ -62,7 +62,9 @@ extension Generator {
     ) throws -> (
         files: [FilePath: File],
         rootElements: [PBXFileElement],
-        resolvedRepositories: [(Path, Path)]
+        resolvedRepositories: [(Path, Path)],
+        usesExternalFileList: Bool,
+        usesGeneratedFileList: Bool
     ) {
         var fileReferences: [FilePath: PBXFileReference] = [:]
         var normalGroups: [FilePath: PBXGroup] = [:]
@@ -553,18 +555,22 @@ extension Generator {
         let generatedPaths = generatedFilePaths
             .map { FilePathResolver.resolveGenerated($0.path) }
 
-        func addXCFileList(_ path: Path, paths: [String]) {
+        func addXCFileList(_ path: Path, paths: [String]) -> Bool {
             guard !paths.isEmpty else {
-                return
+                return false
             }
 
             files[.internal(path)] = .nonReferencedContent(
                 Set(paths.map { "\($0)\n" }).sorted().joined()
             )
+
+            return true
         }
 
-        addXCFileList(externalFileListPath, paths: externalPaths)
-        addXCFileList(generatedFileListPath, paths: generatedPaths)
+        let usesExternalFileList =
+            addXCFileList(externalFileListPath, paths: externalPaths)
+        let usesGeneratedFileList =
+            addXCFileList(generatedFileListPath, paths: generatedPaths)
 
         // Handle special groups
 
@@ -592,7 +598,9 @@ extension Generator {
         return (
             files,
             rootElements,
-            resolvedRepositories
+            resolvedRepositories,
+            usesExternalFileList,
+            usesGeneratedFileList
         )
     }
 

--- a/tools/generator/src/Generator/Environment.swift
+++ b/tools/generator/src/Generator/Environment.swift
@@ -36,7 +36,9 @@ struct Environment {
     ) throws -> (
         files: [FilePath: File],
         rootElements: [PBXFileElement],
-        resolvedRepositories: [(Path, Path)]
+        resolvedRepositories: [(Path, Path)],
+        usesExternalFileList: Bool,
+        usesGeneratedFileList: Bool
     )
 
     let setAdditionalProjectConfiguration: (
@@ -67,7 +69,8 @@ struct Environment {
         _ xcodeConfigurations: Set<String>,
         _ defaultXcodeConfiguration: String,
         _ indexImport: String,
-        _ files: [FilePath: File],
+        _ usesExternalFileList: Bool,
+        _ usesGeneratedFileList: Bool,
         _ bazelConfig: String,
         _ generatorLabel: BazelLabel,
         _ preBuildScript: String?,

--- a/tools/generator/src/Generator/Generator.swift
+++ b/tools/generator/src/Generator/Generator.swift
@@ -67,7 +67,9 @@ class Generator {
         async let (
             files,
             rootElements,
-            resolvedRepositories
+            resolvedRepositories,
+            usesExternalFileList,
+            usesGeneratedFileList
         ) = Task {
             try environment.createFilesAndGroups(
                 pbxProj,
@@ -125,7 +127,8 @@ class Generator {
                 project.xcodeConfigurations,
                 project.defaultXcodeConfiguration,
                 project.indexImport,
-                files,
+                usesExternalFileList,
+                usesGeneratedFileList,
                 project.bazelConfig,
                 project.generatorLabel,
                 project.preBuildScript,


### PR DESCRIPTION
We know from earlier if we are using the file lists. This also makes the logic tied, in case we ever change the logic around when to generate the file lists (like maybe not doing so in BwB mode).