### PR TITLE
Improve progress message for project generation

### DIFF
--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -1319,6 +1319,7 @@ def _write_xcodeproj(
     ctx.actions.run(
         executable = ctx.attr._generator[DefaultInfo].files_to_run,
         mnemonic = "GenerateXcodeProj",
+        progress_message = "Generating \"{}\"".format(install_path),
         arguments = [args],
         inputs = spec_files + [
             execution_root_file,


### PR DESCRIPTION
Before:

```
INFO: From GenerateXcodeProj external/_main~internal~rules_xcodeproj_generated/generator/tools/generator/xcodeproj/xcodeproj.xcodeproj:
WARNING: Was unable to consolidate target groupings "[@@//tools/generator/test:tests.__internal__.__test_bundle applebin_macos-darwin_arm64-dbg-ST-4bf02e38abc1], [@@//tools/generator/test:tests.__internal__.__test_bundle applebin_macos-darwin_arm64-opt-ST-49992506bac4]" since they have conditional dependencies (e.g. `deps`, `test_host`, `watch_application`, etc.)
```

After:

```
INFO: From Generating "tools/generator/generator.xcodeproj":
WARNING: Was unable to consolidate target groupings "[@@//tools/generator/test:tests.__internal__.__test_bundle applebin_macos-darwin_arm64-dbg-ST-4bf02e38abc1], [@@//tools/generator/test:tests.__internal__.__test_bundle applebin_macos-darwin_arm64-opt-ST-49992506bac4]" since they have conditional dependencies (e.g. `deps`, `test_host`, `watch_application`, etc.)
```