### PR TITLE
Prevent spotlight from indexing our Bazel output bases

### DIFF
--- a/examples/cc/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -543,7 +543,7 @@
 			);
 			mainGroup = 9FFDBC24588A91736E9C5DBD /* ../../../../.. */;
 			productRefGroup = 891FF4EFB55BD0CCB8B61ED5 /* Products */;
-			projectDirPath = "../../bazel-output-base/rules_xcodeproj/build_output_base/execroot/__main__";
+			projectDirPath = "../../bazel-output-base/rules_xcodeproj.noindex/build_output_base/execroot/__main__";
 			projectRoot = "";
 			targets = (
 				7E7D155EBCA520F35DEA3571 /* BazelDependencies */,
@@ -952,7 +952,7 @@
 				INDEXING_DEPLOYMENT_LOCATION__YES = NO;
 				INDEXING_PROJECT_DIR__ = "$(INDEXING_PROJECT_DIR__NO)";
 				INDEXING_PROJECT_DIR__NO = "$(PROJECT_DIR)";
-				INDEXING_PROJECT_DIR__YES = "../../../../../bazel-output-base/rules_xcodeproj/indexbuild_output_base/execroot/__main__";
+				INDEXING_PROJECT_DIR__YES = "../../../../../bazel-output-base/rules_xcodeproj.noindex/indexbuild_output_base/execroot/__main__";
 				INDEX_FORCE_SCRIPT_EXECUTION = YES;
 				INSTALL_PATH = "$(BAZEL_PACKAGE_BIN_DIR)/$(TARGET_NAME)/bin";
 				INTERNAL_DIR = "$(PROJECT_FILE_PATH)/rules_xcodeproj";

--- a/examples/cc/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/cc/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -575,7 +575,7 @@
 			);
 			mainGroup = 1EF2569752EC6D782DEDEF47 /* ../../../../.. */;
 			productRefGroup = C5DA04B2480EBE8D895B5826 /* Products */;
-			projectDirPath = "../../bazel-output-base/rules_xcodeproj/build_output_base/execroot/__main__";
+			projectDirPath = "../../bazel-output-base/rules_xcodeproj.noindex/build_output_base/execroot/__main__";
 			projectRoot = "";
 			targets = (
 				FE59281FE487F27A37DC2EE7 /* BazelDependencies */,
@@ -943,7 +943,7 @@
 				INDEXING_DEPLOYMENT_LOCATION__YES = NO;
 				INDEXING_PROJECT_DIR__ = "$(INDEXING_PROJECT_DIR__NO)";
 				INDEXING_PROJECT_DIR__NO = "$(PROJECT_DIR)";
-				INDEXING_PROJECT_DIR__YES = "../../../../../bazel-output-base/rules_xcodeproj/indexbuild_output_base/execroot/__main__";
+				INDEXING_PROJECT_DIR__YES = "../../../../../bazel-output-base/rules_xcodeproj.noindex/indexbuild_output_base/execroot/__main__";
 				INDEX_FORCE_SCRIPT_EXECUTION = YES;
 				INSTALL_PATH = "$(BAZEL_PACKAGE_BIN_DIR)/$(TARGET_NAME)/bin";
 				INTERNAL_DIR = "$(PROJECT_FILE_PATH)/rules_xcodeproj";

--- a/examples/integration/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -6726,7 +6726,7 @@
 			);
 			mainGroup = 9FFDBC24588A91736E9C5DBD /* ../../../../.. */;
 			productRefGroup = 891FF4EFB55BD0CCB8B61ED5 /* Products */;
