### PR TITLE
Always create `{external,generated}.xcfilelist` files

### DIFF
--- a/tools/generators/legacy/src/Generator/AddBazelDependenciesTarget.swift
+++ b/tools/generators/legacy/src/Generator/AddBazelDependenciesTarget.swift
@@ -12,8 +12,6 @@ extension Generator {
         defaultXcodeConfiguration: String,
         targetIdsFile: String,
         indexImport: String,
-        usesExternalFileList: Bool,
-        usesGeneratedFileList: Bool,
         bazelConfig _: String,
         preBuildScript: String?,
         postBuildScript: String?,

--- a/tools/generators/legacy/src/Generator/CreateFilesAndGroups.swift
+++ b/tools/generators/legacy/src/Generator/CreateFilesAndGroups.swift
@@ -68,9 +68,7 @@ extension Generator {
         rootElements: [PBXFileElement],
         compileStub: PBXFileReference?,
         resolvedRepositories: [(Path, Path)],
-        internalFiles: [Path: String],
-        usesExternalFileList: Bool,
-        usesGeneratedFileList: Bool
+        internalFiles: [Path: String]
     ) {
         var fileReferences: [FilePath: PBXFileReference] = [:]
         var variantGroups: [FilePath: PBXVariantGroup] = [:]
@@ -734,20 +732,12 @@ extension Generator {
         // Write xcfilelists
 
         var internalFiles: [Path: String] = [:]
-        func addXCFileList(_ path: Path, paths: [String]) -> Bool {
-            guard !paths.isEmpty else {
-                return false
-            }
-
+        func addXCFileList(_ path: Path, paths: [String]) {
             internalFiles[path] = Set(paths.map { "\($0)\n" }).sorted().joined()
-
-            return true
         }
 
-        let usesExternalFileList =
-            addXCFileList(externalFileListPath, paths: externalFileListPaths)
-        let usesGeneratedFileList =
-            addXCFileList(generatedFileListPath, paths: generatedFileListPaths)
+        addXCFileList(externalFileListPath, paths: externalFileListPaths)
+        addXCFileList(generatedFileListPath, paths: generatedFileListPaths)
 
         // Handle special groups. We add these groups last to ensure their
         // order, which is different from normal sorting. They need to come
@@ -774,9 +764,7 @@ extension Generator {
             rootElements,
             compileStub,
             resolvedRepositories,
-            internalFiles,
-            usesExternalFileList,
-            usesGeneratedFileList
+            internalFiles
         )
     }
 

--- a/tools/generators/legacy/src/Generator/Environment.swift
+++ b/tools/generators/legacy/src/Generator/Environment.swift
@@ -39,9 +39,7 @@ struct Environment {
         rootElements: [PBXFileElement],
         compileStub: PBXFileReference?,
         resolvedRepositories: [(Path, Path)],
-        internalFiles: [Path: String],
-        usesExternalFileList: Bool,
-        usesGeneratedFileList: Bool
+        internalFiles: [Path: String]
     )
 
     let setAdditionalProjectConfiguration: (
@@ -73,8 +71,6 @@ struct Environment {
         _ defaultXcodeConfiguration: String,
         _ target_ids_file: String,
         _ indexImport: String,
-        _ usesExternalFileList: Bool,
-        _ usesGeneratedFileList: Bool,
         _ bazelConfig: String,
         _ preBuildScript: String?,
         _ postBuildScript: String?,

--- a/tools/generators/legacy/src/Generator/Generator.swift
+++ b/tools/generators/legacy/src/Generator/Generator.swift
@@ -72,9 +72,7 @@ class Generator {
             rootElements,
             compileStub,
             resolvedRepositories,
-            internalFiles,
-            usesExternalFileList,
-            usesGeneratedFileList
+            internalFiles
         ) = Task {
             try environment.createFilesAndGroups(
                 pbxProj,
@@ -133,8 +131,6 @@ class Generator {
                 project.defaultXcodeConfiguration,
                 project.targetIdsFile,
                 project.indexImport,
-                usesExternalFileList,
-                usesGeneratedFileList,
                 project.bazelConfig,
                 project.preBuildScript,
                 project.postBuildScript,

--- a/tools/generators/legacy/test/CreateFilesAndGroupsTests.swift
+++ b/tools/generators/legacy/test/CreateFilesAndGroupsTests.swift
@@ -60,8 +60,6 @@ final class CreateFilesAndGroupsTests: XCTestCase {
             createdRootElements,
             _,
             _,
-            _,
-            _,
             _
         ) = try Generator.createFilesAndGroups(
             in: pbxProj,
@@ -162,9 +160,7 @@ final class CreateFilesAndGroupsTests: XCTestCase {
             createdRootElements,
             _,
             _,
-            internalFiles,
-            _,
-            _
+            internalFiles
         ) = try Generator.createFilesAndGroups(
             in: pbxProj,
             buildMode: .xcode,
@@ -271,9 +267,7 @@ final class CreateFilesAndGroupsTests: XCTestCase {
             createdRootElements,
             _,
             _,
-            internalFiles,
-            _,
-            _
+            internalFiles
         ) = try Generator.createFilesAndGroups(
             in: pbxProj,
             buildMode: .bazel,

--- a/tools/generators/legacy/test/GeneratorTests.swift
+++ b/tools/generators/legacy/test/GeneratorTests.swift
@@ -317,9 +317,7 @@ final class GeneratorTests: XCTestCase {
             rootElements: [PBXFileElement],
             compileStub: PBXFileReference?,
             resolvedRepositories: [(Path, Path)],
-            internalFiles: [Path: String],
-            usesExternalFileList: Bool,
-            usesGeneratedFileList: Bool
+            internalFiles: [Path: String]
         ) {
             createFilesAndGroupsCalled.append(.init(
                 pbxProj: pbxProj,
@@ -334,9 +332,7 @@ final class GeneratorTests: XCTestCase {
                 rootElements,
                 nil,
                 resolvedRepositories,
-                [:],
-                true,
-                true
+                [:]
             )
         }
 
@@ -482,8 +478,6 @@ final class GeneratorTests: XCTestCase {
             let defaultXcodeConfiguration: String
             let targetIdsFile: String
             let indexImport: String
-            let usesExternalFileList: Bool
-            let usesGeneratedFileList: Bool
             let bazelConfig: String
             let preBuildScript: String?
             let postBuildScript: String?
@@ -500,8 +494,6 @@ final class GeneratorTests: XCTestCase {
             defaultXcodeConfiguration: String,
             targetIdsFile: String,
             indexImport: String,
-            usesExternalFileList: Bool,
-            usesGeneratedFileList: Bool,
             bazelConfig: String,
             preBuildScript: String?,
             postBuildScript: String?,
@@ -515,8 +507,6 @@ final class GeneratorTests: XCTestCase {
                 defaultXcodeConfiguration: defaultXcodeConfiguration,
                 targetIdsFile: targetIdsFile,
                 indexImport: indexImport,
-                usesExternalFileList: usesExternalFileList,
-                usesGeneratedFileList: usesGeneratedFileList,
                 bazelConfig: bazelConfig,
                 preBuildScript: preBuildScript,
                 postBuildScript: postBuildScript,
@@ -534,8 +524,6 @@ final class GeneratorTests: XCTestCase {
                 defaultXcodeConfiguration: project.defaultXcodeConfiguration,
                 targetIdsFile: project.targetIdsFile,
                 indexImport: project.indexImport,
-                usesExternalFileList: true,
-                usesGeneratedFileList: true,
                 bazelConfig: project.bazelConfig,
                 preBuildScript: project.preBuildScript,
                 postBuildScript: project.postBuildScript,


### PR DESCRIPTION
Forgot this with a49fcc292ebb5a76b88d8b0bad9c888c62ce12b5.