### PR TITLE
Allow {un,}focusing of non-Xcode targets

### DIFF
--- a/docs/bazel.md
+++ b/docs/bazel.md
@@ -580,10 +580,10 @@ stabilizing it.
 
 <pre>
 XcodeProjInfo(<a href="#XcodeProjInfo-args">args</a>, <a href="#XcodeProjInfo-compilation_providers">compilation_providers</a>, <a href="#XcodeProjInfo-dependencies">dependencies</a>, <a href="#XcodeProjInfo-envs">envs</a>, <a href="#XcodeProjInfo-extension_infoplists">extension_infoplists</a>, <a href="#XcodeProjInfo-hosted_targets">hosted_targets</a>,
-              <a href="#XcodeProjInfo-inputs">inputs</a>, <a href="#XcodeProjInfo-is_top_level_target">is_top_level_target</a>, <a href="#XcodeProjInfo-label">label</a>, <a href="#XcodeProjInfo-lldb_context">lldb_context</a>, <a href="#XcodeProjInfo-mergable_xcode_library_targets">mergable_xcode_library_targets</a>,
-              <a href="#XcodeProjInfo-potential_target_merges">potential_target_merges</a>, <a href="#XcodeProjInfo-outputs">outputs</a>, <a href="#XcodeProjInfo-replacement_labels">replacement_labels</a>, <a href="#XcodeProjInfo-resource_bundle_informations">resource_bundle_informations</a>,
-              <a href="#XcodeProjInfo-rule_kind">rule_kind</a>, <a href="#XcodeProjInfo-search_paths">search_paths</a>, <a href="#XcodeProjInfo-target_type">target_type</a>, <a href="#XcodeProjInfo-transitive_dependencies">transitive_dependencies</a>, <a href="#XcodeProjInfo-xcode_required_targets">xcode_required_targets</a>,
-              <a href="#XcodeProjInfo-xcode_target">xcode_target</a>, <a href="#XcodeProjInfo-xcode_targets">xcode_targets</a>)
+              <a href="#XcodeProjInfo-inputs">inputs</a>, <a href="#XcodeProjInfo-is_top_level_target">is_top_level_target</a>, <a href="#XcodeProjInfo-label">label</a>, <a href="#XcodeProjInfo-labels">labels</a>, <a href="#XcodeProjInfo-lldb_context">lldb_context</a>,
+              <a href="#XcodeProjInfo-mergable_xcode_library_targets">mergable_xcode_library_targets</a>, <a href="#XcodeProjInfo-potential_target_merges">potential_target_merges</a>, <a href="#XcodeProjInfo-outputs">outputs</a>, <a href="#XcodeProjInfo-replacement_labels">replacement_labels</a>,
+              <a href="#XcodeProjInfo-resource_bundle_informations">resource_bundle_informations</a>, <a href="#XcodeProjInfo-rule_kind">rule_kind</a>, <a href="#XcodeProjInfo-search_paths">search_paths</a>, <a href="#XcodeProjInfo-target_type">target_type</a>,
+              <a href="#XcodeProjInfo-transitive_dependencies">transitive_dependencies</a>, <a href="#XcodeProjInfo-xcode_required_targets">xcode_required_targets</a>, <a href="#XcodeProjInfo-xcode_target">xcode_target</a>, <a href="#XcodeProjInfo-xcode_targets">xcode_targets</a>)
 </pre>
 
 Provides information needed to generate an Xcode project.
@@ -607,6 +607,7 @@ stabilizing it.
 | <a id="XcodeProjInfo-inputs"></a>inputs |  A value returned from <code>input_files.collect</code>, that contains the input files for this target. It also includes the two extra fields that collect all of the generated <code>Files</code> and all of the <code>Files</code> that should be added to the Xcode project, but are not associated with any targets.    |
 | <a id="XcodeProjInfo-is_top_level_target"></a>is_top_level_target |  Whether this target is a top-level target. Top-level targets are targets that are valid to be listed in the <code>top_level_targets</code> attribute of <code>xcodeproj</code>. In particular, this means that they aren't library targets, which when specified in <code>top_level_targets</code> cause duplicate mis-configured targets to be added to the project.    |
 | <a id="XcodeProjInfo-label"></a>label |  The <code>Label</code> of the target.    |
+| <a id="XcodeProjInfo-labels"></a>labels |  A <code>depset</code> of <code>Labels</code> for the target and its transitive dependencies.    |
 | <a id="XcodeProjInfo-lldb_context"></a>lldb_context |  A value returned from <code>lldb_context.collect</code>.    |
 | <a id="XcodeProjInfo-mergable_xcode_library_targets"></a>mergable_xcode_library_targets |  A <code>List</code> of <code>struct</code>s with 'id' and 'product_path' fields. The 'id' field is the id of the target. The 'product_path' is the path to the target's product.    |
 | <a id="XcodeProjInfo-potential_target_merges"></a>potential_target_merges |  A <code>depset</code> of <code>struct</code>s with 'src' and 'dest' fields. The 'src' field is the id of the target that can be merged into the target with the id of the 'dest' field.    |

