### PR TITLE
Fix `import_indexstores.sh` when using `swift.remap_xcode_path`

### DIFF
--- a/xcodeproj/internal/bazel_integration_files/import_indexstores.sh
+++ b/xcodeproj/internal/bazel_integration_files/import_indexstores.sh
@@ -99,9 +99,9 @@ remaps=(
   # The only other type of path in the unit files are sysroot based. While
   # these should always be Xcode.app relative, our regex supports command-line
   # tools based paths as well.
-  -remap "^(?:.*?/[^/]+/Contents/Developer|/Library/Developer/CommandLineTools).*?/SDKs/([^\\d.]+)=$DEVELOPER_DIR/Platforms/\$1.platform/Developer/SDKs/\$1"
-
-  -remap "DEVELOPER_DIR=$DEVELOPER_DIR"
+  # `DEVELOPER_DIR` has an optional `./` prefix, because index-import adds `./`
+  # to all relative paths.
+  -remap "(?:.*?/[^/]+/Contents/Developer|(?:./)?DEVELOPER_DIR|/Library/Developer/CommandLineTools).*?/SDKs/([^\\d.]+)=$DEVELOPER_DIR/Platforms/\$1.platform/Developer/SDKs/\$1"
 )
 
 # Import

--- a/xcodeproj/internal/bazel_integration_files/import_indexstores.sh
+++ b/xcodeproj/internal/bazel_integration_files/import_indexstores.sh
@@ -100,6 +100,8 @@ remaps=(
   # these should always be Xcode.app relative, our regex supports command-line
   # tools based paths as well.
   -remap "^(?:.*?/[^/]+/Contents/Developer|/Library/Developer/CommandLineTools).*?/SDKs/([^\\d.]+)=$DEVELOPER_DIR/Platforms/\$1.platform/Developer/SDKs/\$1"
+
+  -remap "DEVELOPER_DIR=$DEVELOPER_DIR"
 )
 
 # Import


### PR DESCRIPTION
Post rules_swift 1.6.0 release, "DEVELOPER_DIR" remapping was enabled by default.
I was debugging a different indexing issue and hence came across an observation where this is not remapped to local machine dev directory.
I also haven't seen any issue with rules_xcodeproj indexing so in case this is not needed, happy to abandon it.

Before this change:
[ContentView.o-3P4ZTLDW8HNC.zip](https://github.com/MobileNativeFoundation/rules_xcodeproj/files/11278087/ContentView.o-3P4ZTLDW8HNC.zip)

After this change:
[ContentView.o-3P4ZTLDW8HNC.zip](https://github.com/MobileNativeFoundation/rules_xcodeproj/files/11278090/ContentView.o-3P4ZTLDW8HNC.zip)
