### PR TITLE
Rename `xcode_target._*_params` to `xcode_target.*_params`

### DIFF
--- a/xcodeproj/internal/xcode_targets.bzl
+++ b/xcodeproj/internal/xcode_targets.bzl
@@ -123,7 +123,6 @@ def _make_xcode_target(
         _build_settings = struct(**build_settings),
         _c_params = c_params,
         _cxx_params = cxx_params,
-        _swift_params = swift_params,
         _c_has_fortify_source = c_has_fortify_source,
         _cxx_has_fortify_source = cxx_has_fortify_source,
         _modulemaps = modulemaps,
@@ -152,6 +151,7 @@ def _make_xcode_target(
             _to_xcode_target_outputs(outputs) if not compile_targets else outputs
         ),
         should_create_xcode_target = should_create_xcode_target,
+        swift_params = swift_params,
         transitive_dependencies = transitive_dependencies,
         xcode_required_targets = xcode_required_targets,
     )
@@ -320,7 +320,7 @@ def _merge_xcode_target(*, src_swift, src_non_swift, dest):
     platform = None
     c_params = dest._c_params
     cxx_params = dest._cxx_params
-    swift_params = dest._swift_params
+    swift_params = dest.swift_params
     c_has_fortify_source = dest._c_has_fortify_source
     cxx_has_fortify_source = dest._cxx_has_fortify_source
     swiftmodules = []
@@ -328,7 +328,7 @@ def _merge_xcode_target(*, src_swift, src_non_swift, dest):
     if src_swift:
         srcs.append(src_swift)
         transitive_dependencies.append(src_swift._dependencies)
-        swift_params = src_swift._swift_params or dest._swift_params
+        swift_params = src_swift.swift_params or dest.swift_params
         platform = src_swift.platform
         swiftmodules = src_swift._swiftmodules
         modulemaps = src_swift._modulemaps
@@ -516,7 +516,7 @@ def _set_swift_include_paths(
         build_settings,
         xcode_generated_paths,
         xcode_target):
-    if not xcode_target._swift_params:
+    if not xcode_target.swift_params:
         return
 
     def _handle_swiftmodule_path(file):
@@ -655,8 +655,8 @@ def _xcode_target_to_dto(
         dto["8"] = xcode_target._c_params.path
     if xcode_target._cxx_params:
         dto["9"] = xcode_target._cxx_params.path
-    if xcode_target._swift_params:
-        dto["0"] = xcode_target._swift_params.path
+    if xcode_target.swift_params:
+        dto["0"] = xcode_target.swift_params.path
 
     set_if_true(
         dto,

--- a/xcodeproj/internal/xcode_targets.bzl
+++ b/xcodeproj/internal/xcode_targets.bzl
@@ -121,8 +121,6 @@ def _make_xcode_target(
         _package_bin_dir = package_bin_dir,
         _test_host = test_host,
         _build_settings = struct(**build_settings),
-        _c_params = c_params,
-        _cxx_params = cxx_params,
         _c_has_fortify_source = c_has_fortify_source,
         _cxx_has_fortify_source = cxx_has_fortify_source,
         _modulemaps = modulemaps,
@@ -134,6 +132,8 @@ def _make_xcode_target(
         id = id,
         label = label,
         configuration = configuration,
+        c_params = c_params,
+        cxx_params = cxx_params,
         platform = platform,
         product = product,
         linker_inputs = (
@@ -318,8 +318,8 @@ def _merge_xcode_target(*, src_swift, src_non_swift, dest):
     srcs = []
     transitive_dependencies = [dest._dependencies]
     platform = None
-    c_params = dest._c_params
-    cxx_params = dest._cxx_params
+    c_params = dest.c_params
+    cxx_params = dest.cxx_params
     swift_params = dest.swift_params
     c_has_fortify_source = dest._c_has_fortify_source
     cxx_has_fortify_source = dest._cxx_has_fortify_source
@@ -335,8 +335,8 @@ def _merge_xcode_target(*, src_swift, src_non_swift, dest):
     if src_non_swift:
         srcs.append(src_non_swift)
         transitive_dependencies.append(src_non_swift._dependencies)
-        c_params = src_non_swift._c_params or c_params
-        cxx_params = src_non_swift._cxx_params or cxx_params
+        c_params = src_non_swift.c_params or c_params
+        cxx_params = src_non_swift.cxx_params or cxx_params
         c_has_fortify_source = src_non_swift._c_has_fortify_source or c_has_fortify_source
         cxx_has_fortify_source = src_non_swift._cxx_has_fortify_source or cxx_has_fortify_source
         platform = src_non_swift.platform
@@ -651,10 +651,10 @@ def _xcode_target_to_dto(
         xcode_generated_paths_file = xcode_generated_paths_file,
     )
 
-    if xcode_target._c_params:
-        dto["8"] = xcode_target._c_params.path
-    if xcode_target._cxx_params:
-        dto["9"] = xcode_target._cxx_params.path
+    if xcode_target.c_params:
+        dto["8"] = xcode_target.c_params.path
+    if xcode_target.cxx_params:
+        dto["9"] = xcode_target.cxx_params.path
     if xcode_target.swift_params:
         dto["0"] = xcode_target.swift_params.path
 

--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -528,8 +528,8 @@ targets.
             # Only merge if one src is swift and the other isn't.
             src_1 = src_ids[0]
             src_2 = src_ids[1]
-            src_1_is_swift = unprocessed_targets[src_1]._swift_params
-            src_2_is_swift = unprocessed_targets[src_2]._swift_params
+            src_1_is_swift = unprocessed_targets[src_1].swift_params
+            src_2_is_swift = unprocessed_targets[src_2].swift_params
 
             # Only merge 1 Swift and 1 non-Swift target for now.
             if (src_1_is_swift and src_2_is_swift) or (not src_1_is_swift and not src_2_is_swift):
@@ -653,7 +653,7 @@ targets.
         src_target_non_swift = None
 
         for src_target in src_targets:
-            if src_target._swift_params:
+            if src_target.swift_params:
                 src_target_swift = src_target
             else:
                 src_target_non_swift = src_target
@@ -744,8 +744,8 @@ targets.
             compile_params.append(xcode_target._c_params)
         if xcode_target._cxx_params:
             compile_params.append(xcode_target._cxx_params)
-        if xcode_target._swift_params:
-            compile_params.append(xcode_target._swift_params)
+        if xcode_target.swift_params:
+            compile_params.append(xcode_target.swift_params)
 
         if compile_params:
             target_compile_params[xcode_target.id] = depset(compile_params)

--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -740,10 +740,10 @@ targets.
         )
 
         compile_params = []
-        if xcode_target._c_params:
-            compile_params.append(xcode_target._c_params)
-        if xcode_target._cxx_params:
-            compile_params.append(xcode_target._cxx_params)
+        if xcode_target.c_params:
+            compile_params.append(xcode_target.c_params)
+        if xcode_target.cxx_params:
+            compile_params.append(xcode_target.cxx_params)
         if xcode_target.swift_params:
             compile_params.append(xcode_target.swift_params)
 


### PR DESCRIPTION
Transition `_swift_params`, `_c_params`, & `_cxx_params` to non-underscore prefix since they're used external to `xcode_targets.bzl`.