### PR TITLE
[DO NOT REVIEW] changes for cflag params

### DIFF
--- a/tools/generator/src/Generator/CreateFilesAndGroups.swift
+++ b/tools/generator/src/Generator/CreateFilesAndGroups.swift
@@ -394,6 +394,15 @@ extension Generator {
             if let linkParams = target.linkParams {
                 allInputPaths.insert(linkParams)
             }
+            if !target.cFlags.isEmpty {
+                allInputPaths.insert(target.cFlags[0])
+            }
+            if !target.cxxFlags.isEmpty {
+                allInputPaths.insert(target.cxxFlags[0])
+            }
+            if !target.swiftFlags.isEmpty {
+                allInputPaths.insert(target.swiftFlags[0])
+            }
             if let infoPlist = target.infoPlist {
                 allInputPaths.insert(infoPlist)
             }

--- a/tools/generator/src/Generator/CreateFilesAndGroups.swift
+++ b/tools/generator/src/Generator/CreateFilesAndGroups.swift
@@ -395,13 +395,13 @@ extension Generator {
                 allInputPaths.insert(linkParams)
             }
             if !target.cFlags.isEmpty {
-                allInputPaths.insert(target.cFlags[0])
+                allInputPaths.insert(.generated(Path(target.cFlags[0])))
             }
             if !target.cxxFlags.isEmpty {
-                allInputPaths.insert(target.cxxFlags[0])
+                allInputPaths.insert(.generated(Path(target.cxxFlags[0])))
             }
             if !target.swiftFlags.isEmpty {
-                allInputPaths.insert(target.swiftFlags[0])
+                allInputPaths.insert(.generated(Path(target.swiftFlags[0])))
             }
             if let infoPlist = target.infoPlist {
                 allInputPaths.insert(infoPlist)

--- a/tools/generator/src/Generator/SetTargetConfigurations.swift
+++ b/tools/generator/src/Generator/SetTargetConfigurations.swift
@@ -267,6 +267,27 @@ Target with id "\(id)" not found in `consolidatedTarget.uniqueFiles`
             )
         }
 
+        if !target.cFlags.isEmpty {
+            try buildSettings.prepend(
+                onKey: "OTHER_CFLAGS",
+                ["@$(DERIVED_FILE_DIR)/conlyopts.params"]
+            )
+        }
+
+        if !target.cxxFlags.isEmpty {
+            try buildSettings.prepend(
+                onKey: "OTHER_CPLUSPLUSFLAGS",
+                ["@$(DERIVED_FILE_DIR)/cxxopts.params"]
+            )
+        }
+
+        if !target.swiftFlags.isEmpty {
+            try buildSettings.prepend(
+                onKey: "OTHER_SWIFT_FLAGS",
+                ["@$(DERIVED_FILE_DIR)/swiftcopts.params"]
+            )
+        }
+
         buildSettings.set("ARCHS", to: target.platform.arch)
         buildSettings.set(
             "BAZEL_PACKAGE_BIN_DIR",
@@ -466,10 +487,10 @@ $(CONFIGURATION_BUILD_DIR)
             flagsPrefix: cxxFlagsPrefix,
             flags: cxxFlags
         )
