### PR TITLE
Fix empty `output_groups` check

### DIFF
--- a/xcodeproj/internal/bazel_integration_files/generate_bazel_dependencies.sh
+++ b/xcodeproj/internal/bazel_integration_files/generate_bazel_dependencies.sh
@@ -71,7 +71,7 @@ else
     output_groups+=("${labels_and_output_groups[i+1]}")
   done
 
-  if [ -z "${output_groups:-}" ]; then
+  if [ "${#output_groups[@]}" -eq 1 ]; then
     echo "BazelDependencies invoked without any output groups set." \
       "Exiting early."
     exit


### PR DESCRIPTION
Regressed with e4b289af0c869fbf8dfdc48f784f44d27ea268bf.

Since we now always have one element, we need to make sure it’s more than 1.