### PR TITLE
Remove `platform_info.is_same_type` check

### DIFF
--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSApp.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSApp.xcscheme
@@ -92,9 +92,37 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1EF2B99D58C7884FED2A0769"
+               BuildableName = "LibFramework.watchOS.framework"
+               BlueprintName = "LibFramework.watchOS"
+               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "4CFF47C3FBF2E6C24127D667"
                BuildableName = "UIFramework.iOS.framework"
                BlueprintName = "UIFramework.iOS"
+               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F619A1189B9E946F6BE02A2F"
+               BuildableName = "UIFramework.watchOS.framework"
+               BlueprintName = "UIFramework.watchOS"
                ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSAppObjCUnitTests.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSAppObjCUnitTests.xcscheme
@@ -106,9 +106,37 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1EF2B99D58C7884FED2A0769"
+               BuildableName = "LibFramework.watchOS.framework"
+               BlueprintName = "LibFramework.watchOS"
+               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "4CFF47C3FBF2E6C24127D667"
                BuildableName = "UIFramework.iOS.framework"
                BlueprintName = "UIFramework.iOS"
+               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F619A1189B9E946F6BE02A2F"
+               BuildableName = "UIFramework.watchOS.framework"
+               BlueprintName = "UIFramework.watchOS"
                ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSAppSwiftUnitTests.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSAppSwiftUnitTests.xcscheme
@@ -106,9 +106,37 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1EF2B99D58C7884FED2A0769"
+               BuildableName = "LibFramework.watchOS.framework"
+               BlueprintName = "LibFramework.watchOS"
+               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "4CFF47C3FBF2E6C24127D667"
                BuildableName = "UIFramework.iOS.framework"
                BlueprintName = "UIFramework.iOS"
+               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F619A1189B9E946F6BE02A2F"
+               BuildableName = "UIFramework.watchOS.framework"
+               BlueprintName = "UIFramework.watchOS"
                ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSAppSwiftUnitTests_CommandLineArgs_Scheme.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSAppSwiftUnitTests_CommandLineArgs_Scheme.xcscheme
@@ -106,9 +106,37 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1EF2B99D58C7884FED2A0769"
+               BuildableName = "LibFramework.watchOS.framework"
+               BlueprintName = "LibFramework.watchOS"
+               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "4CFF47C3FBF2E6C24127D667"
                BuildableName = "UIFramework.iOS.framework"
                BlueprintName = "UIFramework.iOS"
+               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F619A1189B9E946F6BE02A2F"
+               BuildableName = "UIFramework.watchOS.framework"
+               BlueprintName = "UIFramework.watchOS"
                ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSAppUnitTests_Scheme.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSAppUnitTests_Scheme.xcscheme
@@ -136,9 +136,37 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1EF2B99D58C7884FED2A0769"
+               BuildableName = "LibFramework.watchOS.framework"
+               BlueprintName = "LibFramework.watchOS"
+               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "4CFF47C3FBF2E6C24127D667"
                BuildableName = "UIFramework.iOS.framework"
                BlueprintName = "UIFramework.iOS"
+               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F619A1189B9E946F6BE02A2F"
+               BuildableName = "UIFramework.watchOS.framework"
+               BlueprintName = "UIFramework.watchOS"
                ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>

