### PR TITLE
Stop providing `runner_label` to the runner

### DIFF
--- a/examples/cc/test/fixtures/bwb_project_spec.json
+++ b/examples/cc/test/fixtures/bwb_project_spec.json
@@ -1,6 +1,6 @@
 {
     "B": "rules_xcodeproj",
-    "R": "@//test/fixtures:xcodeproj_bwb",
+    "R": "//test/fixtures:xcodeproj_bwb",
     "T": "fixture-target-ids-file",
     "e": [
         {

--- a/examples/cc/test/fixtures/bwx_project_spec.json
+++ b/examples/cc/test/fixtures/bwx_project_spec.json
@@ -1,6 +1,6 @@
 {
     "B": "rules_xcodeproj",
-    "R": "@//test/fixtures:xcodeproj_bwx",
+    "R": "//test/fixtures:xcodeproj_bwx",
     "T": "fixture-target-ids-file",
     "e": [
         {

--- a/examples/integration/test/fixtures/bwb_project_spec.json
+++ b/examples/integration/test/fixtures/bwb_project_spec.json
@@ -95,7 +95,7 @@
         "iOSApp/Resources/ExampleResources/nested",
         "iOSApp/Resources/OnlyStructuredResources/Nested"
     ],
-    "R": "@//test/fixtures:xcodeproj_bwb",
+    "R": "//test/fixtures:xcodeproj_bwb",
     "T": "fixture-target-ids-file",
     "a": [
         "//iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTests.__internal__.__test_bundle applebin_ios-ios_x86_64-dbg-STABLE-13",

--- a/examples/integration/test/fixtures/bwx_project_spec.json
+++ b/examples/integration/test/fixtures/bwx_project_spec.json
@@ -70,7 +70,7 @@
             "INTEGRATION_TEST_ENV_VAR": "TRUE"
         }
     ],
-    "R": "@//test/fixtures:xcodeproj_bwx",
+    "R": "//test/fixtures:xcodeproj_bwx",
     "T": "fixture-target-ids-file",
     "a": [
         "//iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTests.__internal__.__test_bundle applebin_ios-ios_x86_64-dbg-STABLE-13",

--- a/examples/rules_ios/test/fixtures/bwb_project_spec.json
+++ b/examples/rules_ios/test/fixtures/bwb_project_spec.json
@@ -8,7 +8,7 @@
         "//iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTests.__internal__.__test_bundle applebin_ios-ios_x86_64-dbg-STABLE-3",
         {}
     ],
-    "R": "@//test/fixtures:xcodeproj_bwb",
+    "R": "//test/fixtures:xcodeproj_bwb",
     "T": "fixture-target-ids-file",
     "a": [
         "//iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTests.__internal__.__test_bundle applebin_ios-ios_x86_64-dbg-STABLE-3",

--- a/examples/sanitizers/test/fixtures/bwb_project_spec.json
+++ b/examples/sanitizers/test/fixtures/bwb_project_spec.json
@@ -1,6 +1,6 @@
 {
     "B": "rules_xcodeproj",
-    "R": "@//test/fixtures:xcodeproj_bwb",
+    "R": "//test/fixtures:xcodeproj_bwb",
     "T": "fixture-target-ids-file",
     "e": [
         "AddressSanitizerApp/BUILD",

--- a/examples/sanitizers/test/fixtures/bwx_project_spec.json
+++ b/examples/sanitizers/test/fixtures/bwx_project_spec.json
@@ -1,6 +1,6 @@
 {
     "B": "rules_xcodeproj",
-    "R": "@//test/fixtures:xcodeproj_bwx",
+    "R": "//test/fixtures:xcodeproj_bwx",
     "T": "fixture-target-ids-file",
     "e": [
         "AddressSanitizerApp/BUILD",

--- a/test/fixtures/generator/bwb_project_spec.json
+++ b/test/fixtures/generator/bwb_project_spec.json
@@ -6,7 +6,7 @@
         "//tools/generator/test:tests.__internal__.__test_bundle applebin_macos-darwin_x86_64-opt-STABLE-4",
         {}
     ],
-    "R": "@//test/fixtures/generator:xcodeproj_bwb",
+    "R": "//test/fixtures/generator:xcodeproj_bwb",
     "T": "fixture-target-ids-file",
     "e": [
         {

--- a/test/fixtures/generator/bwx_project_spec.json
+++ b/test/fixtures/generator/bwx_project_spec.json
@@ -6,7 +6,7 @@
         "//tools/generator/test:tests.__internal__.__test_bundle applebin_macos-darwin_x86_64-opt-STABLE-4",
         {}
     ],
-    "R": "@//test/fixtures/generator:xcodeproj_bwx",
+    "R": "//test/fixtures/generator:xcodeproj_bwx",
     "T": "fixture-target-ids-file",
     "e": [
         {

--- a/xcodeproj/internal/xcodeproj_macro.bzl
+++ b/xcodeproj/internal/xcodeproj_macro.bzl
@@ -440,7 +440,6 @@ Please refer to https://bazel.build/extending/config#defining) on how to them.
         pre_build = pre_build,
         project_name = project_name,
         project_options = project_options,
-        runner_label = bazel_labels.normalize_string(name),
         scheme_autogeneration_mode = scheme_autogeneration_mode,
         schemes_json = schemes_json,
         temporary_directory = temporary_directory,

--- a/xcodeproj/internal/xcodeproj_runner.bzl
+++ b/xcodeproj/internal/xcodeproj_runner.bzl
@@ -232,6 +232,7 @@ def _write_generator_build_file(
         attr,
         build_file_path,
         name,
+        runner_label,
         repo,
         template):
     output = actions.declare_file("{}.generator.BUILD.bazel".format(name))
@@ -264,7 +265,7 @@ def _write_generator_build_file(
             "%project_name%": attr.project_name,
             "%project_options%": str(attr.project_options),
             "%runner_build_file%": build_file_path,
-            "%runner_label%": attr.runner_label,
+            "%runner_label%": runner_label,
             "%scheme_autogeneration_mode%": attr.scheme_autogeneration_mode,
             "%tags%": tags,
             "%testonly%": str(attr.testonly),
@@ -409,6 +410,7 @@ def _xcodeproj_runner_impl(ctx):
         str(ctx.attr._generator_defs_bzl_template.label).split("//", 1)[0] or
         "@"
     )
+    runner_label = str(ctx.label)
 
     xcode_version = _get_xcode_product_version(
         xcode_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig],
@@ -437,6 +439,7 @@ def _xcodeproj_runner_impl(ctx):
         attr = attr,
         build_file_path = ctx.build_file_path,
         name = name,
+        runner_label = runner_label,
         repo = repo,
         template = ctx.file._generator_package_contents_template,
     )
@@ -464,7 +467,7 @@ def _xcodeproj_runner_impl(ctx):
         generator_defs_bzl = generator_defs_bzl,
         is_fixture = is_fixture,
         project_name = project_name,
-        runner_label = str(ctx.label),
+        runner_label = runner_label,
         schemes_json = schemes_json,
         template = ctx.file._runner_template,
         xcode_version = xcode_version,
@@ -531,7 +534,6 @@ xcodeproj_runner = rule(
         "project_name": attr.string(
             mandatory = True,
         ),
-        "runner_label": attr.string(),
         "scheme_autogeneration_mode": attr.string(
             default = "auto",
             values = ["auto", "none", "all"],


### PR DESCRIPTION
The canonical version works, so we can let the runner provide this label.