### PR TITLE
Stop retaining some of `input_files` in `XcodeProj`

### DIFF
--- a/xcodeproj/internal/input_files.bzl
+++ b/xcodeproj/internal/input_files.bzl
@@ -741,7 +741,7 @@ def _collect_input_files(
                 for attr, info in transitive_infos
                 if (info.inputs.has_generated_files and
                     (info.target_type in
-                    automatic_target_info.xcode_targets.get(attr, [None])))
+                     automatic_target_info.xcode_targets.get(attr, [None])))
             ]),
             indexstores = indexstores_depset,
             extra_files = depset(

--- a/xcodeproj/internal/input_files.bzl
+++ b/xcodeproj/internal/input_files.bzl
@@ -844,7 +844,6 @@ def _merge_input_files(*, transitive_infos, extra_generated = None):
                 for _, info in transitive_infos
             ],
         ),
-        entitlements = None,
         xccurrentversions = depset(
             transitive = [
                 info.inputs.xccurrentversions

--- a/xcodeproj/internal/library_targets.bzl
+++ b/xcodeproj/internal/library_targets.bzl
@@ -116,7 +116,7 @@ def process_library_target(
     )
 
     modulemaps = process_modulemaps(swift_info = swift_info)
-    inputs = input_files.collect(
+    (target_inputs, provider_inputs) = input_files.collect(
         ctx = ctx,
         target = target,
         attrs = attrs,
@@ -135,15 +135,15 @@ def process_library_target(
         ctx = ctx,
         debug_outputs = debug_outputs,
         id = id,
-        inputs = inputs,
+        inputs = target_inputs,
         output_group_info = output_group_info,
         swift_info = swift_info,
         transitive_infos = transitive_infos,
     )
 
-    if inputs.pch:
+    if target_inputs.pch:
         build_settings["GCC_PREFIX_HEADER"] = build_setting_path(
-            file = inputs.pch,
+            file = target_inputs.pch,
         )
 
     package_bin_dir = join_paths_ignoring_empty(
@@ -154,8 +154,8 @@ def process_library_target(
     search_paths, conlyopts, cxxopts, swiftcopts, clang_opts = process_opts(
         ctx = ctx,
         build_mode = build_mode,
-        has_c_sources = inputs.has_c_sources,
-        has_cxx_sources = inputs.has_cxx_sources,
+        has_c_sources = target_inputs.has_c_sources,
+        has_cxx_sources = target_inputs.has_cxx_sources,
         target = target,
         implementation_compilation_context = implementation_compilation_context,
         package_bin_dir = package_bin_dir,
@@ -192,7 +192,7 @@ def process_library_target(
         search_paths = search_paths,
         modulemaps = modulemaps,
         swiftmodules = swiftmodules,
-        inputs = inputs,
+        inputs = target_inputs,
         linker_inputs = linker_inputs,
         dependencies = dependencies,
         transitive_dependencies = transitive_dependencies,
@@ -211,7 +211,7 @@ def process_library_target(
         automatic_target_info = automatic_target_info,
         compilation_providers = compilation_providers,
         dependencies = dependencies,
-        inputs = inputs,
+        inputs = provider_inputs,
         library = product.file,
         lldb_context = lldb_context,
         mergable_xcode_library_targets = mergable_xcode_library_targets,

--- a/xcodeproj/internal/non_xcode_targets.bzl
+++ b/xcodeproj/internal/non_xcode_targets.bzl
@@ -109,23 +109,25 @@ rules_xcodeproj requires {} to have `{}` set.
         if providers._is_xcode_library_target
     ]
 
+    (_, provider_inputs) = input_files.collect(
+        ctx = ctx,
+        target = target,
+        attrs = attrs,
+        unfocused = None,
+        id = None,
+        platform = None,
+        is_bundle = False,
+        product = None,
+        linker_inputs = linker_inputs,
+        automatic_target_info = automatic_target_info,
+        transitive_infos = transitive_infos,
+    )
+
     return processed_target(
         automatic_target_info = automatic_target_info,
         compilation_providers = compilation_providers,
         dependencies = dependencies,
-        inputs = input_files.collect(
-            ctx = ctx,
-            target = target,
-            attrs = attrs,
-            unfocused = None,
-            id = None,
-            platform = None,
-            is_bundle = False,
-            product = None,
-            linker_inputs = linker_inputs,
-            automatic_target_info = automatic_target_info,
-            transitive_infos = transitive_infos,
-        ),
+        inputs = provider_inputs,
         lldb_context = lldb_contexts.collect(
             id = None,
             is_swift = is_swift,

--- a/xcodeproj/internal/resources.bzl
+++ b/xcodeproj/internal/resources.bzl
@@ -373,8 +373,8 @@ def collect_resources(
             ]
             if bundle
         ],
-        resources = root_bundle.resources,
-        folder_resources = root_bundle.folder_resources,
+        resources = tuple(root_bundle.resources),
+        folder_resources = tuple(root_bundle.folder_resources),
         generated = generated,
         xccurrentversions = xccurrentversions,
         extra_files = extra_files,

--- a/xcodeproj/internal/top_level_targets.bzl
+++ b/xcodeproj/internal/top_level_targets.bzl
@@ -372,7 +372,7 @@ def process_top_level_target(
         linker_inputs = linker_inputs,
     )
 
-    inputs = input_files.collect(
+    (target_inputs, provider_inputs) = input_files.collect(
         ctx = ctx,
         target = target,
         attrs = attrs,
@@ -393,7 +393,7 @@ def process_top_level_target(
         ctx = ctx,
         debug_outputs = debug_outputs,
         id = id,
-        inputs = inputs,
+        inputs = target_inputs,
         output_group_info = output_group_info,
         swift_info = swift_info,
         top_level_product = product,
@@ -401,9 +401,9 @@ def process_top_level_target(
         transitive_infos = transitive_infos,
     )
 
-    if inputs.entitlements:
+    if target_inputs.entitlements:
         build_settings["CODE_SIGN_ENTITLEMENTS"] = build_setting_path(
-            file = inputs.entitlements,
+            file = target_inputs.entitlements,
         )
 
     package_bin_dir = join_paths_ignoring_empty(
@@ -414,15 +414,15 @@ def process_top_level_target(
     search_paths, conlyopts, cxxopts, swiftcopts, clang_opts = process_opts(
         ctx = ctx,
         build_mode = build_mode,
-        has_c_sources = inputs.has_c_sources,
-        has_cxx_sources = inputs.has_cxx_sources,
+        has_c_sources = target_inputs.has_c_sources,
+        has_cxx_sources = target_inputs.has_cxx_sources,
         target = target,
         implementation_compilation_context = implementation_compilation_context,
         package_bin_dir = package_bin_dir,
         build_settings = build_settings,
     )
 
-    if not inputs.srcs:
+    if not target_inputs.srcs:
         potential_target_merges = [
             struct(
                 src = mergeable_target,
@@ -500,7 +500,7 @@ def process_top_level_target(
         dependencies = dependencies,
         extension_infoplists = extension_infoplists,
         hosted_targets = hosted_targets,
-        inputs = inputs,
+        inputs = provider_inputs,
         is_top_level_target = True,
         is_xcode_required = True,
         lldb_context = lldb_context,
@@ -525,7 +525,7 @@ def process_top_level_target(
             search_paths = search_paths,
             modulemaps = modulemaps,
             swiftmodules = swiftmodules,
-            inputs = inputs,
+            inputs = target_inputs,
             linker_inputs = linker_inputs,
             infoplist = infoplist,
             watch_application = watch_application,

--- a/xcodeproj/internal/xcode_targets.bzl
+++ b/xcodeproj/internal/xcode_targets.bzl
@@ -181,9 +181,9 @@ def _lldb_context_key(*, platform, product):
 
 def _to_xcode_target_inputs(inputs):
     return struct(
-        srcs = inputs.srcs,
-        non_arc_srcs = inputs.non_arc_srcs,
-        hdrs = inputs.hdrs,
+        srcs = tuple(inputs.srcs),
+        non_arc_srcs = tuple(inputs.non_arc_srcs),
+        hdrs = tuple(inputs.hdrs),
         pch = inputs.pch,
         entitlements = inputs.entitlements,
         has_c_sources = inputs.has_c_sources,
@@ -815,7 +815,7 @@ def _inputs_to_dto(inputs):
         if value:
             ret[key] = [
                 file.path
-                for file in value.to_list()
+                for file in value
             ]
 
     _process_attr("srcs", "s")
@@ -832,14 +832,14 @@ def _inputs_to_dto(inputs):
         set_if_true(
             ret,
             "r",
-            inputs.resources.to_list(),
+            inputs.resources,
         )
 
     if inputs.folder_resources:
         set_if_true(
             ret,
             "f",
-            inputs.folder_resources.to_list(),
+            inputs.folder_resources,
         )
 
     return ret

--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -447,10 +447,13 @@ targets.
             # Don't create targets for resource bundles in BwB mode, but still
             # include their files if they aren't unfocused
             focused_targets_extra_files.append(
-                (xcode_target.label, xcode_target.inputs.resources),
+                (xcode_target.label, depset(xcode_target.inputs.resources)),
             )
             focused_targets_extra_folders.append(
-                (xcode_target.label, xcode_target.inputs.folder_resources),
+                (
+                    xcode_target.label,
+                    depset(xcode_target.inputs.folder_resources),
+                ),
             )
             files_only_targets[xcode_target.id] = xcode_target
             continue


### PR DESCRIPTION
We should retain the minimum needed in the `XcodeProj` provider.