### PR TITLE
Verify that the requested target ids were valid

### DIFF
--- a/examples/cc/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -821,6 +821,7 @@
 				INDEX_IMPORT = "fixture-index-import-path";
 				SUPPORTED_PLATFORMS = "$(INDEXING_SUPPORTED_PLATFORMS__$(INDEX_ENABLE_BUILD_ARENA))";
 				SUPPORTS_MACCATALYST = YES;
+				TARGET_IDS_FILE = "fixture-target-ids-file";
 				TARGET_NAME = BazelDependencies;
 			};
 			name = Debug;

--- a/examples/cc/test/fixtures/bwb_project_spec.json
+++ b/examples/cc/test/fixtures/bwb_project_spec.json
@@ -1,6 +1,7 @@
 {
     "B": "rules_xcodeproj",
     "R": "@//test/fixtures:xcodeproj_bwb",
+    "T": "fixture-target-ids-file",
     "b": "$HOMEWBREW_BIN/bazel",
     "e": [
         {

--- a/examples/cc/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/cc/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -883,6 +883,7 @@
 				INDEX_IMPORT = "fixture-index-import-path";
 				SUPPORTED_PLATFORMS = "$(INDEXING_SUPPORTED_PLATFORMS__$(INDEX_ENABLE_BUILD_ARENA))";
 				SUPPORTS_MACCATALYST = YES;
+				TARGET_IDS_FILE = "fixture-target-ids-file";
 				TARGET_NAME = BazelDependencies;
 			};
 			name = Debug;

--- a/examples/cc/test/fixtures/bwx_project_spec.json
+++ b/examples/cc/test/fixtures/bwx_project_spec.json
@@ -1,6 +1,7 @@
 {
     "B": "rules_xcodeproj",
     "R": "@//test/fixtures:xcodeproj_bwx",
+    "T": "fixture-target-ids-file",
     "b": "$HOMEWBREW_BIN/bazel",
     "e": [
         {

--- a/examples/integration/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -11029,6 +11029,7 @@
 				INDEX_IMPORT = "fixture-index-import-path";
 				SUPPORTED_PLATFORMS = "$(INDEXING_SUPPORTED_PLATFORMS__$(INDEX_ENABLE_BUILD_ARENA))";
 				SUPPORTS_MACCATALYST = YES;
+				TARGET_IDS_FILE = "fixture-target-ids-file";
 				TARGET_NAME = BazelDependencies;
 			};
 			name = Debug;
@@ -13069,6 +13070,7 @@
 				INDEX_IMPORT = "fixture-index-import-path";
 				SUPPORTED_PLATFORMS = "$(INDEXING_SUPPORTED_PLATFORMS__$(INDEX_ENABLE_BUILD_ARENA))";
 				SUPPORTS_MACCATALYST = YES;
+				TARGET_IDS_FILE = "fixture-target-ids-file";
 				TARGET_NAME = BazelDependencies;
 			};
 			name = AppStore;

--- a/examples/integration/test/fixtures/bwb_project_spec.json
+++ b/examples/integration/test/fixtures/bwb_project_spec.json
@@ -97,6 +97,7 @@
         "iOSApp/Resources/OnlyStructuredResources/Nested"
     ],
     "R": "@//test/fixtures:xcodeproj_bwb",
+    "T": "fixture-target-ids-file",
     "a": [
         "//iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTests.__internal__.__test_bundle applebin_ios-ios_x86_64-dbg-STABLE-13",
         [

--- a/examples/integration/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -10470,6 +10470,7 @@
 				INDEX_IMPORT = "fixture-index-import-path";
 				SUPPORTED_PLATFORMS = "$(INDEXING_SUPPORTED_PLATFORMS__$(INDEX_ENABLE_BUILD_ARENA))";
 				SUPPORTS_MACCATALYST = YES;
+				TARGET_IDS_FILE = "fixture-target-ids-file";
 				TARGET_NAME = BazelDependencies;
 			};
 			name = AppStore;
@@ -11635,6 +11636,7 @@
 				INDEX_IMPORT = "fixture-index-import-path";
 				SUPPORTED_PLATFORMS = "$(INDEXING_SUPPORTED_PLATFORMS__$(INDEX_ENABLE_BUILD_ARENA))";
 				SUPPORTS_MACCATALYST = YES;
+				TARGET_IDS_FILE = "fixture-target-ids-file";
 				TARGET_NAME = BazelDependencies;
 			};
 			name = Debug;

--- a/examples/integration/test/fixtures/bwx_project_spec.json
+++ b/examples/integration/test/fixtures/bwx_project_spec.json
@@ -72,6 +72,7 @@
         }
     ],
     "R": "@//test/fixtures:xcodeproj_bwx",
