### PR TITLE
Repro for failing unit test execution with focused target

### DIFF
--- a/examples/integration/BUILD
+++ b/examples/integration/BUILD
@@ -75,3 +75,12 @@ exports_files(["README.md"])
         "x86_64",
     ]
 ]
+
+xcodeproj(
+    name = "TestAppResources", 
+    build_mode = "bazel",
+    tags = ["manual"],
+    top_level_targets = XCODEPROJ_TARGETS,
+    bazel_env = BAZEL_ENV,
+    focused_targets = ["//iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTests"],
+)


### PR DESCRIPTION
**Repro steps** 
1. go to `examples/integration`
2. `bazelisk run //:TestAppResources` 
3. from Xcode, run unit test `iOSAppSwiftUnitTest` (command + U)

**Expected** 
1. Tests run successfully 

**Actual** 
Test fails execution with the following log 
```
  Assertions: System: Failed to load the test bundle. If you believe this error represents a bug, please attach the result bundle at /Users/ycho/Library/Developer/Xcode/DerivedData/TestAppResources-gxfhehvpdxlqbxbosomkihkputxm/Logs/Test/Test-iOSAppSwiftUnitTests-2023.05.09_17-05-27--0700.xcresult. (Underlying Error: The bundle “iOSAppSwiftUnitTests” couldn’t be loaded. The bundle couldn’t be loaded. Try reinstalling the bundle. dlopen(/Users/ycho/Library/Developer/Xcode/DerivedData/TestAppResources-gxfhehvpdxlqbxbosomkihkputxm/Build/Products/Debug-iphonesimulator/bazel-out/applebin_ios-ios_sim_arm64-dbg-ST-5a23df6a14d1/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.xctest/iOSAppSwiftUnitTests, 0x0109): Library not loaded: @rpath/CryptoSwift.framework/CryptoSwift
  Referenced from: <4C4C4430-5555-3144-A137-0BC7BF08F065> /Users/ycho/Library/Developer/Xcode/DerivedData/TestAppResources-gxfhehvpdxlqbxbosomkihkputxm/Build/Products/Debug-iphonesimulator/bazel-out/applebin_ios-ios_sim_arm64-dbg-ST-5a23df6a14d1/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.xctest/iOSAppSwiftUnitTests
  Reason: tried: '/Users/ycho/Library/Developer/Xcode/DerivedData/TestAppResources-gxfhehvpdxlqbxbosomkihkputxm/Build/Products/Debug-iphonesimulator/bazel-out/applebin_ios-ios_sim_arm64-dbg-ST-5a23df6a14d1/bin/iOSApp/Test/SwiftUnitTests/CryptoSwift.framework/CryptoSwift' (errno=2), '/Applications/Xcode-14.1.0.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/Library/Frameworks/CryptoSwift.framework/CryptoSwift' (errno=2), '/Applications/Xcode-14.1.0.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/swift/CryptoSwift.framework/CryptoSwift' (errno=2), '/usr/lib/swift/CryptoSwift.framework/CryptoSwift' (errno=2, not in dyld cache), '/Applications/Xcode-14.1.0.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/Library/Xcode/Agents/Frameworks/CryptoSwift.framework/CryptoSwift' (errno=2), '/Users/ycho/Library/Developer/Xcode/DerivedData/TestAppResources-gxfhehvpdxlqbxbosomkihkputxm/Build/Products/Debug-iphonesimulator/bazel-out/applebin_ios-ios_sim_arm64-dbg-ST-5a23df6a14d1/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.xctest/Frameworks/CryptoSwift.framework/CryptoSwift' (errno=2), '/Applications/Xcode-14.1.0.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/swift/CryptoSwift.framework/CryptoSwift' (errno=2), '/usr/lib/swift/CryptoSwift.framework/CryptoSwift' (errno=2, not in dyld cache), '/Applications/Xcode-14.1.0.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/Library/Xcode/Agents/Frameworks/CryptoSwift.framework/CryptoSwift' (errno=2), '/Users/ycho/Library/Developer/Xcode/DerivedData/TestAppResources-gxfhehvpdxlqbxbosomkihkputxm/Build/Products/Debug-iphonesimulator/bazel-out/applebin_ios-ios_sim_arm64-dbg-ST-5a23df6a14d1/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.xctest/Frameworks/CryptoSwift.framework/CryptoSwift' (errno=2), '/Applications/Xcode-14.1.0.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/Library/Frameworks/CryptoSwift.framework/CryptoSwift' (errno=2), '/Applications/Xcode-14.1.0.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks/CryptoSwift.framework/CryptoSwift' (errno=2), '/Applications/Xcode-14.1.0.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/usr/lib/CryptoSwift.framework/CryptoSwift' (errno=2), '/Applications/Xcode-14.1.0.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/CryptoSwift.framework/CryptoSwift' (errno=2))



```

