### PR TITLE
[DO NOT REVIEW] Repro for missing rules_ios files during indexing

### DIFF
--- a/examples/rules_ios/iOSApp/Source/UtilsSwift/BUILD
+++ b/examples/rules_ios/iOSApp/Source/UtilsSwift/BUILD
@@ -1,0 +1,21 @@
+load(
+    "@build_bazel_rules_ios//rules:framework.bzl",
+    rules_ios_apple_framework = "apple_framework",
+)
+
+rules_ios_apple_framework(
+    name = "UtilsSwift",
+    srcs = glob(
+        ["**/*.swift"],
+    ),
+    module_name = "UtilsSwift",
+    platforms = {
+        "ios": "15.0",
+    },
+    public_headers = [],
+    tags = ["manual"],
+    visibility = ["//iOSApp:__subpackages__"],
+    deps = [
+        "//iOSApp/Source/Utils:Utils",
+    ],
+)

--- a/examples/rules_ios/iOSApp/Source/UtilsSwift/UtilsSwift.swift
+++ b/examples/rules_ios/iOSApp/Source/UtilsSwift/UtilsSwift.swift
@@ -1,0 +1,12 @@
+import Foundation
+import Utils
+
+@objc
+public class UtilsSwift: NSObject {
+    
+    @objc
+    public
+    static func UtilsSwift() -> String {
+        "UtilsSwift"
+    }
+}

--- a/examples/rules_ios/iOSApp/Test/SwiftUnitTests/BUILD
+++ b/examples/rules_ios/iOSApp/Test/SwiftUnitTests/BUILD
@@ -12,5 +12,6 @@ rules_ios_ios_unit_test(
     deps = [
         "//iOSApp/Source:iOSApp.library",
         "//iOSApp/Source/Utils",
+        "//iOSApp/Source/UtilsSwift",
     ],
 )


### PR DESCRIPTION
**change**

add swift target that depends on objc


**Repro**
1. go to rules_ios example dir 
2. run `bazelisk clean --expunge`
3. run `rm -rf ~/Library/Developer/Xcode/DerivedData/rules_ios-[id]` to delete derived data for project if there is one 
4. `bazelisk run //:xcodeproj` 
5. open rules_ios.xcodeproj 
6. open `UtilsSwift.swift` file and see if index-compile works on index build logs

**Expected**
opening `UtilsSwift.swift` on Xcode shows index-compile succeeds 
<img width="2280" alt="Screenshot 2023-04-12 at 3 43 44 PM" src="https://user-images.githubusercontent.com/49507839/231602318-9c48162c-f68d-4434-a1d8-139565e6c3c8.png">

**Actual**
1. Checkout https://github.com/MobileNativeFoundation/rules_xcodeproj/pull/2016 and apply this change 
2. bzl run //:xcodeproj 
7. open `UtilsSwift.swift` and observe that index compile fails with error message "no such module Utils"


