### PR TITLE
pop to insert

### DIFF
--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -525,7 +525,7 @@ actual targets: {}
             if src_label_str in unfocused_labels:
                 unfocused_labels.pop(src_label_str, None)
             if focused_labels:
-                focused_labels.pop(src_label_str, None)
+                focused_labels.insert(src_label_str, None)
 
     unfocused_dependencies = _calculate_unfocused_dependencies(
         build_mode = build_mode,


### PR DESCRIPTION
https://github.com/MobileNativeFoundation/rules_xcodeproj/pull/1782/files originally made the focused_labels to insert the new label, but looks like it was changed to pop here : https://github.com/MobileNativeFoundation/rules_xcodeproj/pull/1834/files#diff-b1fb3508a2b896cec3f09ffc0aa4234ef6b8972d977da9c142f8e2d3b5f71d39R466 