-			projectDirPath = "../../bazel-output-base/rules_xcodeproj/build_output_base/execroot/__main__";
+			projectDirPath = "../../bazel-output-base/rules_xcodeproj.noindex/build_output_base/execroot/__main__";
 			projectRoot = "";
 			targets = (
 				7E7D155EBCA520F35DEA3571 /* BazelDependencies */,
@@ -10088,7 +10088,7 @@
 				INDEXING_DEPLOYMENT_LOCATION__YES = NO;
 				INDEXING_PROJECT_DIR__ = "$(INDEXING_PROJECT_DIR__NO)";
 				INDEXING_PROJECT_DIR__NO = "$(PROJECT_DIR)";
-				INDEXING_PROJECT_DIR__YES = "../../../../../bazel-output-base/rules_xcodeproj/indexbuild_output_base/execroot/__main__";
+				INDEXING_PROJECT_DIR__YES = "../../../../../bazel-output-base/rules_xcodeproj.noindex/indexbuild_output_base/execroot/__main__";
 				INDEX_FORCE_SCRIPT_EXECUTION = YES;
 				INSTALL_PATH = "$(BAZEL_PACKAGE_BIN_DIR)/$(TARGET_NAME)/bin";
 				INTERNAL_DIR = "$(PROJECT_FILE_PATH)/rules_xcodeproj";
@@ -12554,7 +12554,7 @@
 				INDEXING_DEPLOYMENT_LOCATION__YES = NO;
 				INDEXING_PROJECT_DIR__ = "$(INDEXING_PROJECT_DIR__NO)";
 				INDEXING_PROJECT_DIR__NO = "$(PROJECT_DIR)";
-				INDEXING_PROJECT_DIR__YES = "../../../../../bazel-output-base/rules_xcodeproj/indexbuild_output_base/execroot/__main__";
+				INDEXING_PROJECT_DIR__YES = "../../../../../bazel-output-base/rules_xcodeproj.noindex/indexbuild_output_base/execroot/__main__";
 				INDEX_FORCE_SCRIPT_EXECUTION = YES;
 				INSTALL_PATH = "$(BAZEL_PACKAGE_BIN_DIR)/$(TARGET_NAME)/bin";
 				INTERNAL_DIR = "$(PROJECT_FILE_PATH)/rules_xcodeproj";

--- a/examples/integration/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -7639,7 +7639,7 @@
 			);
 			mainGroup = 1EF2569752EC6D782DEDEF47 /* ../../../../.. */;
 			productRefGroup = C5DA04B2480EBE8D895B5826 /* Products */;
-			projectDirPath = "../../bazel-output-base/rules_xcodeproj/build_output_base/execroot/__main__";
+			projectDirPath = "../../bazel-output-base/rules_xcodeproj.noindex/build_output_base/execroot/__main__";
 			projectRoot = "";
 			targets = (
 				FE59281FE487F27A37DC2EE7 /* BazelDependencies */,
@@ -12381,7 +12381,7 @@
 				INDEXING_DEPLOYMENT_LOCATION__YES = NO;
 				INDEXING_PROJECT_DIR__ = "$(INDEXING_PROJECT_DIR__NO)";
 				INDEXING_PROJECT_DIR__NO = "$(PROJECT_DIR)";
-				INDEXING_PROJECT_DIR__YES = "../../../../../bazel-output-base/rules_xcodeproj/indexbuild_output_base/execroot/__main__";
+				INDEXING_PROJECT_DIR__YES = "../../../../../bazel-output-base/rules_xcodeproj.noindex/indexbuild_output_base/execroot/__main__";
 				INDEX_FORCE_SCRIPT_EXECUTION = YES;
 				INSTALL_PATH = "$(BAZEL_PACKAGE_BIN_DIR)/$(TARGET_NAME)/bin";
 				INTERNAL_DIR = "$(PROJECT_FILE_PATH)/rules_xcodeproj";
@@ -13497,7 +13497,7 @@
 				INDEXING_DEPLOYMENT_LOCATION__YES = NO;
 				INDEXING_PROJECT_DIR__ = "$(INDEXING_PROJECT_DIR__NO)";
 				INDEXING_PROJECT_DIR__NO = "$(PROJECT_DIR)";
-				INDEXING_PROJECT_DIR__YES = "../../../../../bazel-output-base/rules_xcodeproj/indexbuild_output_base/execroot/__main__";
+				INDEXING_PROJECT_DIR__YES = "../../../../../bazel-output-base/rules_xcodeproj.noindex/indexbuild_output_base/execroot/__main__";
 				INDEX_FORCE_SCRIPT_EXECUTION = YES;
 				INSTALL_PATH = "$(BAZEL_PACKAGE_BIN_DIR)/$(TARGET_NAME)/bin";
 				INTERNAL_DIR = "$(PROJECT_FILE_PATH)/rules_xcodeproj";

--- a/examples/rules_ios/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/rules_ios/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -2039,7 +2039,7 @@
 			);
 			mainGroup = 9FFDBC24588A91736E9C5DBD /* ../../../../.. */;
 			productRefGroup = 891FF4EFB55BD0CCB8B61ED5 /* Products */;
