### PR TITLE
Fix `pop` error with multiple merge destinations

### DIFF
--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -645,7 +645,7 @@ targets.
             target_merge_dests.setdefault(dest, []).append(src)
 
     for dest, srcs in target_merge_dests.items():
-        src_targets = [focused_targets.pop(src) for src in srcs]
+        src_targets = [focused_targets.pop(src, None) for src in srcs]
 
         # This functionality assumes that 2 or less sources are present in the
         # potential merge. If that changes, this will need updated.


### PR DESCRIPTION
If a library target can merge into multiple top-level targets, then the second+ destination will fail `pop()` if we don’t have a default specified.