### PR TITLE
Short circuit `_calculate_swiftui_preview_targets`

### DIFF
--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSApp.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSApp.xcscheme
@@ -64,6 +64,20 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "13A68B4984727F4B3DAE6AFB"
+               BuildableName = "AppClip.app"
+               BlueprintName = "AppClip"
+               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "7F21C434B520AB441229E270"
                BuildableName = "CoreUtilsObjC.framework"
                BlueprintName = "FrameworkCoreUtilsObjC"

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSAppObjCUnitTests.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSAppObjCUnitTests.xcscheme
@@ -64,6 +64,20 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "13A68B4984727F4B3DAE6AFB"
+               BuildableName = "AppClip.app"
+               BlueprintName = "AppClip"
+               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "7F21C434B520AB441229E270"
                BuildableName = "CoreUtilsObjC.framework"
                BlueprintName = "FrameworkCoreUtilsObjC"

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSAppSwiftUnitTests.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSAppSwiftUnitTests.xcscheme
@@ -64,6 +64,20 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "13A68B4984727F4B3DAE6AFB"
+               BuildableName = "AppClip.app"
+               BlueprintName = "AppClip"
+               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "7F21C434B520AB441229E270"
                BuildableName = "CoreUtilsObjC.framework"
                BlueprintName = "FrameworkCoreUtilsObjC"

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSAppSwiftUnitTests_CommandLineArgs_Scheme.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSAppSwiftUnitTests_CommandLineArgs_Scheme.xcscheme
@@ -64,6 +64,20 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "13A68B4984727F4B3DAE6AFB"
+               BuildableName = "AppClip.app"
+               BlueprintName = "AppClip"
+               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "7F21C434B520AB441229E270"
                BuildableName = "CoreUtilsObjC.framework"
                BlueprintName = "FrameworkCoreUtilsObjC"

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSAppUnitTests_Scheme.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSAppUnitTests_Scheme.xcscheme
@@ -80,6 +80,20 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "13A68B4984727F4B3DAE6AFB"
+               BuildableName = "AppClip.app"
+               BlueprintName = "AppClip"
+               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "7F21C434B520AB441229E270"
                BuildableName = "CoreUtilsObjC.framework"
                BlueprintName = "FrameworkCoreUtilsObjC"

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/macOSAppUITests.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/macOSAppUITests.xcscheme
@@ -64,20 +64,6 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "AE02B41E521B2C6360C30D20"
-               BuildableName = "macOSApp.app"
-               BlueprintName = "macOSApp"
-               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
                BlueprintIdentifier = "DBA520153E51B3D6E3103986"
                BuildableName = "macOSAppUITests.xctest"
                BlueprintName = "macOSAppUITests"

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/tvOSAppUITests.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/tvOSAppUITests.xcscheme
@@ -64,51 +64,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "C03F5C0CA2104493AE9E52C9"
-               BuildableName = "LibFramework.tvOS.framework"
-               BlueprintName = "LibFramework.tvOS"
-               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "ACEF2F653E0F6BEA37D2C7B6"
-               BuildableName = "tvOSApp.app"
-               BlueprintName = "tvOSApp"
-               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
                BlueprintIdentifier = "53852A3B10D473B77DE57F4D"
                BuildableName = "tvOSAppUITests.xctest"
                BlueprintName = "tvOSAppUITests"
-               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "A23C98B4BFB6C775689A2A7D"
-               BuildableName = "UIFramework.tvOS.framework"
-               BlueprintName = "UIFramework.tvOS"
                ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/watchOSAppUITests.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/watchOSAppUITests.xcscheme
@@ -64,34 +64,6 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "1EF2B99D58C7884FED2A0769"
-               BuildableName = "LibFramework.watchOS.framework"
-               BlueprintName = "LibFramework.watchOS"
-               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "F619A1189B9E946F6BE02A2F"
-               BuildableName = "UIFramework.watchOS.framework"
-               BlueprintName = "UIFramework.watchOS"
-               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
                BlueprintIdentifier = "CA1F809431EBB13936399836"
                BuildableName = "watchOSAppUITests.xctest"
                BlueprintName = "watchOSAppUITests"