+    "T": "fixture-target-ids-file",
     "a": [
         "//iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTests.__internal__.__test_bundle applebin_ios-ios_x86_64-dbg-STABLE-13",
         [

--- a/examples/rules_ios/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/rules_ios/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -3062,6 +3062,7 @@
 				INDEX_IMPORT = "fixture-index-import-path";
 				SUPPORTED_PLATFORMS = "$(INDEXING_SUPPORTED_PLATFORMS__$(INDEX_ENABLE_BUILD_ARENA))";
 				SUPPORTS_MACCATALYST = YES;
+				TARGET_IDS_FILE = "fixture-target-ids-file";
 				TARGET_NAME = BazelDependencies;
 			};
 			name = Debug;

--- a/examples/rules_ios/test/fixtures/bwb_project_spec.json
+++ b/examples/rules_ios/test/fixtures/bwb_project_spec.json
@@ -9,6 +9,7 @@
         {}
     ],
     "R": "@//test/fixtures:xcodeproj_bwb",
+    "T": "fixture-target-ids-file",
     "a": [
         "//iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTests.__internal__.__test_bundle applebin_ios-ios_x86_64-dbg-STABLE-3",
         [

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -682,6 +682,7 @@
 				INDEX_IMPORT = "fixture-index-import-path";
 				SUPPORTED_PLATFORMS = "$(INDEXING_SUPPORTED_PLATFORMS__$(INDEX_ENABLE_BUILD_ARENA))";
 				SUPPORTS_MACCATALYST = YES;
+				TARGET_IDS_FILE = "fixture-target-ids-file";
 				TARGET_NAME = BazelDependencies;
 			};
 			name = Debug;

--- a/examples/sanitizers/test/fixtures/bwb_project_spec.json
+++ b/examples/sanitizers/test/fixtures/bwb_project_spec.json
@@ -1,6 +1,7 @@
 {
     "B": "rules_xcodeproj",
     "R": "@//test/fixtures:xcodeproj_bwb",
+    "T": "fixture-target-ids-file",
     "b": "$HOMEWBREW_BIN/bazel",
     "e": [
         "AddressSanitizerApp/BUILD",

--- a/examples/sanitizers/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/sanitizers/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -602,6 +602,7 @@
 				INDEX_IMPORT = "fixture-index-import-path";
 				SUPPORTED_PLATFORMS = "$(INDEXING_SUPPORTED_PLATFORMS__$(INDEX_ENABLE_BUILD_ARENA))";
 				SUPPORTS_MACCATALYST = YES;
+				TARGET_IDS_FILE = "fixture-target-ids-file";
 				TARGET_NAME = BazelDependencies;
 			};
 			name = Debug;

--- a/examples/sanitizers/test/fixtures/bwx_project_spec.json
+++ b/examples/sanitizers/test/fixtures/bwx_project_spec.json
@@ -1,6 +1,7 @@
 {
     "B": "rules_xcodeproj",
     "R": "@//test/fixtures:xcodeproj_bwx",
+    "T": "fixture-target-ids-file",
     "b": "$HOMEWBREW_BIN/bazel",
     "e": [
         "AddressSanitizerApp/BUILD",

--- a/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
@@ -3271,6 +3271,7 @@
 				INDEX_IMPORT = "fixture-index-import-path";
 				SUPPORTED_PLATFORMS = "$(INDEXING_SUPPORTED_PLATFORMS__$(INDEX_ENABLE_BUILD_ARENA))";
 				SUPPORTS_MACCATALYST = YES;
+				TARGET_IDS_FILE = "fixture-target-ids-file";
 				TARGET_NAME = BazelDependencies;
 			};
 			name = Release;
@@ -3517,6 +3518,7 @@
 				INDEX_IMPORT = "fixture-index-import-path";
 				SUPPORTED_PLATFORMS = "$(INDEXING_SUPPORTED_PLATFORMS__$(INDEX_ENABLE_BUILD_ARENA))";
 				SUPPORTS_MACCATALYST = YES;
+				TARGET_IDS_FILE = "fixture-target-ids-file";
 				TARGET_NAME = BazelDependencies;
 			};
 			name = Debug;
@@ -4377,6 +4379,7 @@
 				INDEX_IMPORT = "fixture-index-import-path";
 				SUPPORTED_PLATFORMS = "$(INDEXING_SUPPORTED_PLATFORMS__$(INDEX_ENABLE_BUILD_ARENA))";
 				SUPPORTS_MACCATALYST = YES;
+				TARGET_IDS_FILE = "fixture-target-ids-file";
 				TARGET_NAME = BazelDependencies;
 			};
 			name = Profile;

--- a/test/fixtures/generator/bwb_project_spec.json
+++ b/test/fixtures/generator/bwb_project_spec.json
@@ -7,6 +7,7 @@
         {}
     ],
     "R": "@//test/fixtures/generator:xcodeproj_bwb",
