### PR TITLE
Fix more sorting non-determinism

### DIFF
--- a/examples/integration/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -7997,8 +7997,8 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F2654AC7861464A75EF63853 /* Assets.xcassets in Resources */,
 				7950848A641B9A1086428155 /* Assets.xcassets in Resources */,
+				F2654AC7861464A75EF63853 /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8032,10 +8032,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				A7EE330C67CB794EA5DC8FCE /* Assets.xcassets in Resources */,
-				EB509AB2045BC989DBE6563C /* bucket in Resources */,
 				96536BFC80D7064031732BC1 /* bucket in Resources */,
-				57B6669C9AE0F887A3D54BDA /* bucket in Resources */,
 				130B4EF21F478D0D76C741D0 /* bucket in Resources */,
+				57B6669C9AE0F887A3D54BDA /* bucket in Resources */,
+				EB509AB2045BC989DBE6563C /* bucket in Resources */,
 				A48717BC5F009B090ECFBE3D /* ExampleNestedResources.bundle in Resources */,
 				8FA8E339A4D6550088042CF4 /* nested in Resources */,
 			);
@@ -8058,8 +8058,8 @@
 				5748C8D48BA08EF8C2F33D56 /* Assets.xcassets in Resources */,
 				E278F1DD818736A085E8EF07 /* ExampleNestedResources.bundle in Resources */,
 				9662270A130DFD557C8BEBA5 /* ExampleResources.bundle in Resources */,
-				868A1DC835387DF8B2925C81 /* GoogleMaps.bundle in Resources */,
 				31FB3493B0CBCAB455AFA25D /* GoogleMaps.bundle in Resources */,
+				868A1DC835387DF8B2925C81 /* GoogleMaps.bundle in Resources */,
 				C52713F177F42B0488A82FA1 /* launch_images_ios.xcassets in Resources */,
 				E372FF2EEEDA50F8041AD197 /* Launch.storyboard in Resources */,
 				3DB5B62545E1286F7EE7FF88 /* Localizable.strings in Resources */,
@@ -8129,8 +8129,8 @@
 			files = (
 				C96515E7CF5EB8DFDC4A4D33 /* Assets.xcassets in Resources */,
 				4BAA64EC25430110196B80F8 /* dir in Resources */,
-				C5806E50BE8A7D0EAAB1069F /* ExampleNestedResources.bundle in Resources */,
 				3BA5C2F09EA47A66AFDDCB3F /* ExampleNestedResources.bundle in Resources */,
+				C5806E50BE8A7D0EAAB1069F /* ExampleNestedResources.bundle in Resources */,
 				B113FDC76331C2B59078B69C /* Localizable.strings in Resources */,
 				B5B2DEF7E38E09E7CD67C7EB /* Utils.bundle in Resources */,
 			);

--- a/tools/generator/src/Extensions/Sorting.swift
+++ b/tools/generator/src/Extensions/Sorting.swift
@@ -14,6 +14,31 @@ extension PBXFileElement {
             return cached
         }
 
+        let ret = """
+\(name ?? path ?? "")\t\(name ?? "")\t\(path ?? "")
+"""
+        Self.cache[uuid] = ret
+        return ret
+    }
+}
+
+extension PBXBuildFile {
+    private static var cache: [String: String] = [:]
+    private static let cacheLock = NSRecursiveLock()
+
+    var namePathSortString: String {
+        Self.cacheLock.lock()
+        defer {
+            Self.cacheLock.unlock()
+        }
+        if let cached = Self.cache[uuid] {
+            return cached
+        }
+
+        let name = file!.name
+        let path = file!.path
+        let parent = file!.parent
+
         let parentNamePathSortString = parent?.namePathSortString ?? ""
         let ret = """
 \(name ?? path ?? "")\t\(name ?? "")\t\(path ?? "")\t\(parentNamePathSortString)
@@ -62,7 +87,7 @@ extension Array where Element == PBXFileElement {
 
 extension Sequence where Element == PBXBuildFile {
     func sortedLocalizedStandard() -> [Element] {
-        return sortedLocalizedStandard(\.file!.namePathSortString)
+        return sortedLocalizedStandard(\.namePathSortString)
     }
 }
 


### PR DESCRIPTION
Regressed with 9041dc2af622df7b3c0221add5ff1cbf07dc5b1b.

We are caching the non-fully created tree result in `PBXFileElement.namePathSortString`, so we need a new cache for `PBXBuildFile` explicitly, which can take into account the parent.