--- a/examples/integration/test/fixtures/bwb_targets_spec.json
+++ b/examples/integration/test/fixtures/bwb_targets_spec.json
@@ -6128,6 +6128,7 @@
         },
         "6": "bazel-out/darwin_x86_64-dbg-STABLE-0/bin/external/rules_xcodeproj_generated/generator/test/fixtures/xcodeproj_bwb/xcodeproj_bwb-params/iOSApp.65.link.params",
         "7": [
+            "//AppClip:AppClip applebin_ios-ios_arm64-dbg-STABLE-14",
             "//WidgetExtension:WidgetExtension applebin_ios-ios_arm64-dbg-STABLE-14",
             "//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC applebin_ios-ios_arm64-dbg-STABLE-14",
             "//UI:UIFramework.iOS applebin_ios-ios_arm64-dbg-STABLE-14"
@@ -6252,6 +6253,7 @@
         },
         "6": "bazel-out/darwin_x86_64-dbg-STABLE-0/bin/external/rules_xcodeproj_generated/generator/test/fixtures/xcodeproj_bwb/xcodeproj_bwb-params/iOSApp.138.link.params",
         "7": [
+            "//AppClip:AppClip applebin_ios-ios_arm64-opt-STABLE-16",
             "//WidgetExtension:WidgetExtension applebin_ios-ios_arm64-opt-STABLE-16",
             "//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC applebin_ios-ios_arm64-opt-STABLE-16",
             "//UI:UIFramework.iOS applebin_ios-ios_arm64-opt-STABLE-16"
@@ -6378,6 +6380,7 @@
         },
         "6": "bazel-out/darwin_x86_64-dbg-STABLE-0/bin/external/rules_xcodeproj_generated/generator/test/fixtures/xcodeproj_bwb/xcodeproj_bwb-params/iOSApp.12.link.params",
         "7": [
+            "//AppClip:AppClip applebin_ios-ios_x86_64-dbg-STABLE-13",
             "//WidgetExtension:WidgetExtension applebin_ios-ios_x86_64-dbg-STABLE-13",
             "//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC applebin_ios-ios_x86_64-dbg-STABLE-13",
             "//UI:UIFramework.iOS applebin_ios-ios_x86_64-dbg-STABLE-13"
@@ -6501,6 +6504,7 @@
         },
         "6": "bazel-out/darwin_x86_64-dbg-STABLE-0/bin/external/rules_xcodeproj_generated/generator/test/fixtures/xcodeproj_bwb/xcodeproj_bwb-params/iOSApp.85.link.params",
         "7": [
+            "//AppClip:AppClip applebin_ios-ios_x86_64-opt-STABLE-15",
             "//WidgetExtension:WidgetExtension applebin_ios-ios_x86_64-opt-STABLE-15",
             "//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC applebin_ios-ios_x86_64-opt-STABLE-15",
             "//UI:UIFramework.iOS applebin_ios-ios_x86_64-opt-STABLE-15"
@@ -6625,6 +6629,7 @@
         },
         "6": "bazel-out/darwin_x86_64-dbg-STABLE-0/bin/external/rules_xcodeproj_generated/generator/test/fixtures/xcodeproj_bwb/xcodeproj_bwb-params/iOSAppObjCUnitTests.23.link.params",
         "7": [
+            "//AppClip:AppClip applebin_ios-ios_x86_64-dbg-STABLE-13",
             "//WidgetExtension:WidgetExtension applebin_ios-ios_x86_64-dbg-STABLE-13",
             "//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC applebin_ios-ios_x86_64-dbg-STABLE-13",
             "//UI:UIFramework.iOS applebin_ios-ios_x86_64-dbg-STABLE-13",
@@ -6718,6 +6723,7 @@
         },
         "6": "bazel-out/darwin_x86_64-dbg-STABLE-0/bin/external/rules_xcodeproj_generated/generator/test/fixtures/xcodeproj_bwb/xcodeproj_bwb-params/iOSAppObjCUnitTests.96.link.params",
         "7": [
+            "//AppClip:AppClip applebin_ios-ios_x86_64-opt-STABLE-15",
             "//WidgetExtension:WidgetExtension applebin_ios-ios_x86_64-opt-STABLE-15",
             "//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC applebin_ios-ios_x86_64-opt-STABLE-15",
             "//UI:UIFramework.iOS applebin_ios-ios_x86_64-opt-STABLE-15",
@@ -6815,6 +6821,7 @@
         },
         "6": "bazel-out/darwin_x86_64-dbg-STABLE-0/bin/external/rules_xcodeproj_generated/generator/test/fixtures/xcodeproj_bwb/xcodeproj_bwb-params/iOSAppSwiftUnitTests.27.link.params",
         "7": [
+            "//AppClip:AppClip applebin_ios-ios_x86_64-dbg-STABLE-13",
             "//WidgetExtension:WidgetExtension applebin_ios-ios_x86_64-dbg-STABLE-13",
             "//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC applebin_ios-ios_x86_64-dbg-STABLE-13",
             "//UI:UIFramework.iOS applebin_ios-ios_x86_64-dbg-STABLE-13",
@@ -6916,6 +6923,7 @@
         },
         "6": "bazel-out/darwin_x86_64-dbg-STABLE-0/bin/external/rules_xcodeproj_generated/generator/test/fixtures/xcodeproj_bwb/xcodeproj_bwb-params/iOSAppSwiftUnitTests.100.link.params",
         "7": [
+            "//AppClip:AppClip applebin_ios-ios_x86_64-opt-STABLE-15",
             "//WidgetExtension:WidgetExtension applebin_ios-ios_x86_64-opt-STABLE-15",
             "//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC applebin_ios-ios_x86_64-opt-STABLE-15",
             "//UI:UIFramework.iOS applebin_ios-ios_x86_64-opt-STABLE-15",
@@ -7333,9 +7341,6 @@
         },
         "4": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-31/bin/macOSApp/Test/UITests/rules_xcodeproj/macOSAppUITests.__internal__.__test_bundle/Info.plist",
         "6": "bazel-out/darwin_x86_64-dbg-STABLE-0/bin/external/rules_xcodeproj_generated/generator/test/fixtures/xcodeproj_bwb/xcodeproj_bwb-params/macOSAppUITests.29.link.params",
