### PR TITLE
Stop producing unneeded output groups

### DIFF
--- a/xcodeproj/internal/input_files.bzl
+++ b/xcodeproj/internal/input_files.bzl
@@ -598,14 +598,17 @@ def _collect_input_files(
         modulemaps = modulemaps_depset.to_list()
 
     if id:
-        compiling_output_group_name = "xc {}".format(id)
-        indexstores_output_group_name = "xi {}".format(id)
-        linking_output_group_name = "xl {}".format(id)
-
         compiling_files = depset(
             modulemaps,
             transitive = [generated_depset],
         )
+    else:
+        compiling_files = generated_depset
+
+    if id and ctx.attr._build_mode == "xcode":
+        compiling_output_group_name = "xc {}".format(id)
+        indexstores_output_group_name = "xi {}".format(id)
+        linking_output_group_name = "xl {}".format(id)
 
         indexstores_filelist = filelists.write(
             ctx = ctx,
@@ -627,7 +630,6 @@ def _collect_input_files(
         compiling_output_group_name = None
         indexstores_output_group_name = None
         linking_output_group_name = None
-        compiling_files = generated_depset
         direct_group_list = None
 
     if not unfocused_libraries:

--- a/xcodeproj/internal/output_files.bzl
+++ b/xcodeproj/internal/output_files.bzl
@@ -280,7 +280,7 @@ def _collect_output_files(
         inputs = None,
         transitive_infos,
         should_produce_dto = True,
-        should_produce_output_groups = None):
+        should_produce_output_groups = True):
     """Collects the outputs of a target.
 
     Args:
@@ -309,7 +309,7 @@ def _collect_output_files(
         An opaque `struct` that should be used with `output_files.to_dto` or
         `output_files.to_output_groups_fields`.
     """
-    if should_produce_output_groups == None:
+    if should_produce_output_groups:
         should_produce_output_groups = ctx.attr._build_mode != "xcode"
 
     outputs = _get_outputs(

--- a/xcodeproj/internal/output_files.bzl
+++ b/xcodeproj/internal/output_files.bzl
@@ -280,7 +280,7 @@ def _collect_output_files(
         inputs = None,
         transitive_infos,
         should_produce_dto = True,
-        should_produce_output_groups = True):
+        should_produce_output_groups = None):
     """Collects the outputs of a target.
 
     Args:
@@ -309,6 +309,9 @@ def _collect_output_files(
         An opaque `struct` that should be used with `output_files.to_dto` or
         `output_files.to_output_groups_fields`.
     """
+    if should_produce_output_groups == None:
+        should_produce_output_groups = ctx.attr._build_mode != "xcode"
+
     outputs = _get_outputs(
         debug_outputs = debug_outputs,
         id = id,


### PR DESCRIPTION
In BwB mode we don’t need the BwX mode output groups, and vice versa.