-        let swiftFlagsString = processFlagsString(
-            flagsPrefix: swiftFlagsPrefix,
-            flags: swiftFlags
-        )
+        // let swiftFlagsString = processFlagsString(
+        //     flagsPrefix: swiftFlagsPrefix,
+        //     flags: swiftFlags
+        // )
 
         // Append settings when using ASAN
         if cFlags.contains("-D_FORTIFY_SOURCE=1") {
@@ -499,15 +520,15 @@ $(ASAN_OTHER_CPLUSPLUSFLAGS__$(CLANG_ADDRESS_SANITIZER))
 """
         }
 
-        if !swiftFlagsString.isEmpty {
-            buildSettings.set("OTHER_SWIFT_FLAGS", to: swiftFlagsString)
-        }
-        if !cFlagsString.isEmpty {
-            buildSettings.set("OTHER_CFLAGS", to: cFlagsString)
-        }
-        if !cxxFlagsString.isEmpty {
-            buildSettings.set("OTHER_CPLUSPLUSFLAGS", to: cxxFlagsString)
-        }
+        // if !swiftFlagsString.isEmpty {
+        //     buildSettings.set("OTHER_SWIFT_FLAGS", to: swiftFlagsString)
+        // }
+        // if !cFlagsString.isEmpty {
+        //     buildSettings.set("OTHER_CFLAGS", to: cFlagsString)
+        // }
+        // if !cxxFlagsString.isEmpty {
+        //     buildSettings.set("OTHER_CPLUSPLUSFLAGS", to: cxxFlagsString)
+        // }
 
         return buildSettings
     }

--- a/xcodeproj/internal/output_files.bzl
+++ b/xcodeproj/internal/output_files.bzl
@@ -120,6 +120,7 @@ def _create(
     if should_produce_output_groups and direct_outputs:
         linking_output_group_name = "bl {}".format(direct_outputs.id)
         products_output_group_name = "bp {}".format(direct_outputs.id)
+        generated_output_group_name = "bg {}".format(direct_outputs.id)
 
         indexstores_filelist = filelists.write(
             ctx = ctx,
@@ -139,7 +140,7 @@ def _create(
                 closest_compiled,
             ),
             (
-                "bg {}".format(direct_outputs.id),
+                generated_output_group_name,
                 False,
                 inputs.compiling_files if inputs else depset(),
             ),
@@ -154,6 +155,7 @@ def _create(
     else:
         linking_output_group_name = None
         products_output_group_name = None
+        generated_output_group_name = None
         direct_group_list = None
 
     output_group_list = depset(
@@ -178,6 +180,7 @@ def _create(
         direct_outputs = direct_outputs if should_produce_dto else None,
         linking_output_group_name = linking_output_group_name,
         products_output_group_name = products_output_group_name,
+        generated_output_group_name = generated_output_group_name,
         transitive_infoplists = transitive_infoplists,
     )
 

--- a/xcodeproj/internal/output_files.bzl
+++ b/xcodeproj/internal/output_files.bzl
@@ -382,6 +382,10 @@ def _to_output_groups_fields(
         for name, is_indexstores, files in outputs._output_group_list.to_list()
     }
 
+    # for output_group in output_groups:
+    #     if output_group.startswith("bg "):
+    #         print(output_group, output_groups[output_group])
+
     output_groups["all_b"] = depset(transitive = output_groups.values())
 
     return output_groups

--- a/xcodeproj/internal/xcode_targets.bzl
+++ b/xcodeproj/internal/xcode_targets.bzl
@@ -237,6 +237,7 @@ def _to_xcode_target_outputs(outputs):
             direct_outputs.dsym_files if direct_outputs else None
         ),
         linking_output_group_name = outputs.linking_output_group_name,
+        generated_output_group_name = outputs.generated_output_group_name,
         product_file = (
             direct_outputs.product if direct_outputs else None
         ),
@@ -351,6 +352,7 @@ def _merge_xcode_target_outputs(*, src, dest):
     return struct(
         dsym_files = dest.dsym_files,
         linking_output_group_name = dest.linking_output_group_name,
+        generated_output_group_name = dest.generated_output_group_name,
         swiftmodule = src.swiftmodule,
         swift_generated_header = src.swift_generated_header,
         product_file = dest.product_file,

--- a/xcodeproj/internal/xcode_targets.bzl
+++ b/xcodeproj/internal/xcode_targets.bzl
@@ -589,18 +589,6 @@ def _xcode_target_to_dto(
         xcode_generated_paths_file = xcode_generated_paths_file,
     )
 
-    set_if_true(
-        dto,
-        "b",
-        _build_settings_to_dto(
-            build_mode = build_mode,
-            link_params = link_params,
-            linker_products_map = linker_products_map,
-            xcode_generated_paths = xcode_generated_paths,
-            xcode_target = xcode_target,
-        ),
-    )
-
     conlyopts = xcode_target._conlyopts
     cxxopts = xcode_target._cxxopts
     if is_fixture:
@@ -647,6 +635,21 @@ def _xcode_target_to_dto(
     set_if_true(dto, "9", cxxopts_file_path)
     set_if_true(dto, "0", swiftcopts_file_path)
     opt_files = [conlyopts_file, cxxopts_file, swiftcopts_file]
+
+    set_if_true(
+        dto,
+        "b",
+        _build_settings_to_dto(
+            build_mode = build_mode,
+            link_params = link_params,
+            c_compile_params_path = conlyopts_file_path,
+            cxx_compile_params_path = cxxopts_file_path,
+            swift_compile_params_path = swiftcopts_file_path,
+            linker_products_map = linker_products_map,
+            xcode_generated_paths = xcode_generated_paths,
+            xcode_target = xcode_target,
+        ),
+    )
 
     # set_if_true(dto, "8", conlyopts)
     # set_if_true(dto, "9", cxxopts)
@@ -749,6 +752,9 @@ def _build_settings_to_dto(
         *,
         build_mode,
         link_params,
+        c_compile_params_path,
+        cxx_compile_params_path,
+        swift_compile_params_path,
         linker_products_map,
         xcode_generated_paths,
         xcode_target):
@@ -758,6 +764,15 @@ def _build_settings_to_dto(
         build_settings["LINK_PARAMS_FILE"] = build_setting_path(
             path = link_params.path,
         )
+    
+    if c_compile_params_path:
+        build_settings["C_COMPILE_PARAMS_FILE"] = c_compile_params_path
+
+    if cxx_compile_params_path:
+        build_settings["CXX_COMPILE_PARAMS_FILE"] = cxx_compile_params_path
+
+    if swift_compile_params_path:
+        build_settings["SWIFT_COMPILE_PARAMS_FILE"] = swift_compile_params_path
 
     _set_bazel_outputs_product(
         build_mode = build_mode,

--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -1780,12 +1780,7 @@ done
             input_files_output_groups["all_xl"],
         ]
     else:
-        input_files_output_groups = input_files.to_output_groups_fields(
-            inputs = inputs,
-            additional_generated = additional_generated,
-            index_import = ctx.executable._index_import,
-        )
-        print("input_files_output_groups : ", input_files_output_groups)
+        input_files_output_groups = {}
         output_files_output_groups = output_files.to_output_groups_fields(
             outputs = outputs,
             additional_outputs = additional_outputs,


### PR DESCRIPTION
Draft change that passes copts as params file instead to avoid Argument List too long error in Index Builds


**high level changes list** 
1. in `xcode_targets.bzl#_xcode_target_to_dto()`, create params file for `copts`, `cxxopts`, `swiftcopts` 
2. in `xcodeproj_rule.bzl#_process_targets()`, for each processed `xcode_target`, collect `opt_files` and add the collected `opt_files` into `additional_generated` with a output group name `bg` (can I use the same group name for xcode build mode or should I create a new one for xcode different from existing ones?) 
3. in `xcodeproj_rule.bzl#_xcodeproj_impl()`, use `aditional_generated` to pass the opt params files into OutputGroupInfo provider for both Bazel and Xcode mode.  

