### PR TITLE
Stop retaining `implementation_compilation_context` in `XcodeProjInfo`

### DIFF
--- a/xcodeproj/internal/compilation_providers.bzl
+++ b/xcodeproj/internal/compilation_providers.bzl
@@ -66,9 +66,13 @@ def _collect_compilation_providers(
             compilation providers merged.
 
     Returns:
-        An opaque `struct` containing the linker input files for a target. The
-        `struct` should be passed to functions in the `collect_providers` module
-        to retrieve its contents.
+        A `tuple` with two elements:
+
+        -   An opaque `struct` containing the linker input files for a target.
+            The `struct` should be passed to functions in the
+            `collect_providers` module to retrieve its contents.
+        -   The implementation deps aware `CcCompilationContext` for `target`.
+
     """
     is_xcode_library_target = cc_info and is_xcode_target
 
@@ -83,15 +87,16 @@ def _collect_compilation_providers(
         ],
     )
 
-    return struct(
-        _is_swift = swift_info != None,
-        _is_top_level = False,
-        _is_xcode_library_target = is_xcode_library_target,
-        _propagated_objc = objc,
-        _transitive_compilation_providers = (),
-        cc_info = cc_info,
-        implementation_compilation_context = implementation_compilation_context,
-        objc = objc,
+    return (
+        struct(
+            _is_swift = swift_info != None,
+            _is_top_level = False,
+            _is_xcode_library_target = is_xcode_library_target,
+            _propagated_objc = objc,
+            cc_info = cc_info,
+            objc = objc,
+        ),
+        implementation_compilation_context,
     )
 
 def _merge_compilation_providers(
@@ -143,17 +148,16 @@ def _merge_compilation_providers(
     else:
         propagated_objc = objc
 
-    return struct(
-        _is_swift = swift_info != None,
-        _is_top_level = True,
-        _is_xcode_library_target = False,
-        _propagated_objc = propagated_objc,
-        _transitive_compilation_providers = tuple(
-            transitive_compilation_providers,
+    return (
+        struct(
+            _is_swift = swift_info != None,
+            _is_top_level = True,
+            _is_xcode_library_target = False,
+            _propagated_objc = propagated_objc,
+            cc_info = merged_cc_info,
+            objc = objc,
         ),
-        cc_info = merged_cc_info,
-        implementation_compilation_context = implementation_compilation_context,
-        objc = objc,
+        implementation_compilation_context,
     )
 
 def _to_objc(objc, cc_info):

--- a/xcodeproj/internal/input_files.bzl
+++ b/xcodeproj/internal/input_files.bzl
@@ -445,7 +445,7 @@ def _collect_input_files(
     unfocused_libraries = None
     if should_include_non_xcode_outputs(ctx = ctx):
         if unfocused == None:
-            dep_compilation_providers = comp_providers.merge(
+            (dep_compilation_providers, _) = comp_providers.merge(
                 transitive_compilation_providers = [
                     (info.xcode_target, info.compilation_providers)
                     for attr, info in transitive_infos

--- a/xcodeproj/internal/library_targets.bzl
+++ b/xcodeproj/internal/library_targets.bzl
@@ -75,7 +75,10 @@ def process_library_target(
     is_swift = SwiftInfo in target
     swift_info = target[SwiftInfo] if is_swift else None
 
-    compilation_providers = comp_providers.collect(
+    (
+        compilation_providers,
+        implementation_compilation_context,
+    ) = comp_providers.collect(
         cc_info = target[CcInfo],
         objc = objc,
         swift_info = swift_info,
@@ -154,9 +157,7 @@ def process_library_target(
         has_c_sources = inputs.has_c_sources,
         has_cxx_sources = inputs.has_cxx_sources,
         target = target,
-        implementation_compilation_context = (
-            compilation_providers.implementation_compilation_context
-        ),
+        implementation_compilation_context = implementation_compilation_context,
         package_bin_dir = package_bin_dir,
         build_settings = build_settings,
     )

--- a/xcodeproj/internal/non_xcode_targets.bzl
+++ b/xcodeproj/internal/non_xcode_targets.bzl
@@ -81,15 +81,17 @@ rules_xcodeproj requires {} to have `{}` set.
         if XcodeProjInfo in dep
     ]
 
-    compilation_providers = comp_providers.collect(
+    (
+        compilation_providers,
+        _,
+    ) = comp_providers.collect(
         cc_info = cc_info,
         objc = objc,
         swift_info = swift_info,
         is_xcode_target = False,
-        transitive_implementation_providers = [
-            info.compilation_providers
-            for info in deps_infos
-        ],
+        # Since we don't use the returned `implementation_compilation_context`,
+        # we can pass `[]` here
+        transitive_implementation_providers = [],
     )
     linker_inputs = linker_input_files.collect(
         target = target,

--- a/xcodeproj/internal/non_xcode_targets.bzl
+++ b/xcodeproj/internal/non_xcode_targets.bzl
@@ -13,7 +13,6 @@ load(":linker_input_files.bzl", "linker_input_files")
 load(":lldb_contexts.bzl", "lldb_contexts")
 load(":output_files.bzl", "output_files")
 load(":processed_target.bzl", "processed_target")
-load(":providers.bzl", "XcodeProjInfo")
 load(":target_id.bzl", "get_id")
 load(
     ":target_properties.bzl",
@@ -73,13 +72,6 @@ rules_xcodeproj requires {} to have `{}` set.
         ]
     else:
         resource_bundle_informations = None
-
-    deps_infos = [
-        dep[XcodeProjInfo]
-        for attr in automatic_target_info.implementation_deps
-        for dep in getattr(ctx.rule.attr, attr, [])
-        if XcodeProjInfo in dep
-    ]
 
     (
         compilation_providers,

--- a/xcodeproj/internal/top_level_targets.bzl
+++ b/xcodeproj/internal/top_level_targets.bzl
@@ -320,7 +320,7 @@ def process_top_level_target(
         )
 
     if avoid_compilation_providers_list:
-        avoid_compilation_providers = comp_providers.merge(
+        (avoid_compilation_providers, _) = comp_providers.merge(
             transitive_compilation_providers = avoid_compilation_providers_list,
         )
     else:

--- a/xcodeproj/internal/top_level_targets.bzl
+++ b/xcodeproj/internal/top_level_targets.bzl
@@ -340,7 +340,10 @@ def process_top_level_target(
         if XcodeProjInfo in dep
     ]
 
-    compilation_providers = comp_providers.merge(
+    (
+        compilation_providers,
+        implementation_compilation_context,
+    ) = comp_providers.merge(
         apple_dynamic_framework_info = apple_dynamic_framework_info,
         cc_info = target[CcInfo] if CcInfo in target else None,
         swift_info = target[SwiftInfo] if SwiftInfo in target else None,
@@ -414,9 +417,7 @@ def process_top_level_target(
         has_c_sources = inputs.has_c_sources,
         has_cxx_sources = inputs.has_cxx_sources,
         target = target,
-        implementation_compilation_context = (
-            compilation_providers.implementation_compilation_context
-        ),
+        implementation_compilation_context = implementation_compilation_context,
         package_bin_dir = package_bin_dir,
         build_settings = build_settings,
     )


### PR DESCRIPTION
This value is only used in the aspect that creates it, so we don’t need to hold onto the memory for it in the provider.