### PR TITLE
Stop calling `create_compilation_context` if no deps

### DIFF
--- a/xcodeproj/internal/compilation_providers.bzl
+++ b/xcodeproj/internal/compilation_providers.bzl
@@ -7,6 +7,9 @@ def _merge_cc_compilation_context(
     if not direct_compilation_context:
         return None
 
+    if not compilation_contexts:
+        return direct_compilation_context
+
     return cc_common.create_compilation_context(
         # Maybe not correct, but we don't use this value in `opts.bzl`, so not
         # worth the computation to merge it


### PR DESCRIPTION
It’s expensive (CPU and memory) to create compilation contexts if they aren’t needed.