--- a/xcodeproj/internal/providers.bzl
+++ b/xcodeproj/internal/providers.bzl
@@ -157,6 +157,9 @@ specified in `top_level_targets` cause duplicate mis-configured targets to be
 added to the project.
 """,
         "label": "The `Label` of the target.",
+        "labels": """\
+A `depset` of `Labels` for the target and its transitive dependencies.
+""",
         "lldb_context": "A value returned from `lldb_context.collect`.",
         "mergable_xcode_library_targets": """\
 A `List` of `struct`s with 'id' and 'product_path' fields. The 'id' field

--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -345,17 +345,17 @@ def _process_targets(
         for id, label in replacement_labels.items()
     }
 
-    target_labels = {
+    xcode_target_labels = {
         t.id: replacement_labels.get(t.id, t.label)
         for t in unprocessed_targets.values()
     }
-    target_label_strs = {
+    xcode_target_label_strs = {
         id: bazel_labels.normalize_label(label)
-        for id, label in target_labels.items()
+        for id, label in xcode_target_labels.items()
     }
 
-    # Can't use `target_label_strs`, as those are only for bazel targets that
-    # create Xcode targets
+    # Can't use `xcode_target_label_strs`, as those are only for bazel targets
+    # that create Xcode targets
     label_strs = {
         bazel_labels.normalize_label(
             replacement_labels_by_label.get(label, label)
@@ -422,7 +422,7 @@ actual targets: {}
                     path = file.dirname,
                 )] = build_setting_path(file = product.file)
 
-        label_str = target_label_strs[xcode_target.id]
+        label_str = xcode_target_label_strs[xcode_target.id]
         if (label_str in unfocused_labels or
             (has_focused_labels and label_str not in focused_labels)):
             unfocused_targets[xcode_target.id] = xcode_target
@@ -464,8 +464,8 @@ actual targets: {}
 
     infoplists = {}
     for xcode_target in focused_targets.values():
-        label = target_labels[xcode_target.id]
-        label_str = target_label_strs[xcode_target.id]
+        label = xcode_target_labels[xcode_target.id]
+        label_str = xcode_target_label_strs[xcode_target.id]
 
         # Remove from unfocused (to support `xcode_required_targets`)
         unfocused_targets.pop(xcode_target.id, None)
@@ -506,7 +506,7 @@ actual targets: {}
             # We can only merge targets with a single library dependency
             continue
         dest_target = unprocessed_targets[dest]
-        dest_label_str = target_label_strs[dest]
+        dest_label_str = xcode_target_label_strs[dest]
 
         for src in src_ids:
             target_merge_dests.setdefault(dest, []).append(src)
@@ -525,7 +525,7 @@ actual targets: {}
     for dest, srcs in target_merge_dests.items():
         for src in srcs:
             src_target = unprocessed_targets[src]
-            src_label_str = target_label_strs[src]
+            src_label_str = xcode_target_label_strs[src]
 
             # Adjust `{un,}focused_labels` for `extra_files` logic later
             unfocused_labels.pop(src_label_str, None)
@@ -551,8 +551,8 @@ actual targets: {}
     additional_generated = {}
     additional_outputs = {}
     for xcode_target in focused_targets.values():
-        label = target_labels[xcode_target.id]
-        label_str = target_label_strs[xcode_target.id]
+        label = xcode_target_labels[xcode_target.id]
+        label_str = xcode_target_label_strs[xcode_target.id]
 
         for file, owner_label in owned_extra_files.items():
             if label_str == owner_label:
@@ -673,7 +673,7 @@ actual targets: {}
         dto, replaced_dependencies, link_params = xcode_targets.to_dto(
             ctx = ctx,
             xcode_target = xcode_target,
-            label = target_labels[xcode_target.id],
+            label = xcode_target_labels[xcode_target.id],
             is_fixture = is_fixture,
             additional_scheme_target_ids = additional_scheme_target_ids,
             build_mode = build_mode,
@@ -735,7 +735,7 @@ actual targets: {}
         additional_indexstores_files = []
         additional_linking_files = []
 
-        label = target_labels[xcode_target.id]
+        label = xcode_target_labels[xcode_target.id]
         target_infoplists = infoplists.get(label)
         if target_infoplists:
             additional_linking_files.extend(target_infoplists)

--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -358,10 +358,10 @@ def _process_targets(
     # that create Xcode targets
     label_strs = {
         bazel_labels.normalize_label(
-            replacement_labels_by_label.get(label, label)
+            replacement_labels_by_label.get(label, label),
         ): None
         for label in depset(
-            transitive = [info.labels for info in infos]
+            transitive = [info.labels for info in infos],
         ).to_list()
     }
 

--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -345,23 +345,30 @@ def _process_targets(
         for id, label in replacement_labels.items()
     }
 
-    labels = {
+    target_labels = {
         t.id: replacement_labels.get(t.id, t.label)
         for t in unprocessed_targets.values()
     }
-    label_strs = {
-        id: bazel_labels.normalize_label(label)
-        for id, label in labels.items()
-    }
     target_label_strs = {
-        label_str: None
-        for label_str in label_strs.values()
+        id: bazel_labels.normalize_label(label)
+        for id, label in target_labels.items()
+    }
+
+    # Can't use `target_label_strs`, as those are only for bazel targets that
+    # create Xcode targets
+    label_strs = {
+        bazel_labels.normalize_label(
+            replacement_labels_by_label.get(label, label)
+        ): None
+        for label in depset(
+            transitive = [info.labels for info in infos]
+        ).to_list()
     }
 
     invalid_focused_targets = [
         label
         for label in focused_labels
-        if label not in target_label_strs
+        if label not in label_strs
     ]
     if invalid_focused_targets:
         fail("""\
@@ -380,7 +387,7 @@ targets.
     invalid_extra_files_targets = [
         label
         for label in owned_extra_files.values()
-        if label not in target_label_strs
+        if label not in label_strs
     ]
     if invalid_extra_files_targets:
         fail("""\
@@ -415,7 +422,7 @@ actual targets: {}
                     path = file.dirname,
                 )] = build_setting_path(file = product.file)
 
-        label_str = label_strs[xcode_target.id]
+        label_str = target_label_strs[xcode_target.id]
         if (label_str in unfocused_labels or
             (has_focused_labels and label_str not in focused_labels)):
             unfocused_targets[xcode_target.id] = xcode_target
@@ -457,8 +464,8 @@ actual targets: {}
 
     infoplists = {}
     for xcode_target in focused_targets.values():
-        label = labels[xcode_target.id]
-        label_str = label_strs[xcode_target.id]
+        label = target_labels[xcode_target.id]
+        label_str = target_label_strs[xcode_target.id]
 
         # Remove from unfocused (to support `xcode_required_targets`)
         unfocused_targets.pop(xcode_target.id, None)
@@ -499,7 +506,7 @@ actual targets: {}
             # We can only merge targets with a single library dependency
             continue
         dest_target = unprocessed_targets[dest]
-        dest_label_str = label_strs[dest]
+        dest_label_str = target_label_strs[dest]
 
         for src in src_ids:
             target_merge_dests.setdefault(dest, []).append(src)
@@ -518,7 +525,7 @@ actual targets: {}
     for dest, srcs in target_merge_dests.items():
         for src in srcs:
             src_target = unprocessed_targets[src]
-            src_label_str = label_strs[src]
+            src_label_str = target_label_strs[src]
 
             # Adjust `{un,}focused_labels` for `extra_files` logic later
             unfocused_labels.pop(src_label_str, None)
@@ -544,8 +551,8 @@ actual targets: {}
     additional_generated = {}
     additional_outputs = {}
     for xcode_target in focused_targets.values():
-        label = labels[xcode_target.id]
-        label_str = label_strs[xcode_target.id]
+        label = target_labels[xcode_target.id]
+        label_str = target_label_strs[xcode_target.id]
 
         for file, owner_label in owned_extra_files.items():
             if label_str == owner_label:
@@ -666,7 +673,7 @@ actual targets: {}
         dto, replaced_dependencies, link_params = xcode_targets.to_dto(
             ctx = ctx,
             xcode_target = xcode_target,
-            label = labels[xcode_target.id],
+            label = target_labels[xcode_target.id],
             is_fixture = is_fixture,
             additional_scheme_target_ids = additional_scheme_target_ids,
             build_mode = build_mode,
@@ -728,7 +735,7 @@ actual targets: {}
         additional_indexstores_files = []
         additional_linking_files = []
 
-        label = labels[xcode_target.id]
+        label = target_labels[xcode_target.id]
         target_infoplists = infoplists.get(label)
         if target_infoplists:
             additional_linking_files.extend(target_infoplists)

--- a/xcodeproj/internal/xcodeprojinfo.bzl
+++ b/xcodeproj/internal/xcodeprojinfo.bzl
@@ -587,5 +587,12 @@ def create_xcodeprojinfo(*, ctx, build_mode, target, transitive_infos):
 
     return XcodeProjInfo(
         label = target.label,
+        labels = depset(
+            [target.label],
+            transitive = [
+                info.labels
+                for _, info in transitive_infos
+            ],
+        ),
         **info_fields
     )


### PR DESCRIPTION
For example, before this change we couldn’t focus `@com_github_krzyzanowskim_cryptoswift//:CryptoSwift` in `examples/integration`.