### PR TITLE
Further improve `XcodeProjAutomaticTargetProcessingInfo` memory usage

### DIFF
--- a/docs/bazel.md
+++ b/docs/bazel.md
@@ -525,13 +525,12 @@ rules, then you will use these providers to communicate between them.
 ## XcodeProjAutomaticTargetProcessingInfo
 
 <pre>
-XcodeProjAutomaticTargetProcessingInfo(<a href="#XcodeProjAutomaticTargetProcessingInfo-all_attrs">all_attrs</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-alternate_icons">alternate_icons</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-app_icons">app_icons</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-args">args</a>,
-                                       <a href="#XcodeProjAutomaticTargetProcessingInfo-bazel_build_mode_error">bazel_build_mode_error</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-bundle_id">bundle_id</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-codesignopts">codesignopts</a>,
-                                       <a href="#XcodeProjAutomaticTargetProcessingInfo-collect_uncategorized_files">collect_uncategorized_files</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-deps">deps</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-entitlements">entitlements</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-env">env</a>,
-                                       <a href="#XcodeProjAutomaticTargetProcessingInfo-exported_symbols_lists">exported_symbols_lists</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-hdrs">hdrs</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-implementation_deps">implementation_deps</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-infoplists">infoplists</a>,
-                                       <a href="#XcodeProjAutomaticTargetProcessingInfo-launchdplists">launchdplists</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-link_mnemonics">link_mnemonics</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-non_arc_srcs">non_arc_srcs</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-pch">pch</a>,
-                                       <a href="#XcodeProjAutomaticTargetProcessingInfo-provisioning_profile">provisioning_profile</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-should_generate_target">should_generate_target</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-srcs">srcs</a>,
-                                       <a href="#XcodeProjAutomaticTargetProcessingInfo-target_type">target_type</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-xcode_targets">xcode_targets</a>)
+XcodeProjAutomaticTargetProcessingInfo(<a href="#XcodeProjAutomaticTargetProcessingInfo-alternate_icons">alternate_icons</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-app_icons">app_icons</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-args">args</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-bazel_build_mode_error">bazel_build_mode_error</a>,
+                                       <a href="#XcodeProjAutomaticTargetProcessingInfo-bundle_id">bundle_id</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-codesignopts">codesignopts</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-collect_uncategorized_files">collect_uncategorized_files</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-deps">deps</a>,
+                                       <a href="#XcodeProjAutomaticTargetProcessingInfo-entitlements">entitlements</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-env">env</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-exported_symbols_lists">exported_symbols_lists</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-hdrs">hdrs</a>,
+                                       <a href="#XcodeProjAutomaticTargetProcessingInfo-implementation_deps">implementation_deps</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-infoplists">infoplists</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-launchdplists">launchdplists</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-link_mnemonics">link_mnemonics</a>,
+                                       <a href="#XcodeProjAutomaticTargetProcessingInfo-non_arc_srcs">non_arc_srcs</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-pch">pch</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-provisioning_profile">provisioning_profile</a>,
+                                       <a href="#XcodeProjAutomaticTargetProcessingInfo-should_generate_target">should_generate_target</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-srcs">srcs</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-target_type">target_type</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-xcode_targets">xcode_targets</a>)
 </pre>
 
 Provides needed information about a target to allow rules_xcodeproj to
@@ -550,7 +549,6 @@ stabilizing it.
 
 | Name  | Description |
 | :------------- | :------------- |
-| <a id="XcodeProjAutomaticTargetProcessingInfo-all_attrs"></a>all_attrs |  -    |
 | <a id="XcodeProjAutomaticTargetProcessingInfo-alternate_icons"></a>alternate_icons |  An attribute name (or <code>None</code>) to collect the application alternate icons.    |
 | <a id="XcodeProjAutomaticTargetProcessingInfo-app_icons"></a>app_icons |  An attribute name (or <code>None</code>) to collect the application icons.    |
 | <a id="XcodeProjAutomaticTargetProcessingInfo-args"></a>args |  A <code>List</code> (or <code>None</code>) representing the command line arguments that this target should execute or test with.    |

--- a/xcodeproj/internal/default_automatic_target_processing_aspect.bzl
+++ b/xcodeproj/internal/default_automatic_target_processing_aspect.bzl
@@ -2,7 +2,6 @@
 
 load(
     "@build_bazel_rules_apple//apple:providers.bzl",
-    "AppleBinaryInfo",
     "AppleBundleInfo",
     "AppleFrameworkImportInfo",
     "AppleResourceBundleInfo",
@@ -160,6 +159,7 @@ def _default_automatic_target_processing_aspect_impl(target, ctx):
         xcode_targets = _SWIFT_LIBRARY_XCODE_TARGETS
     elif rule_kind == "apple_resource_bundle":
         should_generate_target = False
+
         # Ideally this would be exposed on `AppleResourceBundleInfo`
         bundle_id = "bundle_id"
         infoplists = _INFOPLISTS_ATTRS

--- a/xcodeproj/internal/input_files.bzl
+++ b/xcodeproj/internal/input_files.bzl
@@ -95,6 +95,7 @@ def _collect_input_files(
     Args:
         ctx: The aspect context.
         target: The `Target` to collect inputs from.
+        attrs: `dir(ctx.rule.attr)` (as a performance optimization).
         unfocused: Whether the target is unfocused. If `None`, it will be
             determined automatically (this should only be the case for
             `non_xcode_target`s).

--- a/xcodeproj/internal/input_files.bzl
+++ b/xcodeproj/internal/input_files.bzl
@@ -78,6 +78,7 @@ def _collect_input_files(
         *,
         ctx,
         target,
+        attrs,
         unfocused = False,
         id,
         platform,
@@ -298,7 +299,7 @@ def _collect_input_files(
 
         _handle_file(getattr(ctx.rule.file, attr), handler = handler)
 
-    for attr in automatic_target_info.all_attrs:
+    for attr in attrs:
         if _should_ignore_input_attr(attr):
             continue
 
@@ -306,7 +307,7 @@ def _collect_input_files(
             # Only attributes in `file_handlers` are categorized
             continue
 
-        dep = getattr(ctx.rule.attr, attr, None)
+        dep = getattr(ctx.rule.attr, attr)
 
         dep_type = type(dep)
         if dep_type == "Target":

--- a/xcodeproj/internal/library_targets.bzl
+++ b/xcodeproj/internal/library_targets.bzl
@@ -29,6 +29,7 @@ def process_library_target(
         ctx,
         build_mode,
         target,
+        attrs,
         automatic_target_info,
         transitive_infos):
     """Gathers information about a library target.
@@ -37,6 +38,7 @@ def process_library_target(
         ctx: The aspect context.
         build_mode: See `xcodeproj.build_mode`.
         target: The `Target` to process.
+        attrs: `dir(ctx.rule.attr)` (as a performance optimization).
         automatic_target_info: The `XcodeProjAutomaticTargetProcessingInfo` for
             `target`.
         transitive_infos: A `list` of `depset`s of `XcodeProjInfo`s from the
@@ -114,6 +116,7 @@ def process_library_target(
     inputs = input_files.collect(
         ctx = ctx,
         target = target,
+        attrs = attrs,
         id = id,
         platform = platform,
         is_bundle = False,

--- a/xcodeproj/internal/non_xcode_targets.bzl
+++ b/xcodeproj/internal/non_xcode_targets.bzl
@@ -25,6 +25,7 @@ def process_non_xcode_target(
         *,
         ctx,
         target,
+        attrs,
         automatic_target_info,
         transitive_infos):
     """Gathers information about a non-Xcode target.
@@ -32,6 +33,7 @@ def process_non_xcode_target(
     Args:
         ctx: The aspect context.
         target: The `Target` to process.
+        attrs: `dir(ctx.rule.attr)` (as a performance optimization).
         automatic_target_info: The `XcodeProjAutomaticTargetProcessingInfo` for
             `target`.
         transitive_infos: A `list` of `depset`s of `XcodeProjInfo`s from the
@@ -120,6 +122,7 @@ rules_xcodeproj requires {} to have `{}` set.
         inputs = input_files.collect(
             ctx = ctx,
             target = target,
+            attrs = attrs,
             unfocused = None,
             id = None,
             platform = None,

--- a/xcodeproj/internal/providers.bzl
+++ b/xcodeproj/internal/providers.bzl
@@ -13,7 +13,6 @@ future. If you are using this provider, please let us know so we can prioritize
 stabilizing it.
 """,
     fields = {
-        "all_attrs": "",
         "alternate_icons": """\
 An attribute name (or `None`) to collect the application alternate icons.
 """,
@@ -21,8 +20,8 @@ An attribute name (or `None`) to collect the application alternate icons.
 An attribute name (or `None`) to collect the application icons.
 """,
         "args": """\
-A `List` (or `None`) representing the command line arguments that this target should execute or
-test with.
+A `List` (or `None`) representing the command line arguments that this target
+should execute or test with.
 """,
         "bazel_build_mode_error": """\
 If `build_mode = "bazel"`, then if this is non-`None`, it will be raised as an
@@ -46,8 +45,8 @@ An attribute name (or `None`) to collect `File`s from for the
 `entitlements`-like attribute.
 """,
         "env": """\
-A `dict` representing the environment variables that this target should execute or
-test with.
+A `dict` representing the environment variables that this target should execute
+or test with.
 """,
         "exported_symbols_lists": """\
 A sequence of attribute names to collect `File`s from for the
@@ -66,8 +65,8 @@ A sequence of attribute names to collect `File`s from for the `infoplists`-like
 attributes.
 """,
         "launchdplists": """\
-A sequence of attribute names to collect `File`s from for the `launchdplists`-like
-attributes.
+A sequence of attribute names to collect `File`s from for the
+`launchdplists`-like attributes.
 """,
         "link_mnemonics": """\
 A sequence of mnemonic (action) names to gather link parameters. The first

--- a/xcodeproj/internal/provisioning_profiles.bzl
+++ b/xcodeproj/internal/provisioning_profiles.bzl
@@ -9,7 +9,7 @@ load(":providers.bzl", "XcodeProjProvisioningProfileInfo")
 
 def _process_attr(*, ctx, automatic_target_info, build_settings):
     attr = automatic_target_info.provisioning_profile
-    if not attr:
+    if not attr or not hasattr(ctx.rule.attr, attr):
         return
 
     provisioning_profile_target = getattr(ctx.rule.attr, attr)

--- a/xcodeproj/internal/top_level_targets.bzl
+++ b/xcodeproj/internal/top_level_targets.bzl
@@ -160,6 +160,7 @@ def process_top_level_target(
         ctx,
         build_mode,
         target,
+        attrs,
         automatic_target_info,
         bundle_info,
         transitive_infos):
@@ -169,6 +170,7 @@ def process_top_level_target(
         ctx: The aspect context.
         build_mode: See `xcodeproj.build_mode`.
         target: The `Target` to process.
+        attrs: `dir(ctx.rule.attr)` (as a performance optimization).
         automatic_target_info: The `XcodeProjAutomaticTargetProcessingInfo` for
             `target`.
         bundle_info: The `AppleBundleInfo` provider for `target`, or `None`.
@@ -370,6 +372,7 @@ def process_top_level_target(
     inputs = input_files.collect(
         ctx = ctx,
         target = target,
+        attrs = attrs,
         id = id,
         platform = platform,
         is_bundle = is_bundle,

--- a/xcodeproj/internal/xcodeproj_aspect.bzl
+++ b/xcodeproj/internal/xcodeproj_aspect.bzl
@@ -29,14 +29,14 @@ def _should_ignore_attr(attr):
         attr in _IGNORE_ATTR
     )
 
-def _transitive_infos(*, ctx, automatic_target_info):
+def _transitive_infos(*, ctx, attrs):
     transitive_infos = []
 
     # TODO: Have `XcodeProjAutomaticTargetProcessingInfo` tell us which
     # attributes to look at. About 7% of an example pprof trace is spent on
     # `_should_ignore_attr` and the type checks below. If we had a list of
     # attributes with the types (list or not) we could eliminate that overhead.
-    for attr in automatic_target_info.all_attrs:
+    for attr in attrs:
         if _should_ignore_attr(attr):
             continue
 
@@ -62,15 +62,15 @@ def _xcodeproj_aspect_impl(target, ctx):
     if XcodeProjInfo not in target:
         # Only create an `XcodeProjInfo` if the target hasn't already created
         # one
+        attrs = dir(ctx.rule.attr)
         info = create_xcodeprojinfo(
             ctx = ctx,
             build_mode = ctx.attr._build_mode,
             target = target,
+            attrs = attrs,
             transitive_infos = _transitive_infos(
                 ctx = ctx,
-                automatic_target_info = (
-                    target[XcodeProjAutomaticTargetProcessingInfo]
-                ),
+                attrs = attrs,
             ),
         )
         if info:

--- a/xcodeproj/internal/xcodeproj_aspect.bzl
+++ b/xcodeproj/internal/xcodeproj_aspect.bzl
@@ -7,7 +7,6 @@ load(
 )
 load(
     ":providers.bzl",
-    "XcodeProjAutomaticTargetProcessingInfo",
     "XcodeProjInfo",
     "XcodeProjProvisioningProfileInfo",
 )

--- a/xcodeproj/internal/xcodeprojinfo.bzl
+++ b/xcodeproj/internal/xcodeprojinfo.bzl
@@ -380,6 +380,7 @@ def _create_xcodeprojinfo(
         ctx,
         build_mode,
         target,
+        attrs,
         transitive_infos,
         automatic_target_info):
     """Creates the target portion of an `XcodeProjInfo` for a `Target`.
@@ -388,6 +389,7 @@ def _create_xcodeprojinfo(
         ctx: The aspect context.
         build_mode: See `xcodeproj.build_mode`.
         target: The `Target` to process.
+        attrs: `dir(ctx.rule.attr)` (as a performance optimization).
         automatic_target_info: The `XcodeProjAutomaticTargetProcessingInfo` for
             `target`.
         transitive_infos: A `list` of `XcodeProjInfo`s from the transitive
@@ -407,6 +409,7 @@ def _create_xcodeprojinfo(
         processed_target = process_non_xcode_target(
             ctx = ctx,
             target = target,
+            attrs = attrs,
             automatic_target_info = automatic_target_info,
             transitive_infos = transitive_infos,
         )
@@ -415,6 +418,7 @@ def _create_xcodeprojinfo(
             ctx = ctx,
             build_mode = build_mode,
             target = target,
+            attrs = attrs,
             automatic_target_info = automatic_target_info,
             bundle_info = target[AppleBundleInfo],
             transitive_infos = transitive_infos,
@@ -424,6 +428,7 @@ def _create_xcodeprojinfo(
             ctx = ctx,
             build_mode = build_mode,
             target = target,
+            attrs = attrs,
             automatic_target_info = automatic_target_info,
             bundle_info = None,
             transitive_infos = transitive_infos,
@@ -433,6 +438,7 @@ def _create_xcodeprojinfo(
             ctx = ctx,
             build_mode = build_mode,
             target = target,
+            attrs = attrs,
             automatic_target_info = automatic_target_info,
             transitive_infos = transitive_infos,
         )
@@ -544,12 +550,13 @@ def _create_xcodeprojinfo(
 
 # API
 
-def create_xcodeprojinfo(*, ctx, build_mode, target, transitive_infos):
+def create_xcodeprojinfo(*, ctx, build_mode, target, attrs, transitive_infos):
     """Creates an `XcodeProjInfo` for the given target.
 
     Args:
         ctx: The aspect context.
         build_mode: See `xcodeproj.build_mode`.
+        attrs: `dir(ctx.rule.attr)` (as a performance optimization).
         target: The `Target` to process.
         transitive_infos: A `list` of `XcodeProjInfo`s from the transitive
             dependencies of `target`.
@@ -578,6 +585,7 @@ def create_xcodeprojinfo(*, ctx, build_mode, target, transitive_infos):
             ctx = ctx,
             build_mode = build_mode,
             target = target,
+            attrs = attrs,
             automatic_target_info = automatic_target_info,
             transitive_infos = transitive_infos,
         )


### PR DESCRIPTION
The next step will be to remove the aspect and instead calculate this information if a different provider doesn’t exist that gives it to us. We don’t need this information to go to downstream targets, so we don’t need to hold onto its memory.