-			projectDirPath = "../../bazel-output-base/rules_xcodeproj/build_output_base/execroot/__main__";
+			projectDirPath = "../../bazel-output-base/rules_xcodeproj.noindex/build_output_base/execroot/__main__";
 			projectRoot = "";
 			targets = (
 				7E7D155EBCA520F35DEA3571 /* BazelDependencies */,
@@ -3491,7 +3491,7 @@
 				INDEXING_DEPLOYMENT_LOCATION__YES = NO;
 				INDEXING_PROJECT_DIR__ = "$(INDEXING_PROJECT_DIR__NO)";
 				INDEXING_PROJECT_DIR__NO = "$(PROJECT_DIR)";
-				INDEXING_PROJECT_DIR__YES = "../../../../../bazel-output-base/rules_xcodeproj/indexbuild_output_base/execroot/__main__";
+				INDEXING_PROJECT_DIR__YES = "../../../../../bazel-output-base/rules_xcodeproj.noindex/indexbuild_output_base/execroot/__main__";
 				INDEX_FORCE_SCRIPT_EXECUTION = YES;
 				INSTALL_PATH = "$(BAZEL_PACKAGE_BIN_DIR)/$(TARGET_NAME)/bin";
 				INTERNAL_DIR = "$(PROJECT_FILE_PATH)/rules_xcodeproj";

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -444,7 +444,7 @@
 			);
 			mainGroup = 9FFDBC24588A91736E9C5DBD /* ../../../../.. */;
 			productRefGroup = 891FF4EFB55BD0CCB8B61ED5 /* Products */;
-			projectDirPath = "../../bazel-output-base/rules_xcodeproj/build_output_base/execroot/__main__";
+			projectDirPath = "../../bazel-output-base/rules_xcodeproj.noindex/build_output_base/execroot/__main__";
 			projectRoot = "";
 			targets = (
 				7E7D155EBCA520F35DEA3571 /* BazelDependencies */,
@@ -745,7 +745,7 @@
 				INDEXING_DEPLOYMENT_LOCATION__YES = NO;
 				INDEXING_PROJECT_DIR__ = "$(INDEXING_PROJECT_DIR__NO)";
 				INDEXING_PROJECT_DIR__NO = "$(PROJECT_DIR)";
-				INDEXING_PROJECT_DIR__YES = "../../../../../bazel-output-base/rules_xcodeproj/indexbuild_output_base/execroot/__main__";
+				INDEXING_PROJECT_DIR__YES = "../../../../../bazel-output-base/rules_xcodeproj.noindex/indexbuild_output_base/execroot/__main__";
 				INDEX_FORCE_SCRIPT_EXECUTION = YES;
 				INSTALL_PATH = "$(BAZEL_PACKAGE_BIN_DIR)/$(TARGET_NAME)/bin";
 				INTERNAL_DIR = "$(PROJECT_FILE_PATH)/rules_xcodeproj";

--- a/examples/sanitizers/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/sanitizers/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -442,7 +442,7 @@
 			);
 			mainGroup = 1EF2569752EC6D782DEDEF47 /* ../../../../.. */;
 			productRefGroup = C5DA04B2480EBE8D895B5826 /* Products */;
-			projectDirPath = "../../bazel-output-base/rules_xcodeproj/build_output_base/execroot/__main__";
+			projectDirPath = "../../bazel-output-base/rules_xcodeproj.noindex/build_output_base/execroot/__main__";
 			projectRoot = "";
 			targets = (
 				FE59281FE487F27A37DC2EE7 /* BazelDependencies */,
@@ -744,7 +744,7 @@
 				INDEXING_DEPLOYMENT_LOCATION__YES = NO;
 				INDEXING_PROJECT_DIR__ = "$(INDEXING_PROJECT_DIR__NO)";
 				INDEXING_PROJECT_DIR__NO = "$(PROJECT_DIR)";
-				INDEXING_PROJECT_DIR__YES = "../../../../../bazel-output-base/rules_xcodeproj/indexbuild_output_base/execroot/__main__";
+				INDEXING_PROJECT_DIR__YES = "../../../../../bazel-output-base/rules_xcodeproj.noindex/indexbuild_output_base/execroot/__main__";
 				INDEX_FORCE_SCRIPT_EXECUTION = YES;
 				INSTALL_PATH = "$(BAZEL_PACKAGE_BIN_DIR)/$(TARGET_NAME)/bin";
 				INTERNAL_DIR = "$(PROJECT_FILE_PATH)/rules_xcodeproj";

--- a/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
@@ -2162,7 +2162,7 @@
 			);
 			mainGroup = 9FFDBC24588A91736E9C5DBD /* ../../../../.. */;
 			productRefGroup = 891FF4EFB55BD0CCB8B61ED5 /* Products */;
