### PR TITLE
Fix `create_lldbinit.sh` not appending content to a new line

### DIFF
--- a/xcodeproj/internal/bazel_integration_files/create_lldbinit.sh
+++ b/xcodeproj/internal/bazel_integration_files/create_lldbinit.sh
@@ -81,7 +81,9 @@ fi
 touch "$lldbinit"
 
 readonly required_source='command source ~/.lldbinit-rules_xcodeproj'
-if ! grep -m 1 -q "$required_source" "$lldbinit"; then
+if ! grep -m 1 -q "^$required_source$" "$lldbinit"; then
+  # Add a newline if the file doesn't end with one
+  tail -c 1 "$lldbinit" | read || echo >> "$lldbinit"
   # Update `$lldbinit to source `~/.lldbinit-rules_xcodeproj`
   echo "$required_source" >> "$lldbinit"
 fi


### PR DESCRIPTION
Closes #2035.

Updates the `grep` command to use `^` and `$` to match the entire line, if no match is found it adds the command to the end of the file.

Additionally, adss an extra step before we append the lldbinit content to ensure the file contains a new line.

```sh
tail -c 1 "$lldbinit" | read || echo >> "$lldbinit"
```

This will read last char of lldbinit but only runs echo to add a new line iff the read fails (i.e. EOF found before new line)



### Examples

```sh
# Before (without newline)
cat ~/.lldbinit                                                                                                 
command echo "hello world"%

# After running target in Xcode
command echo "hello world"
command source ~/.lldbinit-rules_xcodeproj
```

```sh
# Before (with newline)
cat ~/.lldbinit                                                                                                 
command echo "hello world"

# After running target in xcode
command echo "hello world"
command source ~/.lldbinit-rules_xcodeproj
```

```sh
# Before (corrupted file)
cat ~/.lldbinit                                                                                                 
command echo "hello world"command source ~/.lldbinit-rules_xcodeproj

# After running target in xcode
command echo "hello world"command source ~/.lldbinit-rules_xcodeproj
command source ~/.lldbinit-rules_xcodeproj

```