-        "7": [
-            "//macOSApp/Source:macOSApp applebin_macos-darwin_x86_64-dbg-STABLE-31"
-        ],
         "b": {
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-31/bin/macOSApp/Source/macOSApp.app.dSYM\"",
@@ -7405,9 +7410,6 @@
         },
         "4": "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-32/bin/macOSApp/Test/UITests/rules_xcodeproj/macOSAppUITests.__internal__.__test_bundle/Info.plist",
         "6": "bazel-out/darwin_x86_64-dbg-STABLE-0/bin/external/rules_xcodeproj_generated/generator/test/fixtures/xcodeproj_bwb/xcodeproj_bwb-params/macOSAppUITests.102.link.params",
-        "7": [
-            "//macOSApp/Source:macOSApp applebin_macos-darwin_x86_64-opt-STABLE-32"
-        ],
         "b": {
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-32/bin/macOSApp/Source/macOSApp.app.dSYM\"",
@@ -7826,11 +7828,6 @@
         },
         "4": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-25/bin/tvOSApp/Test/UITests/rules_xcodeproj/tvOSAppUITests.__internal__.__test_bundle/Info.plist",
         "6": "bazel-out/darwin_x86_64-dbg-STABLE-0/bin/external/rules_xcodeproj_generated/generator/test/fixtures/xcodeproj_bwb/xcodeproj_bwb-params/tvOSAppUITests.30.link.params",
