### PR TITLE
Remove an `isSwift` check

### DIFF
--- a/tools/generator/src/Generator/SetTargetConfigurations.swift
+++ b/tools/generator/src/Generator/SetTargetConfigurations.swift
@@ -424,7 +424,7 @@ $(CONFIGURATION_BUILD_DIR)
                     ])
                 }
 
-                if !target.isSwift, target.inputs.containsSourceFiles {
+                if target.inputs.containsSourceFiles {
                     if !cFlags.isEmpty {
                         cFlagsPrefix.append(contentsOf: [
                             "-ivfsoverlay",


### PR DESCRIPTION
When we have multi-language targets, this check would be incorrect. The `isEmpty` checks, along with the source file check, are all that is needed to make this work correctly.