### PR TITLE
Parallelize `XcodeProj.write()`

### DIFF
--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSAppUnitTests_Scheme.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSAppUnitTests_Scheme.xcscheme
@@ -164,7 +164,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "06E3C912B8DE52D274641347"
+               BlueprintIdentifier = "TEMP_4361CE66-9EFE-4D44-8CA6-9C0F316C984C"
                BuildableName = "WidgetExtension.appex"
                BlueprintName = "WidgetExtension"
                ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">

--- a/examples/integration/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -8034,8 +8034,8 @@
 				A7EE330C67CB794EA5DC8FCE /* Assets.xcassets in Resources */,
 				EB509AB2045BC989DBE6563C /* bucket in Resources */,
 				96536BFC80D7064031732BC1 /* bucket in Resources */,
-				57B6669C9AE0F887A3D54BDA /* bucket in Resources */,
 				130B4EF21F478D0D76C741D0 /* bucket in Resources */,
+				57B6669C9AE0F887A3D54BDA /* bucket in Resources */,
 				A48717BC5F009B090ECFBE3D /* ExampleNestedResources.bundle in Resources */,
 				8FA8E339A4D6550088042CF4 /* nested in Resources */,
 			);
@@ -8129,8 +8129,8 @@
 			files = (
 				C96515E7CF5EB8DFDC4A4D33 /* Assets.xcassets in Resources */,
 				4BAA64EC25430110196B80F8 /* dir in Resources */,
-				C5806E50BE8A7D0EAAB1069F /* ExampleNestedResources.bundle in Resources */,
 				3BA5C2F09EA47A66AFDDCB3F /* ExampleNestedResources.bundle in Resources */,
+				C5806E50BE8A7D0EAAB1069F /* ExampleNestedResources.bundle in Resources */,
 				B113FDC76331C2B59078B69C /* Localizable.strings in Resources */,
 				B5B2DEF7E38E09E7CD67C7EB /* Utils.bundle in Resources */,
 			);

--- a/tools/generator/src/Generator/Environment.swift
+++ b/tools/generator/src/Generator/Environment.swift
@@ -141,5 +141,5 @@ struct Environment {
         _ directories: Directories,
         _ internalFiles: [Path: String],
         _ outputPath: Path
-    ) throws -> Void
+    ) async throws -> Void
 }

--- a/tools/generator/src/Generator/WriteXcodeProj.swift
+++ b/tools/generator/src/Generator/WriteXcodeProj.swift
@@ -8,8 +8,8 @@ extension Generator {
         directories: Directories,
         internalFiles: [Path: String],
         to outputPath: Path
-    ) throws {
-        try xcodeProj.write(path: outputPath)
+    ) async throws {
+        try await xcodeProj.write(path: outputPath)
 
         let internalOutputPath = outputPath + directories.internalDirectoryName
 

--- a/xcodeproj/repositories.bzl
+++ b/xcodeproj/repositories.bzl
@@ -274,6 +274,8 @@ swift_library(
         ignore_version_differences = ignore_version_differences,
     )
 
+    # jpsim fork for async writes
+    xcodeproj_git_sha = "5acbea1bb114e93d62741e8fefef87cde667e48a"
     _maybe(
         http_archive,
         name = "com_github_tuist_xcodeproj",
@@ -290,9 +292,9 @@ swift_library(
     ],
 )
 """,
-        sha256 = "70a4504d5cfd30e1c1968df3929bf0c40cba91bdb2ef0e3143c0e72bbe1d8092",
-        strip_prefix = "XcodeProj-8.9.0",
-        url = "https://github.com/tuist/XcodeProj/archive/refs/tags/8.9.0.tar.gz",
+        sha256 = "5835d539f5e83c3d61dc5f8cc3cbeb363c9c3f83a6145a81a165de56fb527b86",
+        strip_prefix = "XcodeProj-%s" % xcodeproj_git_sha,
+        url = "https://github.com/jpsim/XcodeProj/archive/%s.tar.gz" % xcodeproj_git_sha,
         ignore_version_differences = ignore_version_differences,
     )
 


### PR DESCRIPTION
This is just a proof-of-concept, and needs some updates to XcodeProj upstream before this is reviewable.

For a large project, this brings writing the `.xcodeproj` from 11.058s to 8.318s.

Part of https://github.com/MobileNativeFoundation/rules_xcodeproj/issues/2044.

Messy proof-of-concept upstream changes to XcodeProj: https://github.com/tuist/XcodeProj/compare/main...jpsim:XcodeProj:jp-async-write