--- a/examples/integration/test/fixtures/bwb_targets_spec.json
+++ b/examples/integration/test/fixtures/bwb_targets_spec.json
@@ -6128,6 +6128,8 @@
         },
         "6": "bazel-out/darwin_x86_64-dbg-STABLE-0/bin/external/rules_xcodeproj_generated/generator/test/fixtures/xcodeproj_bwb/xcodeproj_bwb-params/iOSApp.65.link.params",
         "7": [
+            "//Lib:LibFramework.watchOS applebin_watchos-watchos_arm64_32-dbg-STABLE-18",
+            "//UI:UIFramework.watchOS applebin_watchos-watchos_arm64_32-dbg-STABLE-18",
             "//WidgetExtension:WidgetExtension applebin_ios-ios_arm64-dbg-STABLE-14",
             "//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC applebin_ios-ios_arm64-dbg-STABLE-14",
             "//UI:UIFramework.iOS applebin_ios-ios_arm64-dbg-STABLE-14"
@@ -6252,6 +6254,8 @@
         },
         "6": "bazel-out/darwin_x86_64-dbg-STABLE-0/bin/external/rules_xcodeproj_generated/generator/test/fixtures/xcodeproj_bwb/xcodeproj_bwb-params/iOSApp.138.link.params",
         "7": [
+            "//Lib:LibFramework.watchOS applebin_watchos-watchos_arm64_32-opt-STABLE-20",
+            "//UI:UIFramework.watchOS applebin_watchos-watchos_arm64_32-opt-STABLE-20",
             "//WidgetExtension:WidgetExtension applebin_ios-ios_arm64-opt-STABLE-16",
             "//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC applebin_ios-ios_arm64-opt-STABLE-16",
             "//UI:UIFramework.iOS applebin_ios-ios_arm64-opt-STABLE-16"
@@ -6378,6 +6382,8 @@
         },
         "6": "bazel-out/darwin_x86_64-dbg-STABLE-0/bin/external/rules_xcodeproj_generated/generator/test/fixtures/xcodeproj_bwb/xcodeproj_bwb-params/iOSApp.12.link.params",
         "7": [
+            "//Lib:LibFramework.watchOS applebin_watchos-watchos_x86_64-dbg-STABLE-17",
+            "//UI:UIFramework.watchOS applebin_watchos-watchos_x86_64-dbg-STABLE-17",
             "//WidgetExtension:WidgetExtension applebin_ios-ios_x86_64-dbg-STABLE-13",
             "//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC applebin_ios-ios_x86_64-dbg-STABLE-13",
             "//UI:UIFramework.iOS applebin_ios-ios_x86_64-dbg-STABLE-13"
@@ -6501,6 +6507,8 @@
         },
         "6": "bazel-out/darwin_x86_64-dbg-STABLE-0/bin/external/rules_xcodeproj_generated/generator/test/fixtures/xcodeproj_bwb/xcodeproj_bwb-params/iOSApp.85.link.params",
         "7": [
+            "//Lib:LibFramework.watchOS applebin_watchos-watchos_x86_64-opt-STABLE-19",
+            "//UI:UIFramework.watchOS applebin_watchos-watchos_x86_64-opt-STABLE-19",
             "//WidgetExtension:WidgetExtension applebin_ios-ios_x86_64-opt-STABLE-15",
             "//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC applebin_ios-ios_x86_64-opt-STABLE-15",
             "//UI:UIFramework.iOS applebin_ios-ios_x86_64-opt-STABLE-15"
@@ -6625,6 +6633,8 @@
         },
         "6": "bazel-out/darwin_x86_64-dbg-STABLE-0/bin/external/rules_xcodeproj_generated/generator/test/fixtures/xcodeproj_bwb/xcodeproj_bwb-params/iOSAppObjCUnitTests.23.link.params",
         "7": [
+            "//Lib:LibFramework.watchOS applebin_watchos-watchos_x86_64-dbg-STABLE-17",
+            "//UI:UIFramework.watchOS applebin_watchos-watchos_x86_64-dbg-STABLE-17",
             "//WidgetExtension:WidgetExtension applebin_ios-ios_x86_64-dbg-STABLE-13",
             "//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC applebin_ios-ios_x86_64-dbg-STABLE-13",
             "//UI:UIFramework.iOS applebin_ios-ios_x86_64-dbg-STABLE-13",
@@ -6718,6 +6728,8 @@
         },
         "6": "bazel-out/darwin_x86_64-dbg-STABLE-0/bin/external/rules_xcodeproj_generated/generator/test/fixtures/xcodeproj_bwb/xcodeproj_bwb-params/iOSAppObjCUnitTests.96.link.params",
         "7": [
+            "//Lib:LibFramework.watchOS applebin_watchos-watchos_x86_64-opt-STABLE-19",
+            "//UI:UIFramework.watchOS applebin_watchos-watchos_x86_64-opt-STABLE-19",
             "//WidgetExtension:WidgetExtension applebin_ios-ios_x86_64-opt-STABLE-15",
             "//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC applebin_ios-ios_x86_64-opt-STABLE-15",
             "//UI:UIFramework.iOS applebin_ios-ios_x86_64-opt-STABLE-15",
@@ -6815,6 +6827,8 @@
         },
         "6": "bazel-out/darwin_x86_64-dbg-STABLE-0/bin/external/rules_xcodeproj_generated/generator/test/fixtures/xcodeproj_bwb/xcodeproj_bwb-params/iOSAppSwiftUnitTests.27.link.params",
         "7": [
+            "//Lib:LibFramework.watchOS applebin_watchos-watchos_x86_64-dbg-STABLE-17",
+            "//UI:UIFramework.watchOS applebin_watchos-watchos_x86_64-dbg-STABLE-17",
             "//WidgetExtension:WidgetExtension applebin_ios-ios_x86_64-dbg-STABLE-13",
             "//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC applebin_ios-ios_x86_64-dbg-STABLE-13",
             "//UI:UIFramework.iOS applebin_ios-ios_x86_64-dbg-STABLE-13",
@@ -6916,6 +6930,8 @@
         },
         "6": "bazel-out/darwin_x86_64-dbg-STABLE-0/bin/external/rules_xcodeproj_generated/generator/test/fixtures/xcodeproj_bwb/xcodeproj_bwb-params/iOSAppSwiftUnitTests.100.link.params",
         "7": [
+            "//Lib:LibFramework.watchOS applebin_watchos-watchos_x86_64-opt-STABLE-19",
+            "//UI:UIFramework.watchOS applebin_watchos-watchos_x86_64-opt-STABLE-19",
             "//WidgetExtension:WidgetExtension applebin_ios-ios_x86_64-opt-STABLE-15",
             "//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC applebin_ios-ios_x86_64-opt-STABLE-15",
             "//UI:UIFramework.iOS applebin_ios-ios_x86_64-opt-STABLE-15",

--- a/xcodeproj/internal/platform.bzl
+++ b/xcodeproj/internal/platform.bzl
@@ -41,10 +41,6 @@ def _is_platform_type(platform, platform_type):
     """
     return platform._platform.platform_type == platform_type
 
-def _is_same_type(lhs, rhs):
-    """Returns whether two platforms are the same platform type."""
-    return lhs._platform.platform_type == rhs._platform.platform_type
-
 def _platform_to_dto(platform):
     """Generates a target DTO value for a platform.
 
@@ -120,7 +116,6 @@ def _platform_to_lldb_context_triple(platform):
 platform_info = struct(
     collect = _collect_platform,
     is_platform_type = _is_platform_type,
-    is_same_type = _is_same_type,
     to_dto = _platform_to_dto,
     to_lldb_context_triple = _platform_to_lldb_context_triple,
     to_swift_triple = _platform_to_swift_triple,

--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -118,8 +118,6 @@ def _get_minimum_xcode_version(*, ctx):
 def _is_same_platform_swiftui_preview_target(*, platform, xcode_target):
     if not xcode_target:
         return False
-    if not platform_info.is_same_type(platform, xcode_target.platform):
-        return False
     return xcode_target.product.type in _SWIFTUI_PREVIEW_PRODUCT_TYPES
 
 def _process_dep(dep):


### PR DESCRIPTION
This means that in BwB mode, for iOS schemes that have watchOS framework dependencies, and `adjust_schemes_for_swiftui_previews = True` (the default), then those schemes will include those watchOS framework targets. This has minimal impact on build time (just some extra rsync for their outputs per-build), but it reduces critical-path analysis phase time.