### PR TITLE
Add Telegram to list of  Projects using rules_xcodeproj

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ the ruleset.
 - Snap
 - Spotify
 - SwiftLint
+- [Telegram](https://github.com/TelegramMessenger/Telegram-iOS)
 - Ten Ten
 - Tinder
 - Tokopedia


### PR DESCRIPTION
This diff adds Telegram as a Project using rules_xcodeproj.

You can check the implementation here:
https://github.com/TelegramMessenger/Telegram-iOS/blob/master/Telegram/BUILD

https://github.com/TelegramMessenger/Telegram-iOS/blob/master/WORKSPACE