### PR TITLE
Stop retaining some of `output_files` in `XcodeProj`

### DIFF
--- a/xcodeproj/internal/library_targets.bzl
+++ b/xcodeproj/internal/library_targets.bzl
@@ -131,7 +131,7 @@ def process_library_target(
     )
     debug_outputs = target[apple_common.AppleDebugOutputs] if apple_common.AppleDebugOutputs in target else None
     output_group_info = target[OutputGroupInfo] if OutputGroupInfo in target else None
-    outputs = output_files.collect(
+    (target_outputs, provider_outputs) = output_files.collect(
         ctx = ctx,
         debug_outputs = debug_outputs,
         id = id,
@@ -196,7 +196,7 @@ def process_library_target(
         linker_inputs = linker_inputs,
         dependencies = dependencies,
         transitive_dependencies = transitive_dependencies,
-        outputs = outputs,
+        outputs = target_outputs,
         should_create_xcode_target = target.files != depset(),
     )
 
@@ -215,7 +215,7 @@ def process_library_target(
         library = product.file,
         lldb_context = lldb_context,
         mergable_xcode_library_targets = mergable_xcode_library_targets,
-        outputs = outputs,
+        outputs = provider_outputs,
         search_paths = search_paths,
         transitive_dependencies = transitive_dependencies,
         xcode_target = xcode_target,

--- a/xcodeproj/internal/non_xcode_targets.bzl
+++ b/xcodeproj/internal/non_xcode_targets.bzl
@@ -122,6 +122,11 @@ rules_xcodeproj requires {} to have `{}` set.
         automatic_target_info = automatic_target_info,
         transitive_infos = transitive_infos,
     )
+    (_, provider_outputs) = output_files.merge(
+        ctx = ctx,
+        automatic_target_info = automatic_target_info,
+        transitive_infos = transitive_infos,
+    )
 
     return processed_target(
         automatic_target_info = automatic_target_info,
@@ -142,11 +147,7 @@ rules_xcodeproj requires {} to have `{}` set.
             ],
         ),
         mergable_xcode_library_targets = mergable_xcode_library_targets,
-        outputs = output_files.merge(
-            ctx = ctx,
-            automatic_target_info = automatic_target_info,
-            transitive_infos = transitive_infos,
-        ),
+        outputs = provider_outputs,
         resource_bundle_informations = resource_bundle_informations,
         search_paths = None,
         transitive_dependencies = transitive_dependencies,

--- a/xcodeproj/internal/output_files.bzl
+++ b/xcodeproj/internal/output_files.bzl
@@ -35,8 +35,19 @@ def _create(
             with Bazel.
 
     Returns:
-        An opaque `struct` representing the internal data structure of the
-        `output_files` module.
+        A `tuple` with containing two elements:
+
+        *   A `struct`, which will only be used within the aspect, with the
+            following fields:
+
+            *   `direct_outputs`
+            *   `generated_output_group_name`
+            *   `linking_output_group_name`
+            *   `products_output_group_name`
+
+        *   An opaque `struct`, which will end up in `XcodeProjInfo.outputs`,
+            representing the internal data structure of the `output_files`
+            module.
     """
     compiled = None
     direct_products = []
@@ -91,7 +102,7 @@ def _create(
     transitive_infoplists = depset(
         [infoplist] if infoplist else None,
         transitive = [
-            info.outputs.transitive_infoplists
+            info.outputs._transitive_infoplists
             for attr, info in transitive_infos
             if (not automatic_target_info or
                 info.target_type in automatic_target_info.xcode_targets.get(
@@ -171,17 +182,22 @@ def _create(
         ],
     )
 
-    return struct(
-        _closest_compiled = closest_compiled,
-        _is_framework = is_framework,
-        _output_group_list = output_group_list,
-        _transitive_indexestores = transitive_indexestores,
-        _transitive_products = transitive_products,
-        direct_outputs = direct_outputs if should_produce_dto else None,
-        generated_output_group_name = generated_output_group_name,
-        linking_output_group_name = linking_output_group_name,
-        products_output_group_name = products_output_group_name,
-        transitive_infoplists = transitive_infoplists,
+    return (
+        struct(
+            direct_outputs = direct_outputs if should_produce_dto else None,
+            generated_output_group_name = generated_output_group_name,
+            linking_output_group_name = linking_output_group_name,
+            products_output_group_name = products_output_group_name,
+            transitive_infoplists = transitive_infoplists,
+        ),
+        struct(
+            _closest_compiled = closest_compiled,
+            _is_framework = is_framework,
+            _output_group_list = output_group_list,
+            _transitive_indexestores = transitive_indexestores,
+            _transitive_products = transitive_products,
+            _transitive_infoplists = transitive_infoplists,
+        ),
     )
 
 def _get_outputs(*, debug_outputs, id, product, swift_info, output_group_info):

--- a/xcodeproj/internal/resource_target.bzl
+++ b/xcodeproj/internal/resource_target.bzl
@@ -38,7 +38,7 @@ def _process_resource_bundle(bundle, *, information):
         linker_inputs = None,
     )
 
-    outputs = output_files.collect(
+    (target_outputs, _) = output_files.collect(
         ctx = None,
         debug_outputs = None,
         id = id,
@@ -63,7 +63,7 @@ def _process_resource_bundle(bundle, *, information):
         inputs = input_files.from_resource_bundle(bundle),
         dependencies = bundle.dependencies,
         transitive_dependencies = bundle.dependencies,
-        outputs = outputs,
+        outputs = target_outputs,
     )
 
 def process_resource_bundles(bundles, *, resource_bundle_informations):

--- a/xcodeproj/internal/top_level_targets.bzl
+++ b/xcodeproj/internal/top_level_targets.bzl
@@ -389,7 +389,7 @@ def process_top_level_target(
     )
     debug_outputs = target[apple_common.AppleDebugOutputs] if apple_common.AppleDebugOutputs in target else None
     output_group_info = target[OutputGroupInfo] if OutputGroupInfo in target else None
-    outputs = output_files.collect(
+    (target_outputs, provider_outputs) = output_files.collect(
         ctx = ctx,
         debug_outputs = debug_outputs,
         id = id,
@@ -505,7 +505,7 @@ def process_top_level_target(
         is_xcode_required = True,
         lldb_context = lldb_context,
         mergable_xcode_library_targets = [],
-        outputs = outputs,
+        outputs = provider_outputs,
         potential_target_merges = potential_target_merges,
         search_paths = search_paths,
         transitive_dependencies = transitive_dependencies,
@@ -533,7 +533,7 @@ def process_top_level_target(
             app_clips = app_clips,
             dependencies = dependencies,
             transitive_dependencies = transitive_dependencies,
-            outputs = outputs,
+            outputs = target_outputs,
             lldb_context = lldb_context,
             xcode_required_targets = depset(
                 transitive = [

--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -1574,7 +1574,7 @@ configurations: {}""".format(", ".join(xcode_configurations)))
     minimum_xcode_version = (ctx.attr.minimum_xcode_version or
                              _get_minimum_xcode_version(ctx = ctx))
 
-    outputs = output_files.merge(
+    (_, provider_outputs) = output_files.merge(
         ctx = ctx,
         automatic_target_info = None,
         transitive_infos = [(None, info) for info in infos],
@@ -1819,7 +1819,7 @@ done
     else:
         input_files_output_groups = {}
         output_files_output_groups = output_files.to_output_groups_fields(
-            outputs = outputs,
+            outputs = provider_outputs,
             additional_outputs = additional_outputs,
             index_import = ctx.executable._index_import,
         )

--- a/xcodeproj/internal/xcodeprojinfo.bzl
+++ b/xcodeproj/internal/xcodeprojinfo.bzl
@@ -243,6 +243,12 @@ def _skip_target(
         transitive_infos = transitive_infos,
     )
 
+    (_, provider_outputs) = output_files.merge(
+        ctx = ctx,
+        automatic_target_info = None,
+        transitive_infos = transitive_infos,
+    )
+
     return _target_info_fields(
         args = depset(
             [
@@ -295,11 +301,7 @@ def _skip_target(
                 for _, info in transitive_infos
             ],
         ),
-        outputs = output_files.merge(
-            ctx = ctx,
-            automatic_target_info = None,
-            transitive_infos = transitive_infos,
-        ),
+        outputs = provider_outputs,
         potential_target_merges = depset(
             transitive = [
                 info.potential_target_merges


### PR DESCRIPTION
We should retain the minimum needed in the `XcodeProj` provider.