-        "7": [
-            "//Lib:LibFramework.tvOS applebin_tvos-tvos_x86_64-dbg-STABLE-25",
-            "//UI:UIFramework.tvOS applebin_tvos-tvos_x86_64-dbg-STABLE-25",
-            "//tvOSApp/Source:tvOSApp applebin_tvos-tvos_x86_64-dbg-STABLE-25"
-        ],
         "b": {
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-25/bin/Lib/LibFramework.tvOS.framework.dSYM\"",
@@ -7902,11 +7899,6 @@
         },
         "4": "bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-27/bin/tvOSApp/Test/UITests/rules_xcodeproj/tvOSAppUITests.__internal__.__test_bundle/Info.plist",
         "6": "bazel-out/darwin_x86_64-dbg-STABLE-0/bin/external/rules_xcodeproj_generated/generator/test/fixtures/xcodeproj_bwb/xcodeproj_bwb-params/tvOSAppUITests.103.link.params",
-        "7": [
-            "//Lib:LibFramework.tvOS applebin_tvos-tvos_x86_64-opt-STABLE-27",
-            "//UI:UIFramework.tvOS applebin_tvos-tvos_x86_64-opt-STABLE-27",
-            "//tvOSApp/Source:tvOSApp applebin_tvos-tvos_x86_64-opt-STABLE-27"
-        ],
         "b": {
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-27/bin/Lib/LibFramework.tvOS.framework.dSYM\"",
@@ -8152,10 +8144,6 @@
         },
         "4": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-17/bin/watchOSApp/Test/UITests/rules_xcodeproj/watchOSAppUITests.__internal__.__test_bundle/Info.plist",
         "6": "bazel-out/darwin_x86_64-dbg-STABLE-0/bin/external/rules_xcodeproj_generated/generator/test/fixtures/xcodeproj_bwb/xcodeproj_bwb-params/watchOSAppUITests.32.link.params",
-        "7": [
-            "//Lib:LibFramework.watchOS applebin_watchos-watchos_x86_64-dbg-STABLE-17",
-            "//UI:UIFramework.watchOS applebin_watchos-watchos_x86_64-dbg-STABLE-17"
-        ],
         "b": {
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-17/bin/Lib/LibFramework.watchOS.framework.dSYM\"",
@@ -8227,10 +8215,6 @@
         },
         "4": "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-19/bin/watchOSApp/Test/UITests/rules_xcodeproj/watchOSAppUITests.__internal__.__test_bundle/Info.plist",
         "6": "bazel-out/darwin_x86_64-dbg-STABLE-0/bin/external/rules_xcodeproj_generated/generator/test/fixtures/xcodeproj_bwb/xcodeproj_bwb-params/watchOSAppUITests.105.link.params",
-        "7": [
-            "//Lib:LibFramework.watchOS applebin_watchos-watchos_x86_64-opt-STABLE-19",
-            "//UI:UIFramework.watchOS applebin_watchos-watchos_x86_64-opt-STABLE-19"
-        ],
         "b": {
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-19/bin/Lib/LibFramework.watchOS.framework.dSYM\"",
@@ -8689,10 +8673,6 @@
             ]
         },
         "6": "bazel-out/darwin_x86_64-dbg-STABLE-0/bin/external/rules_xcodeproj_generated/generator/test/fixtures/xcodeproj_bwb/xcodeproj_bwb-params/watchOSAppExtension.63.link.params",
