### PR TITLE
Only merge `framework_includes` in Bazel 6+

### DIFF
--- a/xcodeproj/internal/input_files.bzl
+++ b/xcodeproj/internal/input_files.bzl
@@ -460,7 +460,7 @@ def _collect_input_files(
     bwx_unfocused_libraries = None
     if should_include_non_xcode_outputs(ctx = ctx):
         if unfocused == None:
-            (dep_compilation_providers, _) = comp_providers.merge(
+            (dep_compilation_providers, _, _) = comp_providers.merge(
                 transitive_compilation_providers = [
                     (info.xcode_target, info.compilation_providers)
                     for info in transitive_infos

--- a/xcodeproj/internal/library_targets.bzl
+++ b/xcodeproj/internal/library_targets.bzl
@@ -85,6 +85,7 @@ def process_library_target(
     (
         compilation_providers,
         implementation_compilation_context,
+        framework_includes,
     ) = comp_providers.collect(
         cc_info = target[CcInfo],
         objc = objc,
@@ -181,7 +182,7 @@ def process_library_target(
         id = id,
         is_swift = bool(swift_params),
         clang_opts = clang_opts,
-        implementation_compilation_context = implementation_compilation_context,
+        framework_includes = framework_includes,
         swiftmodules = swiftmodules,
         transitive_infos = [
             info

--- a/xcodeproj/internal/lldb_contexts.bzl
+++ b/xcodeproj/internal/lldb_contexts.bzl
@@ -7,7 +7,7 @@ def _collect_lldb_context(
         id,
         is_swift,
         clang_opts,
-        implementation_compilation_context = None,
+        framework_includes = None,
         swiftmodules = None,
         transitive_infos):
     """Collects lldb context information for a target.
@@ -16,8 +16,7 @@ def _collect_lldb_context(
         id: The unique identifier of the target.
         is_swift: Whether the target compiles Swift code.
         clang_opts: A `list` of Swift PCM (clang) compiler options.
-        implementation_compilation_context: The implementation deps aware
-            `CcCompilationContext` for the target.
+        framework_includes: A `depset` of framework include paths.
         swiftmodules: The value returned from `process_swiftmodules`.
         transitive_infos: A `list` of `XcodeProjInfo`s for the transitive
             dependencies of the target.
@@ -27,13 +26,12 @@ def _collect_lldb_context(
     """
     framework_paths = []
     clang = None
-    if id and is_swift and implementation_compilation_context:
-        clang = [(id, tuple(clang_opts))]
+    if id and is_swift:
+        if clang_opts:
+            clang = [(id, tuple(clang_opts))]
 
-        if implementation_compilation_context:
-            framework_paths = [
-                implementation_compilation_context.framework_includes,
-            ]
+        if framework_includes:
+            framework_paths = [framework_includes]
 
     return struct(
         _clang = memory_efficient_depset(

--- a/xcodeproj/internal/non_xcode_targets.bzl
+++ b/xcodeproj/internal/non_xcode_targets.bzl
@@ -76,6 +76,7 @@ rules_xcodeproj requires {} to have `{}` set.
     (
         compilation_providers,
         _,
+        _,
     ) = comp_providers.collect(
         cc_info = cc_info,
         objc = objc,

--- a/xcodeproj/internal/top_level_targets.bzl
+++ b/xcodeproj/internal/top_level_targets.bzl
@@ -333,7 +333,7 @@ def process_top_level_target(
         )
 
     if avoid_compilation_providers_list:
-        (avoid_compilation_providers, _) = comp_providers.merge(
+        (avoid_compilation_providers, _, _) = comp_providers.merge(
             transitive_compilation_providers = avoid_compilation_providers_list,
         )
     else:
@@ -356,6 +356,7 @@ def process_top_level_target(
     (
         compilation_providers,
         implementation_compilation_context,
+        framework_includes,
     ) = comp_providers.merge(
         apple_dynamic_framework_info = apple_dynamic_framework_info,
         cc_info = target[CcInfo] if CcInfo in target else None,
@@ -503,7 +504,7 @@ def process_top_level_target(
         id = id,
         is_swift = bool(swift_params),
         clang_opts = clang_opts,
-        implementation_compilation_context = implementation_compilation_context,
+        framework_includes = framework_includes,
         swiftmodules = swiftmodules,
         transitive_infos = deps_infos,
     )

--- a/xcodeproj/internal/xcodeprojinfo.bzl
+++ b/xcodeproj/internal/xcodeprojinfo.bzl
@@ -229,6 +229,7 @@ def _skip_target(
     (
         compilation_providers,
         _,
+        _,
     ) = comp_providers.merge(
         transitive_compilation_providers = [
             (


### PR DESCRIPTION
We no longer use `implementation_compilation_context` to get compiler opts in Bazel 6+. We only use it for `framework_includes`. So we don’t need to merge all of the other fields, or create a new `cc_compilation_context`, when we are Bazel 6+.