-			projectDirPath = "../../../bazel-output-base/rules_xcodeproj/build_output_base/execroot/rules_xcodeproj";
+			projectDirPath = "../../../bazel-output-base/rules_xcodeproj.noindex/build_output_base/execroot/rules_xcodeproj";
 			projectRoot = "";
 			targets = (
 				7E7D155EBCA520F35DEA3571 /* BazelDependencies */,
@@ -3259,7 +3259,7 @@
 				INDEXING_DEPLOYMENT_LOCATION__YES = NO;
 				INDEXING_PROJECT_DIR__ = "$(INDEXING_PROJECT_DIR__NO)";
 				INDEXING_PROJECT_DIR__NO = "$(PROJECT_DIR)";
-				INDEXING_PROJECT_DIR__YES = "../../../../../bazel-output-base/rules_xcodeproj/indexbuild_output_base/execroot/rules_xcodeproj";
+				INDEXING_PROJECT_DIR__YES = "../../../../../bazel-output-base/rules_xcodeproj.noindex/indexbuild_output_base/execroot/rules_xcodeproj";
 				INDEX_FORCE_SCRIPT_EXECUTION = YES;
 				INSTALL_PATH = "$(BAZEL_PACKAGE_BIN_DIR)/$(TARGET_NAME)/bin";
 				INTERNAL_DIR = "$(PROJECT_FILE_PATH)/rules_xcodeproj";
@@ -3976,7 +3976,7 @@
 				INDEXING_DEPLOYMENT_LOCATION__YES = NO;
 				INDEXING_PROJECT_DIR__ = "$(INDEXING_PROJECT_DIR__NO)";
 				INDEXING_PROJECT_DIR__NO = "$(PROJECT_DIR)";
-				INDEXING_PROJECT_DIR__YES = "../../../../../bazel-output-base/rules_xcodeproj/indexbuild_output_base/execroot/rules_xcodeproj";
+				INDEXING_PROJECT_DIR__YES = "../../../../../bazel-output-base/rules_xcodeproj.noindex/indexbuild_output_base/execroot/rules_xcodeproj";
 				INDEX_FORCE_SCRIPT_EXECUTION = YES;
 				INSTALL_PATH = "$(BAZEL_PACKAGE_BIN_DIR)/$(TARGET_NAME)/bin";
 				INTERNAL_DIR = "$(PROJECT_FILE_PATH)/rules_xcodeproj";
@@ -4359,7 +4359,7 @@
 				INDEXING_DEPLOYMENT_LOCATION__YES = NO;
 				INDEXING_PROJECT_DIR__ = "$(INDEXING_PROJECT_DIR__NO)";
 				INDEXING_PROJECT_DIR__NO = "$(PROJECT_DIR)";
-				INDEXING_PROJECT_DIR__YES = "../../../../../bazel-output-base/rules_xcodeproj/indexbuild_output_base/execroot/rules_xcodeproj";
+				INDEXING_PROJECT_DIR__YES = "../../../../../bazel-output-base/rules_xcodeproj.noindex/indexbuild_output_base/execroot/rules_xcodeproj";
 				INDEX_FORCE_SCRIPT_EXECUTION = YES;
 				INSTALL_PATH = "$(BAZEL_PACKAGE_BIN_DIR)/$(TARGET_NAME)/bin";
 				INTERNAL_DIR = "$(PROJECT_FILE_PATH)/rules_xcodeproj";

--- a/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
@@ -2251,7 +2251,7 @@
 			);
 			mainGroup = 1EF2569752EC6D782DEDEF47 /* ../../../../.. */;
 			productRefGroup = C5DA04B2480EBE8D895B5826 /* Products */;
