### PR TITLE
Remove `default_automatic_target_processing_aspect` aspect

### DIFF
--- a/xcodeproj/internal/automatic_target_info.bzl
+++ b/xcodeproj/internal/automatic_target_info.bzl
@@ -1,4 +1,4 @@
-"""Implementation of the `default_automatic_target_processing_aspect` aspect."""
+"""Functions for calculating automatic target info."""
 
 load(
     "@build_bazel_rules_apple//apple:providers.bzl",
@@ -113,9 +113,18 @@ _DEFAULT_XCODE_TARGETS = {
 
 _EMPTY_LIST = []
 
-def _default_automatic_target_processing_aspect_impl(target, ctx):
+def calculate_automatic_target_info(ctx, target):
+    """Calculates the automatic target info for the given target.
+
+    Args:
+        ctx: The aspect context.
+        target: The `Target` to calculate the automatic target info for.
+
+    Returns:
+        A `XcodeProjAutomaticTargetProcessingInfo` provider.
+    """
     if XcodeProjAutomaticTargetProcessingInfo in target:
-        return []
+        return target[XcodeProjAutomaticTargetProcessingInfo]
 
     this_target_type = _get_target_type(target = target)
 
@@ -228,35 +237,28 @@ def _default_automatic_target_processing_aspect_impl(target, ctx):
                 should_generate_target = False
                 break
 
-    return [
-        XcodeProjAutomaticTargetProcessingInfo(
-            alternate_icons = alternate_icons,
-            app_icons = app_icons,
-            args = args,
-            bazel_build_mode_error = bazel_build_mode_error,
-            bundle_id = bundle_id,
-            codesignopts = codesignopts,
-            collect_uncategorized_files = collect_uncategorized_files,
-            deps = deps,
-            entitlements = entitlements,
-            env = env,
-            exported_symbols_lists = exported_symbols_lists,
-            hdrs = hdrs,
-            infoplists = infoplists,
-            implementation_deps = implementation_deps,
-            launchdplists = launchdplists,
-            link_mnemonics = link_mnemonics,
-            non_arc_srcs = non_arc_srcs,
-            pch = pch,
-            provisioning_profile = provisioning_profile,
-            should_generate_target = should_generate_target,
-            srcs = srcs,
-            target_type = this_target_type,
-            xcode_targets = xcode_targets,
-        ),
-    ]
-
-default_automatic_target_processing_aspect = aspect(
-    implementation = _default_automatic_target_processing_aspect_impl,
-    attr_aspects = ["*"],
-)
+    return XcodeProjAutomaticTargetProcessingInfo(
+        alternate_icons = alternate_icons,
+        app_icons = app_icons,
+        args = args,
+        bazel_build_mode_error = bazel_build_mode_error,
+        bundle_id = bundle_id,
+        codesignopts = codesignopts,
+        collect_uncategorized_files = collect_uncategorized_files,
+        deps = deps,
+        entitlements = entitlements,
+        env = env,
+        exported_symbols_lists = exported_symbols_lists,
+        hdrs = hdrs,
+        infoplists = infoplists,
+        implementation_deps = implementation_deps,
+        launchdplists = launchdplists,
+        link_mnemonics = link_mnemonics,
+        non_arc_srcs = non_arc_srcs,
+        pch = pch,
+        provisioning_profile = provisioning_profile,
+        should_generate_target = should_generate_target,
+        srcs = srcs,
+        target_type = this_target_type,
+        xcode_targets = xcode_targets,
+    )

--- a/xcodeproj/internal/xcodeproj_aspect.bzl
+++ b/xcodeproj/internal/xcodeproj_aspect.bzl
@@ -2,10 +2,6 @@
 
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "use_cpp_toolchain")
 load(
-    ":default_automatic_target_processing_aspect.bzl",
-    "default_automatic_target_processing_aspect",
-)
-load(
     ":providers.bzl",
     "XcodeProjInfo",
     "XcodeProjProvisioningProfileInfo",
@@ -101,6 +97,5 @@ def make_xcodeproj_aspect(*, build_mode):
             ),
         },
         fragments = ["apple", "cpp", "objc"],
-        requires = [default_automatic_target_processing_aspect],
         toolchains = use_cpp_toolchain(),
     )

--- a/xcodeproj/internal/xcodeprojinfo.bzl
+++ b/xcodeproj/internal/xcodeprojinfo.bzl
@@ -7,6 +7,7 @@ load(
     "AppleBinaryInfo",
     "AppleBundleInfo",
 )
+load(":automatic_target_info.bzl", "calculate_automatic_target_info")
 load(":compilation_providers.bzl", comp_providers = "compilation_providers")
 load(":input_files.bzl", "input_files")
 load(":library_targets.bzl", "process_library_target")
@@ -15,7 +16,6 @@ load(":non_xcode_targets.bzl", "process_non_xcode_target")
 load(":output_files.bzl", "output_files")
 load(
     ":providers.bzl",
-    "XcodeProjAutomaticTargetProcessingInfo",
     "XcodeProjInfo",
     "target_type",
 )
@@ -565,7 +565,10 @@ def create_xcodeprojinfo(*, ctx, build_mode, target, attrs, transitive_infos):
         An `XcodeProjInfo` populated with information from `target` and
         `transitive_infos`.
     """
-    automatic_target_info = target[XcodeProjAutomaticTargetProcessingInfo]
+    automatic_target_info = calculate_automatic_target_info(
+        ctx = ctx,
+        target = target,
+    )
 
     if _should_skip_target(ctx = ctx, target = target):
         info_fields = _skip_target(


### PR DESCRIPTION
We don’t need to propagate (and thus retain) the `XcodeProjAutomaticTargetProcessingInfo` provider.