### PR TITLE
Change default value of `adjust_schemes_for_swiftui_previews` to True

### DIFF
--- a/xcodeproj/internal/xcodeproj_runner.bzl
+++ b/xcodeproj/internal/xcodeproj_runner.bzl
@@ -512,7 +512,7 @@ xcodeproj_runner = rule(
     implementation = _xcodeproj_runner_impl,
     attrs = {
         "adjust_schemes_for_swiftui_previews": attr.bool(
-            default = False,
+            default = True,
             mandatory = True,
         ),
         "build_mode": attr.string(


### PR DESCRIPTION
Why
- This value of `adjust_schemes_for_swiftui_previews` should be `True` according to the docs, but in the  `xcodeproj_runner` rule it's set to False. 

What 
- Change default value of `adjust_schemes_for_swiftui_previews` to `True` in `xcodeproj_runner`