### PR TITLE
Remove unneeded `target.files.to_list()`

### DIFF
--- a/xcodeproj/internal/input_files.bzl
+++ b/xcodeproj/internal/input_files.bzl
@@ -158,8 +158,6 @@ def _collect_input_files(
                 this target becomes an input to another target's categorized
                 attribute.
     """
-    output_files = target.files.to_list()
-
     entitlements = []
     c_srcs = []
     cxx_srcs = []
@@ -262,7 +260,7 @@ def _collect_input_files(
             categorized = False
 
         if file.is_source:
-            if not categorized and file not in output_files:
+            if not categorized:
                 uncategorized.append(
                     normalized_file_path(
                         file,


### PR DESCRIPTION
With other changes I think this is no longer needed (fixtures have no changes), and this reduces memory usage (even though it’s not retained, it’s adding more memory to the Starlark side it seems). I believe the original reason for having it was something involving `*_import` based rules.