-        "7": [
-            "//Lib:LibFramework.watchOS applebin_watchos-watchos_arm64_32-dbg-STABLE-18",
-            "//UI:UIFramework.watchOS applebin_watchos-watchos_arm64_32-dbg-STABLE-18"
-        ],
         "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
             "BAZEL_OUTPUTS_DSYM": [
@@ -8775,10 +8755,6 @@
             ]
         },
         "6": "bazel-out/darwin_x86_64-dbg-STABLE-0/bin/external/rules_xcodeproj_generated/generator/test/fixtures/xcodeproj_bwb/xcodeproj_bwb-params/watchOSAppExtension.136.link.params",
-        "7": [
-            "//Lib:LibFramework.watchOS applebin_watchos-watchos_arm64_32-opt-STABLE-20",
-            "//UI:UIFramework.watchOS applebin_watchos-watchos_arm64_32-opt-STABLE-20"
-        ],
         "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
             "BAZEL_OUTPUTS_DSYM": [
@@ -8864,10 +8840,6 @@
             ]
         },
         "6": "bazel-out/darwin_x86_64-dbg-STABLE-0/bin/external/rules_xcodeproj_generated/generator/test/fixtures/xcodeproj_bwb/xcodeproj_bwb-params/watchOSAppExtension.10.link.params",
-        "7": [
-            "//Lib:LibFramework.watchOS applebin_watchos-watchos_x86_64-dbg-STABLE-17",
-            "//UI:UIFramework.watchOS applebin_watchos-watchos_x86_64-dbg-STABLE-17"
-        ],
         "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
             "BAZEL_OUTPUTS_DSYM": [
@@ -8949,10 +8921,6 @@
             ]
         },
         "6": "bazel-out/darwin_x86_64-dbg-STABLE-0/bin/external/rules_xcodeproj_generated/generator/test/fixtures/xcodeproj_bwb/xcodeproj_bwb-params/watchOSAppExtension.83.link.params",
-        "7": [
-            "//Lib:LibFramework.watchOS applebin_watchos-watchos_x86_64-opt-STABLE-19",
-            "//UI:UIFramework.watchOS applebin_watchos-watchos_x86_64-opt-STABLE-19"
-        ],
         "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
             "BAZEL_OUTPUTS_DSYM": [

--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -24,13 +24,19 @@ load(":xcodeproj_aspect.bzl", "make_xcodeproj_aspect")
 
 # Utility
 
-_SWIFTUI_PREVIEW_PRODUCT_TYPES = [
-    "com.apple.product-type.application",
-    "com.apple.product-type.app-extension",
-    "com.apple.product-type.bundle",
-    "com.apple.product-type.framework",
-    "com.apple.product-type.tool",
-]
+_SWIFTUI_PREVIEW_PRODUCT_TYPES = {
+    "com.apple.product-type.application": None,
+    "com.apple.product-type.application.on-demand-install-capable": None,
+    "com.apple.product-type.application.watchapp": None,
+    "com.apple.product-type.application.watchapp2": None,
+    "com.apple.product-type.app-extension": None,
+    "com.apple.product-type.bundle": None,
+    "com.apple.product-type.bundle.unit-test": None,
+    "com.apple.product-type.extensionkit-extension": None,
+    "com.apple.product-type.framework": None,
+    "com.apple.product-type.tool": None,
+    "com.apple.product-type.tv-app-extension": None,
+}
 
 # TODO: Non-test_host applications should be terminal as well
 _TERMINAL_PRODUCT_TYPES = {
@@ -642,7 +648,8 @@ targets.
             for id in xcode_target.transitive_dependencies.to_list()
         }
 
-        if include_swiftui_previews_scheme_targets:
+        if (include_swiftui_previews_scheme_targets and
+            xcode_target.product.type in _SWIFTUI_PREVIEW_PRODUCT_TYPES):
             additional_scheme_target_ids = _calculate_swiftui_preview_targets(
                 xcode_target = xcode_target,
                 transitive_dependencies = transitive_dependencies,


### PR DESCRIPTION
We were looking at dependencies for too many targets. We only have to consider the dependencies for targets that can themselves display SwiftUI previews.

Also fixes the list of target types that can include SwiftUI Previews.