### PR TITLE
Rename `unfocused_libraries` to `bwx_unfocused_libraries`

### DIFF
--- a/xcodeproj/internal/input_files.bzl
+++ b/xcodeproj/internal/input_files.bzl
@@ -450,7 +450,7 @@ def _collect_input_files(
 
     # Collect unfocused target info
     indexstores = []
-    unfocused_libraries = None
+    bwx_unfocused_libraries = None
     if should_include_non_xcode_outputs(ctx = ctx):
         if unfocused == None:
             (dep_compilation_providers, _) = comp_providers.merge(
@@ -472,7 +472,7 @@ def _collect_input_files(
             unfocused = bool(direct_libraries)
             if unfocused:
                 generated.extend(transitive_libraries)
-                unfocused_libraries = depset(
+                bwx_unfocused_libraries = depset(
                     [
                         file.path
                         for file in transitive_libraries
@@ -623,10 +623,10 @@ def _collect_input_files(
         linking_output_group_name = None
         direct_group_list = None
 
-    if not unfocused_libraries:
-        unfocused_libraries = depset(
+    if not bwx_unfocused_libraries:
+        bwx_unfocused_libraries = depset(
             transitive = [
-                info.inputs.unfocused_libraries
+                info.inputs.bwx_unfocused_libraries
                 for info in transitive_infos
             ],
         )
@@ -740,7 +740,7 @@ def _collect_input_files(
                     for info in transitive_infos
                 ],
             ),
-            unfocused_libraries = unfocused_libraries,
+            bwx_unfocused_libraries = bwx_unfocused_libraries,
         ),
     )
 
@@ -866,9 +866,9 @@ def _merge_input_files(*, transitive_infos, extra_generated = None):
                 for info in transitive_infos
             ],
         ),
-        unfocused_libraries = depset(
+        bwx_unfocused_libraries = depset(
             transitive = [
-                info.inputs.unfocused_libraries
+                info.inputs.bwx_unfocused_libraries
                 for info in transitive_infos
             ],
         ),

--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -61,19 +61,19 @@ def _calculate_unfocused_dependencies(
         build_mode,
         targets,
         focused_targets,
-        unfocused_libraries,
+        bwx_unfocused_libraries,
         unfocused_targets):
     if build_mode != "xcode":
         return {}
 
     automatic_unfocused_dependencies = []
     transitive_focused_dependencies = []
-    if unfocused_targets or unfocused_libraries:
+    if unfocused_targets or bwx_unfocused_libraries:
         for xcode_target in focused_targets:
             transitive_focused_dependencies.append(
                 xcode_target.transitive_dependencies,
             )
-            if xcode_target.product.file_path in unfocused_libraries:
+            if xcode_target.product.file_path in bwx_unfocused_libraries:
                 automatic_unfocused_dependencies.append(xcode_target.id)
 
     transitive_dependencies = []
@@ -407,9 +407,9 @@ targets.
             else:
                 warn(message)
 
-    unfocused_libraries = {
+    bwx_unfocused_libraries = {
         library: None
-        for library in inputs.unfocused_libraries.to_list()
+        for library in inputs.bwx_unfocused_libraries.to_list()
     }
     has_focused_labels = bool(focused_labels)
 
@@ -543,11 +543,11 @@ targets.
         build_mode = build_mode,
         targets = unprocessed_targets,
         focused_targets = focused_targets.values(),
-        unfocused_libraries = unfocused_libraries,
+        bwx_unfocused_libraries = bwx_unfocused_libraries,
         unfocused_targets = unfocused_targets,
     )
 
-    has_automatic_unfocused_targets = bool(unfocused_libraries)
+    has_automatic_unfocused_targets = bool(bwx_unfocused_libraries)
     has_unfocused_targets = bool(unfocused_targets)
     include_lldb_context = (
         has_unfocused_targets or


### PR DESCRIPTION
Makes it clear it’s only used in BwX mode.