### PR TITLE
Actually fix `PBXBuildFile` sorting

### DIFF
--- a/examples/integration/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -8816,10 +8816,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				A7EE330C67CB794EA5DC8FCE /* Assets.xcassets in Resources */,
-				130B4EF21F478D0D76C741D0 /* bucket in Resources */,
-				EB509AB2045BC989DBE6563C /* bucket in Resources */,
 				57B6669C9AE0F887A3D54BDA /* bucket in Resources */,
 				96536BFC80D7064031732BC1 /* bucket in Resources */,
+				130B4EF21F478D0D76C741D0 /* bucket in Resources */,
+				EB509AB2045BC989DBE6563C /* bucket in Resources */,
 				A48717BC5F009B090ECFBE3D /* ExampleNestedResources.bundle in Resources */,
 				8FA8E339A4D6550088042CF4 /* nested in Resources */,
 			);
@@ -8913,8 +8913,8 @@
 			files = (
 				C96515E7CF5EB8DFDC4A4D33 /* Assets.xcassets in Resources */,
 				4BAA64EC25430110196B80F8 /* dir in Resources */,
-				3BA5C2F09EA47A66AFDDCB3F /* ExampleNestedResources.bundle in Resources */,
 				C5806E50BE8A7D0EAAB1069F /* ExampleNestedResources.bundle in Resources */,
+				3BA5C2F09EA47A66AFDDCB3F /* ExampleNestedResources.bundle in Resources */,
 				B113FDC76331C2B59078B69C /* Localizable.strings in Resources */,
 				B5B2DEF7E38E09E7CD67C7EB /* Utils.bundle in Resources */,
 			);


### PR DESCRIPTION
Old way wouldn’t take into account parent of parents, because it would end up hitting the `PBXFileElement` cache. Solution is to move the `PBXBuildFile` cache into `PBXFileElement` and use a different property recursively.