### PR TITLE
Pre-filter `transitive_infos`

### DIFF
--- a/xcodeproj/internal/input_files.bzl
+++ b/xcodeproj/internal/input_files.bzl
@@ -14,7 +14,7 @@ load(
     "RESOURCES_FOLDER_TYPE_EXTENSIONS",
     "normalized_file_path",
 )
-load(":frozen_constants.bzl", "EMPTY_DEPSET", "EMPTY_LIST", "NONE_LIST")
+load(":frozen_constants.bzl", "EMPTY_DEPSET", "EMPTY_LIST")
 load(":linker_input_files.bzl", "linker_input_files")
 load(":output_files.bzl", "parse_swift_info_module", "swift_to_outputs")
 load(":providers.bzl", "XcodeProjInfo")
@@ -332,9 +332,7 @@ def _collect_input_files(
     product_framework_files = depset(
         transitive = [
             info.inputs._product_framework_files
-            for attr, info in transitive_infos
-            if (info.target_type in
-                automatic_target_info.xcode_targets.get(attr, NONE_LIST))
+            for info in transitive_infos
         ] + ([product.framework_files] if product else []),
     )
 
@@ -404,9 +402,7 @@ def _collect_input_files(
             for label, d in depset(
                 transitive = [
                     info.inputs._resource_bundle_uncategorized
-                    for attr, info in transitive_infos
-                    if (info.target_type in
-                        automatic_target_info.xcode_targets.get(attr, NONE_LIST))
+                    for info in transitive_infos
                 ],
             ).to_list()
             if label not in bundle_labels
@@ -460,9 +456,7 @@ def _collect_input_files(
             (dep_compilation_providers, _) = comp_providers.merge(
                 transitive_compilation_providers = [
                     (info.xcode_target, info.compilation_providers)
-                    for attr, info in transitive_infos
-                    if (info.target_type in
-                        automatic_target_info.xcode_targets.get(attr, NONE_LIST))
+                    for info in transitive_infos
                 ],
             )
             (
@@ -504,9 +498,7 @@ def _collect_input_files(
             non_target_swift_info_modules = depset(
                 transitive = [
                     info.inputs._non_target_swift_info_modules
-                    for attr, info in transitive_infos
-                    if (info.target_type in
-                        automatic_target_info.xcode_targets.get(attr, NONE_LIST))
+                    for info in transitive_infos
                 ],
             )
         for module in non_target_swift_info_modules.to_list():
@@ -564,9 +556,7 @@ def _collect_input_files(
         generated if generated else None,
         transitive = [
             info.inputs.generated
-            for attr, info in transitive_infos
-            if (info.target_type in
-                automatic_target_info.xcode_targets.get(attr, NONE_LIST))
+            for info in transitive_infos
         ],
     )
 
@@ -575,9 +565,7 @@ def _collect_input_files(
             indexstores if indexstores else None,
             transitive = [
                 info.inputs.indexstores
-                for attr, info in transitive_infos
-                if (info.target_type in
-                    automatic_target_info.xcode_targets.get(attr, NONE_LIST))
+                for info in transitive_infos
             ],
         )
     else:
@@ -590,9 +578,7 @@ def _collect_input_files(
         modulemaps_depset = depset(
             transitive = [
                 info.inputs._modulemaps
-                for attr, info in transitive_infos
-                if (info.target_type in
-                    automatic_target_info.xcode_targets.get(attr, NONE_LIST))
+                for info in transitive_infos
             ],
         )
 
@@ -641,9 +627,7 @@ def _collect_input_files(
         unfocused_libraries = depset(
             transitive = [
                 info.inputs.unfocused_libraries
-                for attr, info in transitive_infos
-                if (info.target_type in
-                    automatic_target_info.xcode_targets.get(attr, NONE_LIST))
+                for info in transitive_infos
             ],
         )
 
@@ -670,9 +654,7 @@ def _collect_input_files(
             resource_bundle_uncategorized_direct,
             transitive = [
                 info.inputs._resource_bundle_uncategorized
-                for attr, info in transitive_infos
-                if (info.target_type in
-                    automatic_target_info.xcode_targets.get(attr, NONE_LIST))
+                for info in transitive_infos
             ],
         )
 
@@ -707,9 +689,7 @@ def _collect_input_files(
                 direct_group_list,
                 transitive = [
                     info.inputs._output_group_list
-                    for attr, info in transitive_infos
-                    if (info.target_type in
-                        automatic_target_info.xcode_targets.get(attr, NONE_LIST))
+                    for info in transitive_infos
                 ],
             ),
             _product_framework_files = product_framework_files,
@@ -719,18 +699,14 @@ def _collect_input_files(
                 resource_bundles,
                 transitive = [
                     info.inputs.resource_bundles
-                    for attr, info in transitive_infos
-                    if (info.target_type in
-                        automatic_target_info.xcode_targets.get(attr, NONE_LIST))
+                    for info in transitive_infos
                 ],
             ),
             xccurrentversions = depset(
                 [(label, tuple(xccurrentversions))] if xccurrentversions else None,
                 transitive = [
                     info.inputs.xccurrentversions
-                    for attr, info in transitive_infos
-                    if (info.target_type in
-                        automatic_target_info.xcode_targets.get(attr, NONE_LIST))
+                    for info in transitive_infos
                 ],
             ),
             generated = generated_depset,
@@ -738,35 +714,27 @@ def _collect_input_files(
                 important_generated if important_generated else None,
                 transitive = [
                     info.inputs.important_generated
-                    for attr, info in transitive_infos
-                    if (info.target_type in
-                        automatic_target_info.xcode_targets.get(attr, NONE_LIST))
+                    for info in transitive_infos
                 ],
             ),
             has_generated_files = bool(generated) or bool([
                 True
-                for attr, info in transitive_infos
-                if (info.inputs.has_generated_files and
-                    (info.target_type in
-                     automatic_target_info.xcode_targets.get(attr, NONE_LIST)))
+                for info in transitive_infos
+                if info.inputs.has_generated_files
             ]),
             indexstores = indexstores_depset,
             extra_files = depset(
                 [(label, depset(extra_files))] if extra_files else None,
                 transitive = [
                     depset(transitive = [info.inputs.extra_files])
-                    for attr, info in transitive_infos
-                    if (info.target_type in
-                        automatic_target_info.xcode_targets.get(attr, NONE_LIST))
+                    for info in transitive_infos
                 ] + transitive_extra_files,
             ),
             uncategorized = depset(
                 [(label, depset(uncategorized))] if uncategorized else None,
                 transitive = [
                     _collect_transitive_uncategorized(info)
-                    for attr, info in transitive_infos
-                    if (info.target_type in
-                        automatic_target_info.xcode_targets.get(attr, NONE_LIST))
+                    for info in transitive_infos
                 ],
             ),
             unfocused_libraries = unfocused_libraries,
@@ -812,91 +780,91 @@ def _merge_input_files(*, transitive_infos, extra_generated = None):
         _modulemaps = depset(
             transitive = [
                 info.inputs._modulemaps
-                for _, info in transitive_infos
+                for info in transitive_infos
             ],
         ),
         _non_target_swift_info_modules = depset(
             transitive = [
                 info.inputs._non_target_swift_info_modules
-                for _, info in transitive_infos
+                for info in transitive_infos
             ],
         ),
         _output_group_list = depset(
             transitive = [
                 info.inputs._output_group_list
-                for _, info in transitive_infos
+                for info in transitive_infos
             ],
         ),
         _product_framework_files = depset(
             transitive = [
                 info.inputs._product_framework_files
-                for _, info in transitive_infos
+                for info in transitive_infos
             ],
         ),
         _resource_bundle_labels = depset(
             transitive = [
                 info.inputs._resource_bundle_labels
-                for _, info in transitive_infos
+                for info in transitive_infos
             ],
         ),
         _resource_bundle_uncategorized = depset(
             transitive = [
                 info.inputs._resource_bundle_uncategorized
-                for _, info in transitive_infos
+                for info in transitive_infos
             ],
         ),
         resource_bundles = depset(
             transitive = [
                 info.inputs.resource_bundles
-                for _, info in transitive_infos
+                for info in transitive_infos
             ],
         ),
         xccurrentversions = depset(
             transitive = [
                 info.inputs.xccurrentversions
-                for _, info in transitive_infos
+                for info in transitive_infos
             ],
         ),
         generated = depset(
             extra_generated if extra_generated else None,
             transitive = [
                 info.inputs.generated
-                for _, info in transitive_infos
+                for info in transitive_infos
             ],
         ),
         important_generated = depset(
             transitive = [
                 info.inputs.important_generated
-                for _, info in transitive_infos
+                for info in transitive_infos
             ],
         ),
         has_generated_files = bool([
             True
-            for _, info in transitive_infos
+            for info in transitive_infos
             if info.inputs.has_generated_files
         ]),
         indexstores = depset(
             transitive = [
                 info.inputs.indexstores
-                for _, info in transitive_infos
+                for info in transitive_infos
             ],
         ),
         extra_files = depset(
             transitive = [
                 info.inputs.extra_files
-                for _, info in transitive_infos
+                for info in transitive_infos
             ],
         ),
         uncategorized = depset(
             transitive = [
                 info.inputs.uncategorized
-                for _, info in transitive_infos
+                for info in transitive_infos
             ],
         ),
         unfocused_libraries = depset(
             transitive = [
                 info.inputs.unfocused_libraries
-                for _, info in transitive_infos
+                for info in transitive_infos
             ],
         ),
     )

--- a/xcodeproj/internal/library_targets.bzl
+++ b/xcodeproj/internal/library_targets.bzl
@@ -60,9 +60,16 @@ def process_library_target(
         "PRODUCT_MODULE_NAME",
         get_product_module_name(ctx = ctx, target = target),
     )
+
+    valid_transitive_infos = [
+        info
+        for attr, info in transitive_infos
+        if (info.target_type in
+            automatic_target_info.xcode_targets.get(attr, NONE_LIST))
+    ]
+
     dependencies, transitive_dependencies = process_dependencies(
-        automatic_target_info = automatic_target_info,
-        transitive_infos = transitive_infos,
+        transitive_infos = valid_transitive_infos,
     )
 
     deps_infos = [
@@ -128,7 +135,7 @@ def process_library_target(
         linker_inputs = linker_inputs,
         automatic_target_info = automatic_target_info,
         modulemaps = modulemaps,
-        transitive_infos = transitive_infos,
+        transitive_infos = valid_transitive_infos,
     )
     debug_outputs = target[apple_common.AppleDebugOutputs] if apple_common.AppleDebugOutputs in target else None
     output_group_info = target[OutputGroupInfo] if OutputGroupInfo in target else None
@@ -139,7 +146,7 @@ def process_library_target(
         inputs = target_inputs,
         output_group_info = output_group_info,
         swift_info = swift_info,
-        transitive_infos = transitive_infos,
+        transitive_infos = valid_transitive_infos,
     )
 
     if target_inputs.pch:

--- a/xcodeproj/internal/non_xcode_targets.bzl
+++ b/xcodeproj/internal/non_xcode_targets.bzl
@@ -93,9 +93,15 @@ rules_xcodeproj requires {} to have `{}` set.
     )
     swiftmodules = process_swiftmodules(swift_info = swift_info)
 
+    valid_transitive_infos = [
+        info
+        for attr, info in transitive_infos
+        if (info.target_type in
+            automatic_target_info.xcode_targets.get(attr, NONE_LIST))
+    ]
+
     dependencies, transitive_dependencies = process_dependencies(
-        automatic_target_info = automatic_target_info,
-        transitive_infos = transitive_infos,
+        transitive_infos = valid_transitive_infos,
     )
 
     mergable_xcode_library_targets = [
@@ -121,12 +127,11 @@ rules_xcodeproj requires {} to have `{}` set.
         product = None,
         linker_inputs = linker_inputs,
         automatic_target_info = automatic_target_info,
-        transitive_infos = transitive_infos,
+        transitive_infos = valid_transitive_infos,
     )
     (_, provider_outputs) = output_files.merge(
         ctx = ctx,
-        automatic_target_info = automatic_target_info,
-        transitive_infos = transitive_infos,
+        transitive_infos = valid_transitive_infos,
     )
 
     return processed_target(
@@ -140,12 +145,7 @@ rules_xcodeproj requires {} to have `{}` set.
             # TODO: Should we still collect this?
             clang_opts = [],
             swiftmodules = swiftmodules,
-            transitive_infos = [
-                info
-                for attr, info in transitive_infos
-                if (info.target_type in
-                    automatic_target_info.xcode_targets.get(attr, NONE_LIST))
-            ],
+            transitive_infos = valid_transitive_infos,
         ),
         mergable_xcode_library_targets = mergable_xcode_library_targets,
         outputs = provider_outputs,

--- a/xcodeproj/internal/target_properties.bzl
+++ b/xcodeproj/internal/target_properties.bzl
@@ -1,7 +1,6 @@
 """Functions for processing target properties"""
 
 load(":collections.bzl", "set_if_true", "uniq")
-load(":frozen_constants.bzl", "NONE_LIST")
 
 def should_include_non_xcode_outputs(ctx):
     """Determines whether outputs of non Xcode targets should be included in \
@@ -16,12 +15,12 @@ def should_include_non_xcode_outputs(ctx):
     """
     return ctx.attr._build_mode == "xcode"
 
-def process_dependencies(*, automatic_target_info, transitive_infos):
+def process_dependencies(*, transitive_infos):
     """Logic for processing target dependencies.
 
     Args:
-        automatic_target_info: Attribute information
-        transitive_infos: Transitive information of the deps
+        transitive_infos: A `list` of `XcodeProjInfo`s for the transitive
+            dependencies of `target`.
 
     Returns:
         A `tuple` containing two elements:
@@ -32,13 +31,7 @@ def process_dependencies(*, automatic_target_info, transitive_infos):
     direct_dependencies = []
     direct_transitive_dependencies = []
     all_transitive_dependencies = []
-    for attr, info in transitive_infos:
-        if not (not automatic_target_info or
-                info.target_type in automatic_target_info.xcode_targets.get(
-                    attr,
-                    NONE_LIST,
-                )):
-            continue
+    for info in transitive_infos:
         all_transitive_dependencies.append(info.transitive_dependencies)
         if info.xcode_target and info.xcode_target.should_create_xcode_target:
             # TODO: Refactor `should_create_xcode_target` and

--- a/xcodeproj/internal/top_level_targets.bzl
+++ b/xcodeproj/internal/top_level_targets.bzl
@@ -184,9 +184,16 @@ def process_top_level_target(
     configuration = get_configuration(ctx)
     label = target.label
     id = get_id(label = label, configuration = configuration)
+
+    valid_transitive_infos = [
+        info
+        for attr, info in transitive_infos
+        if (info.target_type in
+            automatic_target_info.xcode_targets.get(attr, NONE_LIST))
+    ]
+
     dependencies, transitive_dependencies = process_dependencies(
-        automatic_target_info = automatic_target_info,
-        transitive_infos = transitive_infos,
+        transitive_infos = valid_transitive_infos,
     )
 
     frameworks = getattr(ctx.rule.attr, "frameworks", [])
@@ -385,7 +392,7 @@ def process_top_level_target(
         automatic_target_info = automatic_target_info,
         additional_files = additional_files,
         modulemaps = modulemaps,
-        transitive_infos = transitive_infos,
+        transitive_infos = valid_transitive_infos,
         avoid_deps = avoid_deps,
     )
     debug_outputs = target[apple_common.AppleDebugOutputs] if apple_common.AppleDebugOutputs in target else None
@@ -399,7 +406,7 @@ def process_top_level_target(
         swift_info = swift_info,
         top_level_product = product,
         infoplist = infoplist,
-        transitive_infos = transitive_infos,
+        transitive_infos = valid_transitive_infos,
     )
 
     if target_inputs.entitlements:
@@ -546,9 +553,7 @@ def process_top_level_target(
             xcode_required_targets = depset(
                 transitive = [
                     info.xcode_required_targets
-                    for attr, info in transitive_infos
-                    if (info.target_type in
-                        automatic_target_info.xcode_targets.get(attr, NONE_LIST))
+                    for info in valid_transitive_infos
                 ],
             ),
         ),

--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -294,7 +294,7 @@ def _process_targets(
     xcode_configurations = {}
     for xcode_configuration, i in infos_per_xcode_configuration.items():
         configuration_inputs = input_files.merge(
-            transitive_infos = [(None, info) for info in i],
+            transitive_infos = i,
         )
         configuration_resource_bundle_xcode_targets = process_resource_bundles(
             bundles = configuration_inputs.resource_bundles.to_list(),
@@ -1583,12 +1583,11 @@ configurations: {}""".format(", ".join(xcode_configurations)))
 
     (_, provider_outputs) = output_files.merge(
         ctx = ctx,
-        automatic_target_info = None,
-        transitive_infos = [(None, info) for info in infos],
+        transitive_infos = infos,
     )
 
     inputs = input_files.merge(
-        transitive_infos = [(None, info) for info in infos],
+        transitive_infos = infos,
     )
     focused_labels = {label: None for label in ctx.attr.focused_targets}
     unfocused_labels = {label: None for label in ctx.attr.unfocused_targets}

--- a/xcodeproj/internal/xcodeprojinfo.bzl
+++ b/xcodeproj/internal/xcodeprojinfo.bzl
@@ -232,15 +232,18 @@ def _skip_target(
         ],
     )
 
+    valid_transitive_infos = [
+        info
+        for _, info in transitive_infos
+    ]
+
     dependencies, transitive_dependencies = process_dependencies(
-        automatic_target_info = None,
-        transitive_infos = transitive_infos,
+        transitive_infos = valid_transitive_infos,
     )
 
     (_, provider_outputs) = output_files.merge(
         ctx = ctx,
-        automatic_target_info = None,
-        transitive_infos = transitive_infos,
+        transitive_infos = valid_transitive_infos,
     )
 
     return _target_info_fields(
@@ -259,7 +262,7 @@ def _skip_target(
             ],
             transitive = [
                 info.args
-                for _, info in transitive_infos
+                for info in valid_transitive_infos
             ],
         ),
         compilation_providers = compilation_providers,
@@ -267,31 +270,28 @@ def _skip_target(
         extension_infoplists = depset(
             transitive = [
                 info.extension_infoplists
-                for _, info in transitive_infos
+                for info in valid_transitive_infos
             ],
         ),
         hosted_targets = depset(
             transitive = [
                 info.hosted_targets
-                for _, info in transitive_infos
+                for info in valid_transitive_infos
             ],
         ),
         inputs = input_files.merge(
-            transitive_infos = transitive_infos,
+            transitive_infos = valid_transitive_infos,
         ),
         lldb_context = lldb_contexts.collect(
             id = None,
             is_swift = False,
             clang_opts = EMPTY_LIST,
-            transitive_infos = [
-                info
-                for _, info in transitive_infos
-            ],
+            transitive_infos = valid_transitive_infos,
         ),
         mergable_xcode_library_targets = depset(
             transitive = [
                 info.mergable_xcode_library_targets
-                for _, info in transitive_infos
+                for info in valid_transitive_infos
             ],
         ),
         non_top_level_rule_kind = None,
@@ -299,7 +299,7 @@ def _skip_target(
         potential_target_merges = depset(
             transitive = [
                 info.potential_target_merges
-                for _, info in transitive_infos
+                for info in valid_transitive_infos
             ],
         ),
         replacement_labels = depset(
@@ -312,13 +312,13 @@ def _skip_target(
             ],
             transitive = [
                 info.replacement_labels
-                for _, info in transitive_infos
+                for info in valid_transitive_infos
             ],
         ),
         resource_bundle_informations = depset(
             transitive = [
                 info.resource_bundle_informations
-                for _, info in transitive_infos
+                for info in valid_transitive_infos
             ],
         ),
         target_type = target_type.compile,
@@ -337,18 +337,21 @@ def _skip_target(
             ],
             transitive = [
                 info.envs
-                for _, info in transitive_infos
+                for info in valid_transitive_infos
             ],
         ),
         transitive_dependencies = transitive_dependencies,
         xcode_target = None,
         xcode_targets = depset(
-            transitive = [info.xcode_targets for _, info in transitive_infos],
+            transitive = [
+                info.xcode_targets
+                for info in valid_transitive_infos
+            ],
         ),
         xcode_required_targets = depset(
             transitive = [
                 info.xcode_required_targets
-                for _, info in transitive_infos
+                for info in valid_transitive_infos
             ],
         ),
     )


### PR DESCRIPTION
I should have done this a long time ago, but there used to be some more logic around these lists. This is mainly a CPU win, but also a huge readability win.