+    "T": "fixture-target-ids-file",
     "b": "$HOMEWBREW_BIN/bazel",
     "e": [
         {

--- a/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
@@ -3530,6 +3530,7 @@
 				INDEX_IMPORT = "fixture-index-import-path";
 				SUPPORTED_PLATFORMS = "$(INDEXING_SUPPORTED_PLATFORMS__$(INDEX_ENABLE_BUILD_ARENA))";
 				SUPPORTS_MACCATALYST = YES;
+				TARGET_IDS_FILE = "fixture-target-ids-file";
 				TARGET_NAME = BazelDependencies;
 			};
 			name = Debug;
@@ -4189,6 +4190,7 @@
 				INDEX_IMPORT = "fixture-index-import-path";
 				SUPPORTED_PLATFORMS = "$(INDEXING_SUPPORTED_PLATFORMS__$(INDEX_ENABLE_BUILD_ARENA))";
 				SUPPORTS_MACCATALYST = YES;
+				TARGET_IDS_FILE = "fixture-target-ids-file";
 				TARGET_NAME = BazelDependencies;
 			};
 			name = Release;
@@ -4356,6 +4358,7 @@
 				INDEX_IMPORT = "fixture-index-import-path";
 				SUPPORTED_PLATFORMS = "$(INDEXING_SUPPORTED_PLATFORMS__$(INDEX_ENABLE_BUILD_ARENA))";
 				SUPPORTS_MACCATALYST = YES;
+				TARGET_IDS_FILE = "fixture-target-ids-file";
 				TARGET_NAME = BazelDependencies;
 			};
 			name = Profile;

--- a/test/fixtures/generator/bwx_project_spec.json
+++ b/test/fixtures/generator/bwx_project_spec.json
@@ -7,6 +7,7 @@
         {}
     ],
     "R": "@//test/fixtures/generator:xcodeproj_bwx",
