### PR TITLE
Remove `FilePath.forceGroupCreation`

### DIFF
--- a/tools/generator/src/DTO/FilePath.swift
+++ b/tools/generator/src/DTO/FilePath.swift
@@ -3,16 +3,13 @@ import PathKit
 struct FilePath: Hashable, Decodable {
     var path: Path
     var isFolder: Bool
-    var forceGroupCreation: Bool
 
     init(
         path: Path,
-        isFolder: Bool = false,
-        forceGroupCreation: Bool = false
+        isFolder: Bool = false
     ) {
         self.path = path
         self.isFolder = isFolder
-        self.forceGroupCreation = forceGroupCreation
     }
 
     // MARK: Decodable
@@ -20,7 +17,6 @@ struct FilePath: Hashable, Decodable {
     init(from decoder: Decoder) throws {
         path = try decoder.singleValueContainer().decode(Path.self)
         isFolder = false
-        forceGroupCreation = false
     }
 }
 
@@ -28,8 +24,7 @@ extension FilePath {
     func parent() -> FilePath {
         return FilePath(
             path: path.parent().normalize(),
-            isFolder: false,
-            forceGroupCreation: forceGroupCreation
+            isFolder: false
         )
     }
 }
@@ -59,7 +54,6 @@ func + (lhs: FilePath, rhs: String) -> FilePath {
 
     return FilePath(
         path: path,
-        isFolder: false,
-        forceGroupCreation: lhs.forceGroupCreation
+        isFolder: false
     )
 }

--- a/tools/generator/src/DTO/Inputs.swift
+++ b/tools/generator/src/DTO/Inputs.swift
@@ -91,7 +91,6 @@ private extension KeyedDecodingContainer where K == Inputs.CodingKeys {
         var folders = try decodeIfPresent([FilePath].self, forKey: key) ?? []
         for i in folders.indices {
             folders[i].isFolder = true
-            folders[i].forceGroupCreation = true
         }
         return folders
     }

--- a/tools/generator/src/DTO/Project.swift
+++ b/tools/generator/src/DTO/Project.swift
@@ -139,7 +139,6 @@ private extension KeyedDecodingContainer where K == Project.CodingKeys {
         var folders = try decodeIfPresent([FilePath].self, forKey: key) ?? []
         for i in folders.indices {
             folders[i].isFolder = true
-            folders[i].forceGroupCreation = true
         }
         return folders
     }

--- a/tools/generator/src/Extensions/Path+Extensions.swift
+++ b/tools/generator/src/Extensions/Path+Extensions.swift
@@ -12,6 +12,7 @@ extension Path {
     }
 
     var isCoreDataContainer: Bool { self.extension == "xcdatamodeld" }
+    var isCoreDataModel: Bool { self.extension == "xcdatamodel" }
     var isLocalizedContainer: Bool { self.extension == "lproj" }
 
     var isBazelBuildFile: Bool {
@@ -52,7 +53,6 @@ extension Path {
     }
 
     private var isBundle: Bool { self.extension == "bundle" }
-    private var isCoreDataModel: Bool { self.extension == "xcdatamodel" }
     private var isDocCArchive: Bool { self.extension == "docc" }
     private var isFramework: Bool { self.extension == "framework" }
     private var isSceneKitAssets: Bool { self.extension == "scnassets" }

--- a/tools/generator/src/Generator/CreateFilesAndGroups.swift
+++ b/tools/generator/src/Generator/CreateFilesAndGroups.swift
@@ -147,8 +147,7 @@ extension Generator {
             offset: Int,
             isExternal: Bool,
             parentIsLocalizedContainer: Bool,
-            isLeaf: Bool,
-            forceGroupCreation: Bool
+            isLeaf: Bool
         ) -> (PBXFileElement, isNew: Bool)? {
             if filePath.path.isLocalizedContainer {
                 // Localized container (e.g. /path/to/en.lproj)
@@ -186,7 +185,7 @@ extension Generator {
                 xcVersionGroups[filePath] = xcVersionGroup
 
                 return (xcVersionGroup, true)
-            } else if !isLeaf, forceGroupCreation || !filePath.path.isFolderTypeFileSource {
+            } else if !isLeaf && !filePath.path.isCoreDataModel {
                 if let group = normalGroups[filePath] {
                     return (group, false)
                 }
@@ -214,7 +213,7 @@ extension Generator {
                 )
 
                 let lastKnownFileType: String?
-                if filePath.isFolder, !filePath.path.isFolderTypeFileSource {
+                if filePath.isFolder && !filePath.path.isFolderTypeFileSource {
                     lastKnownFileType = "folder"
                 } else {
                     lastKnownFileType = filePath.path.lastKnownFileType
@@ -490,8 +489,7 @@ extension Generator {
                         offset: offset,
                         isExternal: isExternal,
                         parentIsLocalizedContainer: parentIsLocalizedContainer,
-                        isLeaf: isLeaf,
-                        forceGroupCreation: fullFilePath.forceGroupCreation
+                        isLeaf: isLeaf
                     )
                 {
                     if isNew {

--- a/tools/generator/test/Fixtures.swift
+++ b/tools/generator/test/Fixtures.swift
@@ -73,9 +73,7 @@ enum Fixtures {
                 srcs: ["x/y.swift"],
                 nonArcSrcs: ["b.c"],
                 resources: [
-                    "Assets.xcassets/Contents.json",
-                    "Assets.xcassets/some_image/Contents.json",
-                    "Assets.xcassets/some_image/some_image.png",
+                    "Assets.xcassets",
                 ]
             ),
             outputs: .init(
@@ -257,9 +255,7 @@ enum Fixtures {
             inputs: .init(
                 resources: [
                     "r1/X.txt",
-                    "r1/Assets.xcassets/Contents.json",
-                    "r1/Assets.xcassets/image/Contents.json",
-                    "r1/Assets.xcassets/image/image.png",
+                    "r1/Assets.xcassets",
                     "r1/E.xcdatamodeld/K2.xcdatamodel/contents",
                     .project("r1/nested", isFolder: true),
                     .project("r1/dir", isFolder: true),
@@ -750,11 +746,6 @@ enum Fixtures {
             lastKnownFileType: "folder.assetcatalog",
             path: "Assets.xcassets"
         )
-        elements["Assets.xcassets/Contents.json"] = elements["Assets.xcassets"]!
-        elements["Assets.xcassets/some_image/Contents.json"] =
-            elements["Assets.xcassets"]!
-        elements["Assets.xcassets/some_image/some_image.png"] =
-            elements["Assets.xcassets"]!
 
         // Localized files
 
@@ -827,12 +818,6 @@ enum Fixtures {
             lastKnownFileType: "folder.assetcatalog",
             path: "Assets.xcassets"
         )
-        elements["r1/Assets.xcassets/Contents.json"] =
-            elements["r1/Assets.xcassets"]!
-        elements["r1/Assets.xcassets/image/Contents.json"] =
-            elements["r1/Assets.xcassets"]!
-        elements["r1/Assets.xcassets/image/image.png"] =
-            elements["r1/Assets.xcassets"]!
 
         // r1/E.xcdatamodeld
 
@@ -2344,25 +2329,21 @@ extension FilePath {
 
     static func generated(
         _ path: Path,
-        isFolder: Bool = false,
-        forceGroupCreation: Bool = false
+        isFolder: Bool = false
     ) -> FilePath {
         return FilePath(
             path: "bazel-out" + path,
-            isFolder: isFolder,
-            forceGroupCreation: forceGroupCreation
+            isFolder: isFolder
         )
     }
 
     static func project(
         _ path: Path,
-        isFolder: Bool = false,
-        forceGroupCreation: Bool = false
+        isFolder: Bool = false
     ) -> FilePath {
         return FilePath(
             path: path,
-            isFolder: isFolder,
-            forceGroupCreation: forceGroupCreation
+            isFolder: isFolder
         )
     }
 }


### PR DESCRIPTION
We already normalize paths in Starlark, so `filePath.path.isFolderTypeFileSource` is a no-op check.

This does codify (for now) that localized files or CodeData files can never have their folders be folders, they will always be recognized as folder type files. Later, after refactoring `createFilesAndGroups`, we can fix this to allow those to be unstructured files as well.