### PR TITLE
Add pch files to `extra_files`

### DIFF
--- a/examples/integration/test/fixtures/bwb_project_spec.json
+++ b/examples/integration/test/fixtures/bwb_project_spec.json
@@ -276,6 +276,7 @@
         "iOSApp/Source/CoreUtilsMixed/MixedAnswer/BUILD",
         "iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer.h",
         "iOSApp/Source/CoreUtilsObjC/BUILD",
+        "iOSApp/Source/CoreUtilsObjC/CoreUtils/CoreUtils.pch",
         "iOSApp/Source/CoreUtilsObjC/Info.plist",
         "iOSApp/Source/Info.plist",
         "iOSApp/Source/Utils/BUILD",

--- a/examples/integration/test/fixtures/bwb_targets_spec.json
+++ b/examples/integration/test/fixtures/bwb_targets_spec.json
@@ -5037,7 +5037,6 @@
             "h": [
                 "iOSApp/Source/CoreUtilsObjC/CoreUtils/Answers.h"
             ],
-            "p": "iOSApp/Source/CoreUtilsObjC/CoreUtils/CoreUtils.pch",
             "s": [
                 "iOSApp/Source/CoreUtilsObjC/Answers.mm",
                 "iOSApp/Source/CoreUtilsObjC/CoreUtils/Answers.h",
@@ -5094,7 +5093,6 @@
             "h": [
                 "iOSApp/Source/CoreUtilsObjC/CoreUtils/Answers.h"
             ],
-            "p": "iOSApp/Source/CoreUtilsObjC/CoreUtils/CoreUtils.pch",
             "s": [
                 "iOSApp/Source/CoreUtilsObjC/Answers.mm",
                 "iOSApp/Source/CoreUtilsObjC/CoreUtils/Answers.h",
@@ -5154,7 +5152,6 @@
             "h": [
                 "iOSApp/Source/CoreUtilsObjC/CoreUtils/Answers.h"
             ],
-            "p": "iOSApp/Source/CoreUtilsObjC/CoreUtils/CoreUtils.pch",
             "s": [
                 "iOSApp/Source/CoreUtilsObjC/Answers.mm",
                 "iOSApp/Source/CoreUtilsObjC/CoreUtils/Answers.h",
@@ -5211,7 +5208,6 @@
             "h": [
                 "iOSApp/Source/CoreUtilsObjC/CoreUtils/Answers.h"
             ],
-            "p": "iOSApp/Source/CoreUtilsObjC/CoreUtils/CoreUtils.pch",
             "s": [
                 "iOSApp/Source/CoreUtilsObjC/Answers.mm",
                 "iOSApp/Source/CoreUtilsObjC/CoreUtils/Answers.h",

--- a/examples/integration/test/fixtures/bwx_project_spec.json
+++ b/examples/integration/test/fixtures/bwx_project_spec.json
@@ -264,6 +264,7 @@
         "iOSApp/Source/CoreUtilsMixed/MixedAnswer/BUILD",
         "iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer.h",
         "iOSApp/Source/CoreUtilsObjC/BUILD",
+        "iOSApp/Source/CoreUtilsObjC/CoreUtils/CoreUtils.pch",
         "iOSApp/Source/CoreUtilsObjC/Info.plist",
         "iOSApp/Source/Info.plist",
         "iOSApp/Source/Utils/BUILD",

--- a/examples/integration/test/fixtures/bwx_targets_spec.json
+++ b/examples/integration/test/fixtures/bwx_targets_spec.json
@@ -5257,7 +5257,6 @@
             "h": [
                 "iOSApp/Source/CoreUtilsObjC/CoreUtils/Answers.h"
             ],
-            "p": "iOSApp/Source/CoreUtilsObjC/CoreUtils/CoreUtils.pch",
             "s": [
                 "iOSApp/Source/CoreUtilsObjC/Answers.mm",
                 "iOSApp/Source/CoreUtilsObjC/CoreUtils/Answers.h",
@@ -5309,7 +5308,6 @@
             "h": [
                 "iOSApp/Source/CoreUtilsObjC/CoreUtils/Answers.h"
             ],
-            "p": "iOSApp/Source/CoreUtilsObjC/CoreUtils/CoreUtils.pch",
             "s": [
                 "iOSApp/Source/CoreUtilsObjC/Answers.mm",
                 "iOSApp/Source/CoreUtilsObjC/CoreUtils/Answers.h",
@@ -5364,7 +5362,6 @@
             "h": [
                 "iOSApp/Source/CoreUtilsObjC/CoreUtils/Answers.h"
             ],
-            "p": "iOSApp/Source/CoreUtilsObjC/CoreUtils/CoreUtils.pch",
             "s": [
                 "iOSApp/Source/CoreUtilsObjC/Answers.mm",
                 "iOSApp/Source/CoreUtilsObjC/CoreUtils/Answers.h",
@@ -5416,7 +5413,6 @@
             "h": [
                 "iOSApp/Source/CoreUtilsObjC/CoreUtils/Answers.h"
             ],
-            "p": "iOSApp/Source/CoreUtilsObjC/CoreUtils/CoreUtils.pch",
             "s": [
                 "iOSApp/Source/CoreUtilsObjC/Answers.mm",
                 "iOSApp/Source/CoreUtilsObjC/CoreUtils/Answers.h",

--- a/examples/rules_ios/test/fixtures/bwb_targets_spec.json
+++ b/examples/rules_ios/test/fixtures/bwb_targets_spec.json
@@ -600,7 +600,6 @@
         ],
         "f": true,
         "i": {
-            "p": "external/build_bazel_rules_ios/rules/library/common.pch",
             "s": [
                 "iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer.m"
             ]
@@ -631,7 +630,6 @@
         ],
         "f": true,
         "i": {
-            "p": "external/build_bazel_rules_ios/rules/library/common.pch",
             "s": [
                 "iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer.m"
             ]
@@ -785,7 +783,6 @@
         },
         "c": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-2",
         "i": {
-            "p": "iOSApp/Source/CoreUtilsObjC/CoreUtils/CoreUtils.pch",
             "s": [
                 "iOSApp/Source/CoreUtilsObjC/Answers.mm",
                 "iOSApp/Source/CoreUtilsObjC/CoreUtils/RealAnswer.h"
@@ -814,7 +811,6 @@
         },
         "c": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
         "i": {
-            "p": "iOSApp/Source/CoreUtilsObjC/CoreUtils/CoreUtils.pch",
             "s": [
                 "iOSApp/Source/CoreUtilsObjC/Answers.mm",
                 "iOSApp/Source/CoreUtilsObjC/CoreUtils/RealAnswer.h"
@@ -874,7 +870,6 @@
         ],
         "f": true,
         "i": {
-            "p": "external/build_bazel_rules_ios/rules/library/common.pch",
             "s": [
                 "iOSApp/Source/Utils/Foo.m"
             ]
@@ -1159,7 +1154,6 @@
         ],
         "f": true,
         "i": {
-            "p": "external/build_bazel_rules_ios/rules/library/common.pch",
             "s": [
                 "iOSApp/Test/MixedUnitTests/ObjCUnitTests.m"
             ]
@@ -1246,7 +1240,6 @@
         "f": true,
         "h": "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-dbg-STABLE-3",
         "i": {
-            "p": "external/build_bazel_rules_ios/rules/library/common.pch",
             "s": [
                 "iOSApp/Test/ObjCUnitTests/ObjCUnitTests.m"
             ]

--- a/tools/generator/src/DTO/Inputs.swift
+++ b/tools/generator/src/DTO/Inputs.swift
@@ -2,7 +2,6 @@ struct Inputs: Equatable {
     var srcs: [FilePath]
     var nonArcSrcs: [FilePath]
     let hdrs: Set<FilePath>
-    var pch: FilePath?
     var resources: Set<FilePath>
     var entitlements: FilePath?
 
@@ -10,14 +9,12 @@ struct Inputs: Equatable {
         srcs: [FilePath] = [],
         nonArcSrcs: [FilePath] = [],
         hdrs: Set<FilePath> = [],
-        pch: FilePath? = nil,
         resources: Set<FilePath> = [],
         entitlements: FilePath? = nil
     ) {
         self.srcs = srcs
         self.nonArcSrcs = nonArcSrcs
         self.hdrs = hdrs
-        self.pch = pch
         self.resources = resources
         self.entitlements = entitlements
     }
@@ -30,15 +27,7 @@ extension Inputs {
         return Set(srcs)
             .union(Set(nonArcSrcs))
             .union(Set(hdrs))
-            .union(pchSet)
             .union(entitlementsSet)
-    }
-
-    private var pchSet: Set<FilePath> {
-        guard let pch = pch else {
-            return []
-        }
-        return [pch]
     }
 
     private var entitlementsSet: Set<FilePath> {
@@ -56,7 +45,6 @@ extension Inputs: Decodable {
         case srcs = "s"
         case nonArcSrcs = "n"
         case hdrs = "h"
-        case pch = "p"
         case resources = "r"
         case folderResources = "f"
         case entitlements = "e"
@@ -68,7 +56,6 @@ extension Inputs: Decodable {
         srcs = try container.decodeFilePaths(.srcs)
         nonArcSrcs = try container.decodeFilePaths(.nonArcSrcs)
         hdrs = try container.decodeFilePaths(.hdrs)
-        pch = try container.decodeIfPresent(FilePath.self, forKey: .pch)
         resources = try Set(
             container.decodeFilePaths(.resources) +
             container.decodeFolderFilePaths(.folderResources)

--- a/tools/generator/test/Fixtures.swift
+++ b/tools/generator/test/Fixtures.swift
@@ -176,8 +176,7 @@ enum Fixtures {
             ),
             inputs: .init(
                 srcs: ["a/b/c.m"],
-                hdrs: ["a/b/c.h"],
-                pch: "a/b/c.pch"
+                hdrs: ["a/b/c.h"]
             )
         ),
         "C 2": Target.mock(
@@ -654,14 +653,6 @@ enum Fixtures {
             path: "c.m"
         )
 
-        // a/b/c.pch
-
-        elements["a/b/c.pch"] = PBXFileReference(
-            sourceTree: .group,
-            lastKnownFileType: "sourcecode.c.h",
-            path: "c.pch"
-        )
-
         // a/b/d.m
 
         elements["a/b/d.m"] = PBXFileReference(
@@ -676,7 +667,6 @@ enum Fixtures {
             children: [
                 elements["a/b/c.h"]!,
                 elements["a/b/c.m"]!,
-                elements["a/b/c.pch"]!,
                 elements["a/b/d.m"]!,
             ],
             sourceTree: .group,

--- a/xcodeproj/internal/input_files.bzl
+++ b/xcodeproj/internal/input_files.bzl
@@ -208,6 +208,7 @@ def _collect_input_files(
         # assigning to `pch` creates a new local variable instead of
         # assigning to the existing variable
         pch.append(file)
+        extra_files.append(file.path)
 
     # buildifier: disable=uninitialized
     def _handle_entitlements_file(file):

--- a/xcodeproj/internal/xcode_targets.bzl
+++ b/xcodeproj/internal/xcode_targets.bzl
@@ -189,7 +189,6 @@ def _to_xcode_target_inputs(inputs):
         srcs = tuple(inputs.srcs),
         non_arc_srcs = tuple(inputs.non_arc_srcs),
         hdrs = tuple(inputs.hdrs),
-        pch = inputs.pch,
         entitlements = inputs.entitlements,
         has_c_sources = inputs.has_c_sources,
         has_cxx_sources = inputs.has_cxx_sources,
@@ -335,7 +334,6 @@ def _merge_xcode_target_inputs(*, src, dest):
         srcs = src.srcs,
         non_arc_srcs = src.non_arc_srcs,
         hdrs = dest.hdrs,
-        pch = src.pch,
         entitlements = dest.entitlements,
         has_c_sources = src.has_c_sources,
         has_cxx_sources = src.has_cxx_sources,
@@ -745,7 +743,6 @@ def _inputs_to_dto(inputs):
         *   `srcs`: A `list` of `FilePath`s for `srcs`.
         *   `non_arc_srcs`: A `list` of `FilePath`s for `non_arc_srcs`.
         *   `hdrs`: A `list` of `FilePath`s for `hdrs`.
-        *   `pch`: An optional `FilePath` for `pch`.
         *   `resources`: A `list` of `FilePath`s for `resources`.
         *   `entitlements`: An optional `FilePath` for `entitlements`.
     """
@@ -762,9 +759,6 @@ def _inputs_to_dto(inputs):
     _process_attr("srcs", "s")
     _process_attr("non_arc_srcs", "n")
     _process_attr("hdrs", "h")
-
-    if inputs.pch:
-        ret["p"] = inputs.pch.path
 
     if inputs.entitlements:
         ret["e"] = inputs.entitlements.path


### PR DESCRIPTION
Since we set `GCC_PREFIX_HEADER` in Starlark, we don’t need to special case it in the generator. Reduces Starlark memory usage.