### PR TITLE
Stop storing `automatic_target_info` in `processed_target`

### DIFF
--- a/xcodeproj/internal/library_targets.bzl
+++ b/xcodeproj/internal/library_targets.bzl
@@ -210,7 +210,6 @@ def process_library_target(
     ]
 
     return processed_target(
-        automatic_target_info = automatic_target_info,
         compilation_providers = compilation_providers,
         dependencies = dependencies,
         inputs = provider_inputs,

--- a/xcodeproj/internal/non_xcode_targets.bzl
+++ b/xcodeproj/internal/non_xcode_targets.bzl
@@ -128,7 +128,6 @@ rules_xcodeproj requires {} to have `{}` set.
     )
 
     return processed_target(
-        automatic_target_info = automatic_target_info,
         compilation_providers = compilation_providers,
         dependencies = dependencies,
         inputs = provider_inputs,

--- a/xcodeproj/internal/processed_target.bzl
+++ b/xcodeproj/internal/processed_target.bzl
@@ -4,7 +4,6 @@ load(":providers.bzl", "target_type")
 
 def processed_target(
         *,
-        automatic_target_info,
         compilation_providers,
         dependencies,
         extension_infoplists = None,
@@ -23,8 +22,6 @@ def processed_target(
     """Generates the return value for target processing functions.
 
     Args:
-        automatic_target_info: The `XcodeProjAutomaticTargetProcessingInfo` for
-            the target.
         compilation_providers: A value returned from
             `compilation_providers.collect`.
         dependencies: A `depset` of target ids of direct dependencies of this
@@ -58,7 +55,6 @@ def processed_target(
         A `struct` containing fields for each argument.
     """
     return struct(
-        automatic_target_info = automatic_target_info,
         compilation_providers = compilation_providers,
         extension_infoplists = extension_infoplists,
         dependencies = dependencies,

--- a/xcodeproj/internal/top_level_targets.bzl
+++ b/xcodeproj/internal/top_level_targets.bzl
@@ -508,7 +508,6 @@ def process_top_level_target(
     )
 
     return processed_target(
-        automatic_target_info = automatic_target_info,
         compilation_providers = compilation_providers,
         dependencies = dependencies,
         extension_infoplists = extension_infoplists,

--- a/xcodeproj/internal/xcodeprojinfo.bzl
+++ b/xcodeproj/internal/xcodeprojinfo.bzl
@@ -504,7 +504,7 @@ def _create_xcodeprojinfo(
                 for info in valid_transitive_infos
             ],
         ),
-        target_type = processed_target.automatic_target_info.target_type,
+        target_type = automatic_target_info.target_type,
         envs = memory_efficient_depset(
             transitive = [
                 info.envs


### PR DESCRIPTION
Should have been removed with 1cf5e8c897e7c7774a7bfeb418de618f653fe28c.