### PR TITLE
Ensure target product file is present for merges

### DIFF
--- a/xcodeproj/internal/xcode_targets.bzl
+++ b/xcodeproj/internal/xcode_targets.bzl
@@ -425,7 +425,7 @@ def _merge_xcode_target_outputs(*, src_swift, dest):
     )
 
 def _merge_xcode_target_product(*, srcs, dest):
-    src_files = [src.file for src in srcs]
+    src_files = [src.file for src in srcs if src.file]
     src_framework_files = [src.framework_files for src in srcs]
     src_additional_files = [src._additional_files for src in srcs]
     return struct(
@@ -859,7 +859,7 @@ def _linker_inputs_to_dto(
         return ({}, None)
 
     if compile_targets:
-        self_product_paths = [compile_target.product.file.path for compile_target in compile_targets]
+        self_product_paths = [compile_target.product.file.path for compile_target in compile_targets if compile_target.product.file]
     else:
         # Handle `{cc,swift}_{binary,test}` with `srcs` case
         self_product_paths = [paths.join(


### PR DESCRIPTION
Ensure we don’t add/access `None` to a couple places in the `xcode_target` merging logic.

Error 1:
```
ERROR: /private/var/tmp/_bazel_matt.robinson/0e64031a9efbb95e4728094ee9457143/rules_xcodeproj.noindex/build_output_base/external/rules_xcodeproj_generated/generator/tests/ios/app/foo/BUILD:12:10: in xcodeproj rule @rules_xcodeproj_generated//generator/tests/ios/app/foo:foo:
Traceback (most recent call last):
	File "/private/var/tmp/_bazel_matt.robinson/0e64031a9efbb95e4728094ee9457143/rules_xcodeproj.noindex/build_output_base/external/rules_xcodeproj/xcodeproj/internal/xcodeproj_rule.bzl", line 1596, column 25, in _xcodeproj_impl
		) = _process_targets(
	File "/private/var/tmp/_bazel_matt.robinson/0e64031a9efbb95e4728094ee9457143/rules_xcodeproj.noindex/build_output_base/external/rules_xcodeproj/xcodeproj/internal/xcodeproj_rule.bzl", line 667, column 52, in _process_targets
		focused_targets[dest] = xcode_targets.merge(
	File "/private/var/tmp/_bazel_matt.robinson/0e64031a9efbb95e4728094ee9457143/rules_xcodeproj.noindex/build_output_base/external/rules_xcodeproj/xcodeproj/internal/xcode_targets.bzl", line 352, column 46, in _merge_xcode_target
		product = _merge_xcode_target_product(
	File "/private/var/tmp/_bazel_matt.robinson/0e64031a9efbb95e4728094ee9457143/rules_xcodeproj.noindex/build_output_base/external/rules_xcodeproj/xcodeproj/internal/xcode_targets.bzl", line 454, column 52, in _merge_xcode_target_product
		_additional_files = memory_efficient_depset(
	File "/private/var/tmp/_bazel_matt.robinson/0e64031a9efbb95e4728094ee9457143/rules_xcodeproj.noindex/build_output_base/external/rules_xcodeproj/xcodeproj/internal/memory_efficiency.bzl", line 25, column 22, in memory_efficient_depset
		return depset(direct, transitive = transitive, **kwargs)
Error in depset: cannot add an item of type 'NoneType' to a depset of 'File'
```

Error 2:
```
ERROR: /private/var/tmp/_bazel_matt.robinson/0e64031a9efbb95e4728094ee9457143/rules_xcodeproj.noindex/build_output_base/external/rules_xcodeproj_generated/generator/tests/ios/app/foo/BUILD:12:10: in xcodeproj rule @rules_xcodeproj_generated//generator/tests/ios/app/foo:foo:
Traceback (most recent call last):
	File "/private/var/tmp/_bazel_matt.robinson/0e64031a9efbb95e4728094ee9457143/rules_xcodeproj.noindex/build_output_base/external/rules_xcodeproj/xcodeproj/internal/xcodeproj_rule.bzl", line 1596, column 25, in _xcodeproj_impl
		) = _process_targets(
	File "/private/var/tmp/_bazel_matt.robinson/0e64031a9efbb95e4728094ee9457143/rules_xcodeproj.noindex/build_output_base/external/rules_xcodeproj/xcodeproj/internal/xcodeproj_rule.bzl", line 726, column 33, in _process_targets
		) = xcode_targets.to_dto(
	File "/private/var/tmp/_bazel_matt.robinson/0e64031a9efbb95e4728094ee9457143/rules_xcodeproj.noindex/build_output_base/external/rules_xcodeproj/xcodeproj/internal/xcode_targets.bzl", line 648, column 59, in _xcode_target_to_dto
		linker_inputs_dto, link_params = _linker_inputs_to_dto(
	File "/private/var/tmp/_bazel_matt.robinson/0e64031a9efbb95e4728094ee9457143/rules_xcodeproj.noindex/build_output_base/external/rules_xcodeproj/xcodeproj/internal/xcode_targets.bzl", line 871, column 58, in _linker_inputs_to_dto
		self_product_paths = [compile_target.product.file.path for compile_target in compile_targets]
Error: 'NoneType' value has no field or method 'path'
```

Fixes https://github.com/MobileNativeFoundation/rules_xcodeproj/issues/2021:
<img width="1512" alt="Screenshot 2023-04-28 at 10 29 34 AM" src="https://user-images.githubusercontent.com/5728070/235203031-43dfcd7f-f6e9-40ee-906f-02534a8e2a7f.png">

