### PR TITLE
Make iOS tests in examples manual

### DIFF
--- a/examples/integration/iOSApp/Test/BUILD
+++ b/examples/integration/iOSApp/Test/BUILD
@@ -1,5 +1,6 @@
 test_suite(
     name = "iOSAppTestSuite",
+    tags = ["manual"],
     tests = [
         "//iOSApp/Test/ObjCUnitTests:iOSAppObjCUnitTests",
         "//iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTests",

--- a/examples/integration/iOSApp/Test/ObjCUnitTests/BUILD
+++ b/examples/integration/iOSApp/Test/ObjCUnitTests/BUILD
@@ -7,6 +7,7 @@ ios_unit_test(
         "IOS_APP_UNIT_TESTS": "CUSTOM_ENV_VALUE",
     },
     minimum_os_version = "15.0",
+    tags = ["manual"],
     test_host = "//iOSApp",
     visibility = [
         "//iOSApp:__subpackages__",

--- a/examples/integration/iOSApp/Test/SwiftUnitTests/BUILD
+++ b/examples/integration/iOSApp/Test/SwiftUnitTests/BUILD
@@ -10,6 +10,7 @@ ios_unit_test(
     },
     minimum_os_version = "15.0",
     resources = ["//iOSApp/Resources/ExampleResources:exported_resources"],
+    tags = ["manual"],
     test_host = "//iOSApp",
     visibility = [
         "//iOSApp:__subpackages__",

--- a/examples/integration/iOSApp/Test/UITests/BUILD
+++ b/examples/integration/iOSApp/Test/UITests/BUILD
@@ -5,6 +5,7 @@ ios_ui_test(
     name = "iOSAppUITests",
     bundle_id = "rules-xcodeproj.example.uitests",
     minimum_os_version = "15.0",
+    tags = ["manual"],
     test_host = "//iOSApp",
     visibility = ["@rules_xcodeproj//xcodeproj:generated"],
     deps = [":iOSAppUITests.library"],

--- a/examples/rules_ios/iOSApp/Test/MixedUnitTests/BUILD
+++ b/examples/rules_ios/iOSApp/Test/MixedUnitTests/BUILD
@@ -12,6 +12,7 @@ rules_ios_ios_unit_test(
     bundle_id = "rules-xcodeproj.example.mixedtests",
     minimum_os_version = "15.0",
     module_name = "iOSAppMixedUnitTests",
+    tags = ["manual"],
     test_host = "//iOSApp",
     visibility = ["@rules_xcodeproj//xcodeproj:generated"],
     deps = [

--- a/examples/rules_ios/iOSApp/Test/ObjCUnitTests/BUILD
+++ b/examples/rules_ios/iOSApp/Test/ObjCUnitTests/BUILD
@@ -9,6 +9,7 @@ rules_ios_ios_unit_test(
     bundle_id = "rules-xcodeproj.example.objctests",
     minimum_os_version = "15.0",
     module_name = "iOSAppObjCUnitTests",
+    tags = ["manual"],
     test_host = "//iOSApp",
     visibility = ["@rules_xcodeproj//xcodeproj:generated"],
     deps = [

--- a/examples/rules_ios/iOSApp/Test/SwiftUnitTests/BUILD
+++ b/examples/rules_ios/iOSApp/Test/SwiftUnitTests/BUILD
@@ -7,6 +7,7 @@ rules_ios_ios_unit_test(
     bundle_id = "rules-xcodeproj.example.tests",
     minimum_os_version = "15.0",
     module_name = "iOSAppSwiftUnitTests",
+    tags = ["manual"],
     test_host = "//iOSApp",
     visibility = ["@rules_xcodeproj//xcodeproj:generated"],
     deps = [

--- a/examples/rules_ios/iOSApp/Test/UITests/BUILD
+++ b/examples/rules_ios/iOSApp/Test/UITests/BUILD
@@ -6,6 +6,7 @@ rules_ios_ios_ui_test(
     bundle_id = "rules-xcodeproj.example.uitests",
     minimum_os_version = "15.0",
     module_name = "iOSAppUITests",
+    tags = ["manual"],
     test_host = "//iOSApp",
     visibility = ["@rules_xcodeproj//xcodeproj:generated"],
 )


### PR DESCRIPTION
#2196 has surfaced an issue related to tests actually running as part of the CI checks. There's timeouts happening and we might want to investigate that better (and potentially decide if we even want to run tests or not). From a project generation perspective we don't necessarily have to run the tests.

For those reasons, this PR makes tests `manual`. Planning to do the same with the new tests being added in #2196 once this lands.