+    "T": "fixture-target-ids-file",
     "b": "$HOMEWBREW_BIN/bazel",
     "e": [
         {

--- a/tools/generator/src/DTO/Project.swift
+++ b/tools/generator/src/DTO/Project.swift
@@ -39,6 +39,7 @@ struct Project: Equatable {
     let extraFiles: Set<FilePath>
     let schemeAutogenerationMode: SchemeAutogenerationMode
     var customXcodeSchemes: [XcodeScheme] = []
+    let targetIdsFile: String
     let indexImport: String
     let preBuildScript: String?
     let postBuildScript: String?
@@ -63,6 +64,7 @@ extension Project: Decodable {
         case extraFiles = "e"
         case extraFolders = "F"
         case schemeAutogenerationMode = "s"
+        case targetIdsFile = "T"
         case indexImport = "i"
         case preBuildScript = "p"
         case postBuildScript = "P"
@@ -111,6 +113,8 @@ extension Project: Decodable {
                 SchemeAutogenerationMode.self,
                 forKey: .schemeAutogenerationMode
             ) ?? .all
+        targetIdsFile = try container
+            .decode(String.self, forKey: .targetIdsFile)
         indexImport = try container
             .decode(String.self, forKey: .indexImport)
         preBuildScript = try container

--- a/tools/generator/src/Generator/AddBazelDependenciesTarget.swift
+++ b/tools/generator/src/Generator/AddBazelDependenciesTarget.swift
@@ -9,6 +9,7 @@ extension Generator {
         minimumXcodeVersion: SemanticVersion,
         xcodeConfigurations: Set<String>,
         defaultXcodeConfiguration: String,
+        targetIdsFile: String,
         indexImport: String,
         usesExternalFileList: Bool,
         usesGeneratedFileList: Bool,
@@ -56,6 +57,7 @@ $(INDEXING_SUPPORTED_PLATFORMS__NO)
 $(INDEXING_SUPPORTED_PLATFORMS__$(INDEX_ENABLE_BUILD_ARENA))
 """,
             "SUPPORTS_MACCATALYST": true,
+            "TARGET_IDS_FILE": targetIdsFile,
             "TARGET_NAME": "BazelDependencies",
         ]
 

--- a/tools/generator/src/Generator/Environment.swift
+++ b/tools/generator/src/Generator/Environment.swift
@@ -68,6 +68,7 @@ struct Environment {
         _ minimumXcodeVersion: SemanticVersion,
         _ xcodeConfigurations: Set<String>,
         _ defaultXcodeConfiguration: String,
+        _ target_ids_file: String,
         _ indexImport: String,
         _ usesExternalFileList: Bool,
         _ usesGeneratedFileList: Bool,

--- a/tools/generator/src/Generator/Generator.swift
+++ b/tools/generator/src/Generator/Generator.swift
@@ -126,6 +126,7 @@ class Generator {
                 project.minimumXcodeVersion,
                 project.xcodeConfigurations,
                 project.defaultXcodeConfiguration,
+                project.targetIdsFile,
                 project.indexImport,
                 usesExternalFileList,
                 usesGeneratedFileList,

--- a/tools/generator/test/Fixtures.swift
+++ b/tools/generator/test/Fixtures.swift
@@ -43,6 +43,7 @@ enum Fixtures {
         ],
         schemeAutogenerationMode: .auto,
         customXcodeSchemes: [],
+        targetIdsFile: "/tmp/target_ids",
         indexImport: "/tmp/index-import",
         preBuildScript: "./pre-build.sh",
         postBuildScript: "./post-build.sh"

--- a/tools/generator/test/GeneratorTests.swift
+++ b/tools/generator/test/GeneratorTests.swift
@@ -67,6 +67,7 @@ final class GeneratorTests: XCTestCase {
             extraFiles: [],
             schemeAutogenerationMode: .auto,
             customXcodeSchemes: [],
+            targetIdsFile: "/tmp/target_ids",
             indexImport: "/tmp/index-import",
             preBuildScript: "./pre-build.sh",
             postBuildScript: "./post-build.sh"
@@ -454,6 +455,7 @@ final class GeneratorTests: XCTestCase {
             let minimumXcodeVersion: SemanticVersion
             let xcodeConfigurations: Set<String>
             let defaultXcodeConfiguration: String
+            let targetIdsFile: String
             let indexImport: String
             let usesExternalFileList: Bool
             let usesGeneratedFileList: Bool
@@ -472,6 +474,7 @@ final class GeneratorTests: XCTestCase {
             minimumXcodeVersion: SemanticVersion,
             xcodeConfigurations: Set<String>,
             defaultXcodeConfiguration: String,
+            targetIdsFile: String,
             indexImport: String,
             usesExternalFileList: Bool,
             usesGeneratedFileList: Bool,
@@ -487,6 +490,7 @@ final class GeneratorTests: XCTestCase {
                 minimumXcodeVersion: minimumXcodeVersion,
                 xcodeConfigurations: xcodeConfigurations,
                 defaultXcodeConfiguration: defaultXcodeConfiguration,
+                targetIdsFile: targetIdsFile,
                 indexImport: indexImport,
                 usesExternalFileList: usesExternalFileList,
                 usesGeneratedFileList: usesGeneratedFileList,
@@ -506,6 +510,7 @@ final class GeneratorTests: XCTestCase {
                 minimumXcodeVersion: project.minimumXcodeVersion,
                 xcodeConfigurations: project.xcodeConfigurations,
                 defaultXcodeConfiguration: project.defaultXcodeConfiguration,
+                targetIdsFile: project.targetIdsFile,
                 indexImport: project.indexImport,
                 usesExternalFileList: true,
                 usesGeneratedFileList: true,

--- a/xcodeproj/internal/bazel_integration_files/generate_bazel_dependencies.sh
+++ b/xcodeproj/internal/bazel_integration_files/generate_bazel_dependencies.sh
@@ -65,9 +65,11 @@ else
         && printf '\0' )
 
   raw_labels=()
-  output_groups=()
+  raw_target_ids=()
+  output_groups=("target_ids_list")
   for (( i=0; i<${#labels_and_output_groups[@]}; i+=2 )); do
     raw_labels+=("${labels_and_output_groups[i]}")
+    raw_target_ids+=("${labels_and_output_groups[i+1]#* }")
     output_groups+=("${labels_and_output_groups[i+1]}")
   done
 
@@ -80,6 +82,11 @@ else
     while IFS= read -r -d '' label; do
       labels+=("$label")
     done < <(printf "%s\0" "${raw_labels[@]}" | sort -uz)
+
+    target_ids=()
+    while IFS= read -r -d '' target_id; do
+      target_ids+=("$target_id")
+    done < <(printf "%s\0" "${raw_target_ids[@]}" | sort -uz)
   fi
 fi
 

--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -988,7 +988,8 @@ def _write_spec(
         extra_files,
         extra_folders,
         infos,
-        minimum_xcode_version):
+        minimum_xcode_version,
+        target_ids_list):
     # `target_hosts`
     hosted_targets = depset(
         transitive = [info.hosted_targets for info in infos],
@@ -1004,6 +1005,9 @@ def _write_spec(
     spec_dto = {
         "B": config,
         "g": str(ctx.label),
+        "T": "fixture-target-ids-file" if is_fixture else build_setting_path(
+            file = target_ids_list,
+        ),
         "i": "fixture-index-import-path" if is_fixture else build_setting_path(
             file = ctx.executable._index_import,
         ),
@@ -1234,6 +1238,18 @@ echo "$execution_root" > "{out_full}"
             "no-remote": "1",
             "no-sandbox": "1",
         },
+    )
+
+    return output
+
+def _write_target_ids_list(*, ctx, target_dtos):
+    output = ctx.actions.declare_file(
+        "{}_target_ids".format(ctx.attr.name),
+    )
+
+    ctx.actions.write(
+        output,
+        "".join([id + "\n" for id in sorted(target_dtos.keys())]),
     )
 
     return output
@@ -1546,6 +1562,10 @@ configurations: {}""".format(", ".join(xcode_configurations)))
         replacement_labels_by_label = replacement_labels_by_label,
         inputs = inputs,
     )
+    target_ids_list = _write_target_ids_list(
+        ctx = ctx,
+        target_dtos = target_dtos,
+    )
 
     extension_infoplists = [
         s
@@ -1573,6 +1593,7 @@ configurations: {}""".format(", ".join(xcode_configurations)))
         extra_folders = extra_folders,
         infos = infos,
         minimum_xcode_version = minimum_xcode_version,
+        target_ids_list = target_ids_list,
     )
     execution_root_file = _write_execution_root_file(ctx = ctx)
     xccurrentversions_file = _write_xccurrentversions(
@@ -1719,6 +1740,7 @@ done
             all_targets = depset(
                 transitive = all_targets_files,
             ),
+            target_ids_list = depset([target_ids_list]),
             **dicts.add(
                 input_files_output_groups,
                 output_files_output_groups,


### PR DESCRIPTION
Before this change, if something would cause your target ids to change, like a config change, and you didn’t regenerate your project, building with Xcode could silently do nothing on a build. Now `bazel_build.sh` can properly detect this, buy verifying that all requested target ids are known by the `xcodeproj` target.