### PR TITLE
Change generated repository path

### DIFF
--- a/xcodeproj/internal/runner.template.sh
+++ b/xcodeproj/internal/runner.template.sh
@@ -105,7 +105,7 @@ readonly nested_output_base="$output_base/rules_xcodeproj/build_output_base"
 
 # Create files for the generator target
 output_base_hash=$(/sbin/md5 -q -s "$output_base")
-readonly generator_package_directory="/tmp/rules_xcodeproj/generated/$output_base_hash/%generator_package_name%"
+readonly generator_package_directory="/tmp/rules_xcodeproj/generated_v2/$output_base_hash/%generator_package_name%"
 
 mkdir -p "$generator_package_directory"
 cp "$generator_build_file" "$generator_package_directory/BUILD"

--- a/xcodeproj/repositories.bzl
+++ b/xcodeproj/repositories.bzl
@@ -74,7 +74,7 @@ package_group(
     # Ensure that this repository is unique per output base
     output_base_hash = output_base_hash_result.stdout.strip()
     repository_ctx.symlink(
-        "/tmp/rules_xcodeproj/generated/{}/generator".format(output_base_hash),
+        "/tmp/rules_xcodeproj/generated_v2/{}/generator".format(output_base_hash),
         "generator",
     )
 


### PR DESCRIPTION
If someone generated a project before 1a45cceea54ee37aa0bf15a7f847eab10c1f3e6a, and their project is under a `//build` package, they can run into an error like this:

```
mkdir: /tmp/rules_xcodeproj/generated/26a7aae8a172d3845d4cafea37027a39/generator/build: Not a directory
```

The fix is to delete `/tmp/rules_xcodeproj/generated/26a7aae8a172d3845d4cafea37027a39/generator`, but instead we will just change the path to make sure people can upgrade from 1.3.3 to 1.4.0 without issues.