### PR TITLE
Add public bzl_library for xcodeproj files

### DIFF
--- a/xcodeproj/BUILD
+++ b/xcodeproj/BUILD
@@ -1,3 +1,4 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "string_flag")
 
 bool_flag(
@@ -33,6 +34,13 @@ string_flag(
 package_group(
     name = "generated",
     includes = ["@rules_xcodeproj_generated//:package_group"],
+)
+
+bzl_library(
+    name = "xcodeproj",
+    srcs = glob(["*.bzl"]),
+    visibility = ["//visibility:public"],
+    deps = ["//xcodeproj/internal:xcodeproj_internal"],
 )
 
 # Release


### PR DESCRIPTION
I have the need to generate [stardoc](https://github.com/bazelbuild/stardoc) documentation for our rules that currently import `rules_xcodeproj`. For this reason, I need to set up the full transitive set of dependencies between Starlark files. This change will make it easier for other consumers to also depend on this public `bzl_library` target.