### PR TITLE
Set default for `developmentRegion` in one place

### DIFF
--- a/examples/cc/test/fixtures/bwb_project_spec.json
+++ b/examples/cc/test/fixtures/bwb_project_spec.json
@@ -20,5 +20,8 @@
     "i": "fixture-index-import-path",
     "m": "13.0",
     "n": "bwb",
+    "o": {
+        "d": "en"
+    },
     "s": "auto"
 }

--- a/examples/cc/test/fixtures/bwx_project_spec.json
+++ b/examples/cc/test/fixtures/bwx_project_spec.json
@@ -20,5 +20,8 @@
     "i": "fixture-index-import-path",
     "m": "13.0",
     "n": "bwx",
+    "o": {
+        "d": "en"
+    },
     "s": "auto"
 }

--- a/examples/rules_ios/test/fixtures/bwb_project_spec.json
+++ b/examples/rules_ios/test/fixtures/bwb_project_spec.json
@@ -171,6 +171,9 @@
     "i": "fixture-index-import-path",
     "m": "13.0",
     "n": "bwb",
+    "o": {
+        "d": "en"
+    },
     "t": [
         "//WidgetExtension:WidgetExtension applebin_ios-ios_arm64-dbg-STABLE-4",
         [

--- a/examples/sanitizers/test/fixtures/bwb_project_spec.json
+++ b/examples/sanitizers/test/fixtures/bwb_project_spec.json
@@ -17,5 +17,8 @@
     "i": "fixture-index-import-path",
     "m": "13.0",
     "n": "bwb",
+    "o": {
+        "d": "en"
+    },
     "s": "none"
 }

--- a/examples/sanitizers/test/fixtures/bwx_project_spec.json
+++ b/examples/sanitizers/test/fixtures/bwx_project_spec.json
@@ -17,5 +17,8 @@
     "i": "fixture-index-import-path",
     "m": "13.0",
     "n": "bwx",
+    "o": {
+        "d": "en"
+    },
     "s": "none"
 }

--- a/test/fixtures/generator/bwb_project_spec.json
+++ b/test/fixtures/generator/bwb_project_spec.json
@@ -21,6 +21,9 @@
     "i": "fixture-index-import-path",
     "m": "13.0",
     "n": "bwb",
+    "o": {
+        "d": "en"
+    },
     "s": "none",
     "x": [
         "Debug",

--- a/test/fixtures/generator/bwx_project_spec.json
+++ b/test/fixtures/generator/bwx_project_spec.json
@@ -21,6 +21,9 @@
     "i": "fixture-index-import-path",
     "m": "13.0",
     "n": "bwx",
+    "o": {
+        "d": "en"
+    },
     "s": "none",
     "x": [
         "Debug",

--- a/tools/generators/legacy/src/DTO/Project.swift
+++ b/tools/generators/legacy/src/DTO/Project.swift
@@ -122,7 +122,7 @@ extension Project.Options: Decodable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
         developmentRegion = try container
-            .decodeIfPresent(String.self, forKey: .developmentRegion) ?? "en"
+            .decode(String.self, forKey: .developmentRegion)
         indentWidth = try container
             .decodeIfPresent(UInt.self, forKey: .indentWidth)
         organizationName = try container

--- a/tools/generators/pbxproject_prefix/README.md
+++ b/tools/generators/pbxproject_prefix/README.md
@@ -13,7 +13,7 @@ The generator accepts the following command-line arguments (see
 - Positional `workspace`
 - Positional `execution-root-file`
 - Positional `minimum-xcode-version`
-- Optional option `--development-region <development-region>`
+- Positional `development-region`
 - Optional option `--organization-name <organization-name>`
 - Flag `--colorize`
 
@@ -25,7 +25,7 @@ $ pbxproject_prefix \
     /tmp/workspace \
     bazel-output-base/rules_xcodeproj.noindex/build_output_base/execroot/_main/bazel-out/darwin_arm64-dbg/bin/external/_main~internal~rules_xcodeproj_generated/generator/tools/generators/xcodeproj/xcodeproj_execution_root_file \
     14.0 \
-    --development-region enGB \
+    enGB \
     --organization-name MobileNativeFoundation
 ```
 

--- a/tools/generators/pbxproject_prefix/src/Generator/Arguments.swift
+++ b/tools/generators/pbxproject_prefix/src/Generator/Arguments.swift
@@ -28,8 +28,8 @@ Minimum Xcode version that the generated project supports.
 """)
         var minimumXcodeVersion: SemanticVersion
 
-        @Option(help: "Development region for the project.")
-        var developmentRegion = "en"
+        @Argument(help: "Development region for the project.")
+        var developmentRegion
 
         @Option(help: """
 Populates the `ORGANIZATIONNAME` attribute for the project.

--- a/tools/generators/pbxproject_prefix/src/Generator/Arguments.swift
+++ b/tools/generators/pbxproject_prefix/src/Generator/Arguments.swift
@@ -29,7 +29,7 @@ Minimum Xcode version that the generated project supports.
         var minimumXcodeVersion: SemanticVersion
 
         @Argument(help: "Development region for the project.")
-        var developmentRegion
+        var developmentRegion: String
 
         @Option(help: """
 Populates the `ORGANIZATIONNAME` attribute for the project.

--- a/xcodeproj/internal/project_options.bzl
+++ b/xcodeproj/internal/project_options.bzl
@@ -49,7 +49,7 @@ def project_options_to_dto(project_options):
         A `dict` containing the fields of the provided `project_options` struct.
     """
     dto = {
-        "d": project_options["development_region"]
+        "d": project_options["development_region"],
     }
 
     indent_width = project_options.get("indent_width")

--- a/xcodeproj/internal/project_options.bzl
+++ b/xcodeproj/internal/project_options.bzl
@@ -48,11 +48,9 @@ def project_options_to_dto(project_options):
     Returns:
         A `dict` containing the fields of the provided `project_options` struct.
     """
-    dto = {}
-
-    development_region = project_options.get("development_region")
-    if development_region and development_region != "en":
-        dto["d"] = development_region
+    dto = {
+        "d": project_options["development_region"]
+    }
 
     indent_width = project_options.get("indent_width")
     if indent_width:


### PR DESCRIPTION
Since `ProjectOptions` is only set once per project, the spec is only slightly larger by not sending the default value. This simplifies the logic that has to change if we ever change the default, and is a slight Starlark CPU use reduction.