### PR TITLE
Skip unnecessary partition call in normalized_file_path

### DIFF
--- a/xcodeproj/internal/files.bzl
+++ b/xcodeproj/internal/files.bzl
@@ -173,9 +173,9 @@ def normalized_file_path(file, *, folder_type_extensions):
     path = file.path
 
     for extension in folder_type_extensions:
-        prefix, ext, _ = path.partition(extension)
-        if not ext:
+        if extension not in path:
             continue
+        prefix, ext, _ = path.partition(extension)
         return file_path(
             file,
             path = prefix + ext,


### PR DESCRIPTION
Ran `--starlark_cpu_profile` in one of our apps and noticed a small optimization we can do. This skips early if `extension not in path` to avoid an unnecessary `.partition()` call.

Before:
![image](https://user-images.githubusercontent.com/10197663/230969480-1b8cc283-3dc5-4f16-8265-c9aa7d902096.png)
![image](https://user-images.githubusercontent.com/10197663/230969516-9ab1d00f-18b3-47c9-a07b-528f9a8bebab.png)

After:
![image](https://user-images.githubusercontent.com/10197663/230969588-9d730ed8-70b3-44ae-8703-01668c81ca87.png)
![image](https://user-images.githubusercontent.com/10197663/230969621-ea43a029-95fc-4d30-b74f-dc8379764202.png)

I noticed that `file_path` has increased from `48.99s` to `58.45s` after this change but I couldn't find evidence for any change in behaviour here. I sent to a file all paths hitting both `return` statements in this code and I couldn't find any delta.

Still, I believe since things improve at the `normalized_file_path` level we can always come back and improve `file_path` in a separate PR. Open to suggestions here though!