### PR TITLE
Simplify `bazel_path` resolution

### DIFF
--- a/tools/generator/src/DTO/Project.swift
+++ b/tools/generator/src/DTO/Project.swift
@@ -25,7 +25,7 @@ struct Project: Equatable {
     let options: Options
     let bazel: String
     let bazelPathEnv: String
-    let bazelReal: String
+    let bazelReal: String?
     let bazelConfig: String
     let xcodeConfigurations: Set<String>
     let defaultXcodeConfiguration: String
@@ -82,7 +82,7 @@ extension Project: Decodable {
             .decodeIfPresent(String.self, forKey: .bazelPathEnv) ??
             "/usr/bin:/bin"
         bazelReal = try container
-            .decodeIfPresent(String.self, forKey: .bazelReal) ?? ""
+            .decodeIfPresent(String.self, forKey: .bazelReal)
         bazelConfig = try container.decode(String.self, forKey: .bazelConfig)
         xcodeConfigurations = try container
             .decodeIfPresent(Set<String>.self, forKey: .xcodeConfigurations) ??

--- a/tools/generator/src/Generator/CreateProject.swift
+++ b/tools/generator/src/Generator/CreateProject.swift
@@ -75,7 +75,6 @@ extension Generator {
             "BAZEL_OUTPUT_BASE": "$(_BAZEL_OUTPUT_BASE:standardizepath)",
             "BAZEL_PATH": project.bazel,
             "BAZEL_PATH_ENV": project.bazelPathEnv,
-            "BAZEL_REAL": project.bazelReal,
             "BAZEL_WORKSPACE_ROOT": "$(SRCROOT)",
             "BUILD_DIR": """
 $(SYMROOT)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)
@@ -142,6 +141,10 @@ $(PROJECT_TEMP_DIR)/$(BAZEL_PACKAGE_BIN_DIR)/$(COMPILE_TARGET_NAME)
             "USE_HEADERMAP": false,
             "VALIDATE_WORKSPACE": false,
         ]
+
+        if let bazelReal = project.bazelReal {
+            buildSettings["BAZEL_REAL"] = bazelReal
+        }
 
         if buildMode.usesBazelModeBuildScripts {
             buildSettings.merge([

--- a/xcodeproj/internal/bazel_integration_files/bazel_build.sh
+++ b/xcodeproj/internal/bazel_integration_files/bazel_build.sh
@@ -66,15 +66,9 @@ if [[ -s "$BAZEL_INTEGRATION_DIR/xcodeproj_extra_flags.bazelrc" ]]; then
 fi
 readonly bazelrcs
 
-envs=(PATH="$BAZEL_PATH_ENV")
-
-if [[ -n "${BAZEL_REAL:-}" ]]; then
-  envs+=(BAZEL_REAL="$BAZEL_REAL")
-fi
-
 readonly bazel_cmd=(
   env
-  "${envs[@]}"
+  PATH="$BAZEL_PATH_ENV"
   "$BAZEL_PATH"
 
   # Restart bazel server if `DEVELOPER_DIR` changes to clear `developerDirCache`

--- a/xcodeproj/internal/runner.template.sh
+++ b/xcodeproj/internal/runner.template.sh
@@ -80,23 +80,15 @@ fi
 
 cd "$BUILD_WORKSPACE_DIRECTORY"
 
-# Remove bazelisk's path adjustment, so we find the `tools/wrapper`, or bazelisk
-# itself
-un_bazelisked_path=$(echo "$PATH" | perl -p -e 's|/[^:]+/bazelisk/downloads/[^:]+:||i')
-
-# Unset `BAZELISK_SKIP_WRAPPER` to allow the wrapper to be run again for our
-# commands
-unset BAZELISK_SKIP_WRAPPER
-
 # Resolve path to bazel before changing the env variable. This allows bazelisk
-# downloaded bazel to be found
-bazel_path=$(PATH="$un_bazelisked_path" which "%bazel_path%" || true)
+# downloaded bazel to be found.
+bazel_path=$(which "%bazel_path%" || true)
 
 if [[ -z "$bazel_path" ]]; then
-  echo "Failed to find \"%bazel_path%\" in \$PATH (\"$un_bazelisked_path\")." \
+  echo "Failed to find \"%bazel_path%\" in \$PATH (\"$PATH\")." \
     "Please make sure the 'bazel' attribute on %runner_label% is correct, or" \
-    "if you are filtering your \$PATH in a bazel wrapper, that the \$PATH" \
-    "includes where bazelisk is installed." >&2
+    "if you are filtering \$PATH in a bazel wrapper, that \$PATH includes" \
+    "where \"%bazel_path%\" (maybe as bazlisk) is installed." >&2
   exit 1
 fi
 


### PR DESCRIPTION
We don’t need to filter `$PATH`, because resolving to the downloaded `bazel` is fine, and will only happen if a `tools/bazel` isn’t being used (as that would be at the front of the path instead).

We don’t need to unset `BAZELISK_SKIP_WRAPPER`, because we are either resolving to `tools/bazel`, in which case it has no effect (and we probably actually want it set anyway), or we are resolving directly to bazel (in which case it has no effect), or we are resolving to bazelisk (in which case there wasn’t a wrapper anyway, so it should be set for efficiency sake).

We don't need to explicitly set `BAZEL_REAL` in `bazel_build.sh`, since we aren’t using `env -i`. And because of this, we only set `BAZEL_REAL` as a build setting if needed.