-			projectDirPath = "../../../bazel-output-base/rules_xcodeproj/build_output_base/execroot/rules_xcodeproj";
+			projectDirPath = "../../../bazel-output-base/rules_xcodeproj.noindex/build_output_base/execroot/rules_xcodeproj";
 			projectRoot = "";
 			targets = (
 				FE59281FE487F27A37DC2EE7 /* BazelDependencies */,
@@ -3625,7 +3625,7 @@
 				INDEXING_DEPLOYMENT_LOCATION__YES = NO;
 				INDEXING_PROJECT_DIR__ = "$(INDEXING_PROJECT_DIR__NO)";
 				INDEXING_PROJECT_DIR__NO = "$(PROJECT_DIR)";
-				INDEXING_PROJECT_DIR__YES = "../../../../../bazel-output-base/rules_xcodeproj/indexbuild_output_base/execroot/rules_xcodeproj";
+				INDEXING_PROJECT_DIR__YES = "../../../../../bazel-output-base/rules_xcodeproj.noindex/indexbuild_output_base/execroot/rules_xcodeproj";
 				INDEX_FORCE_SCRIPT_EXECUTION = YES;
 				INSTALL_PATH = "$(BAZEL_PACKAGE_BIN_DIR)/$(TARGET_NAME)/bin";
 				INTERNAL_DIR = "$(PROJECT_FILE_PATH)/rules_xcodeproj";
@@ -4001,7 +4001,7 @@
 				INDEXING_DEPLOYMENT_LOCATION__YES = NO;
 				INDEXING_PROJECT_DIR__ = "$(INDEXING_PROJECT_DIR__NO)";
 				INDEXING_PROJECT_DIR__NO = "$(PROJECT_DIR)";
-				INDEXING_PROJECT_DIR__YES = "../../../../../bazel-output-base/rules_xcodeproj/indexbuild_output_base/execroot/rules_xcodeproj";
+				INDEXING_PROJECT_DIR__YES = "../../../../../bazel-output-base/rules_xcodeproj.noindex/indexbuild_output_base/execroot/rules_xcodeproj";
 				INDEX_FORCE_SCRIPT_EXECUTION = YES;
 				INSTALL_PATH = "$(BAZEL_PACKAGE_BIN_DIR)/$(TARGET_NAME)/bin";
 				INTERNAL_DIR = "$(PROJECT_FILE_PATH)/rules_xcodeproj";
@@ -4317,7 +4317,7 @@
 				INDEXING_DEPLOYMENT_LOCATION__YES = NO;
 				INDEXING_PROJECT_DIR__ = "$(INDEXING_PROJECT_DIR__NO)";
 				INDEXING_PROJECT_DIR__NO = "$(PROJECT_DIR)";
-				INDEXING_PROJECT_DIR__YES = "../../../../../bazel-output-base/rules_xcodeproj/indexbuild_output_base/execroot/rules_xcodeproj";
+				INDEXING_PROJECT_DIR__YES = "../../../../../bazel-output-base/rules_xcodeproj.noindex/indexbuild_output_base/execroot/rules_xcodeproj";
 				INDEX_FORCE_SCRIPT_EXECUTION = YES;
 				INSTALL_PATH = "$(BAZEL_PACKAGE_BIN_DIR)/$(TARGET_NAME)/bin";
 				INTERNAL_DIR = "$(PROJECT_FILE_PATH)/rules_xcodeproj";

--- a/xcodeproj/internal/bazel_integration_files/import_indexstores.sh
+++ b/xcodeproj/internal/bazel_integration_files/import_indexstores.sh
@@ -37,7 +37,7 @@ fi
 
 # We only support importing indexes built with rules_xcodeproj, and we override
 # our output bases, so we know the the ending of the execution root
-readonly execution_root_regex='.*/[^/]+/(?:_)?rules_xcodeproj/[^/]+_output_base/execroot/[^/]+'
+readonly execution_root_regex='.*/[^/]+/(?:_)?rules_xcodeproj(?:\.noindex)?/[^/]+_output_base/execroot/[^/]+'
 
 # We remove any `/private` prefix from the current execution_root, since it's
 # removed in the Project navigator.

--- a/xcodeproj/internal/installer.template.sh
+++ b/xcodeproj/internal/installer.template.sh
@@ -221,7 +221,7 @@ if [[ -f "$dest/rules_xcodeproj/generated.xcfilelist" ]]; then
 
   readonly workspace_name="${execution_root##*/}"
   readonly output_base="${execution_root%/*/*}"
-  readonly nested_output_base="$output_base/rules_xcodeproj/build_output_base"
+  readonly nested_output_base="$output_base/rules_xcodeproj.noindex/build_output_base"
   readonly bazel_out="$nested_output_base/execroot/$workspace_name/bazel-out"
 
   # Create directory structure in bazel-out

--- a/xcodeproj/internal/runner.template.sh
+++ b/xcodeproj/internal/runner.template.sh
@@ -98,7 +98,7 @@ execution_root=$(<"$execution_root_file")
 installer_flags+=(--execution_root "$execution_root")
 
 readonly output_base="${execution_root%/*/*}"
-readonly nested_output_base="$output_base/rules_xcodeproj/build_output_base"
+readonly nested_output_base="$output_base/rules_xcodeproj.noindex/build_output_base"
 
 # Set bazel env
 %collect_bazel_env%


### PR DESCRIPTION
This allows Instruments to find the modified dSYM in Xcode’s DerivedData.