### PR TITLE
Remove special handling for `-swift-version`

### DIFF
--- a/test/internal/opts/process_compiler_opts_tests.bzl
+++ b/test/internal/opts/process_compiler_opts_tests.bzl
@@ -707,16 +707,6 @@ def process_compiler_opts_test_suite(name):
         },
     )
 
-    ## SWIFT_VERSION
-
-    _add_test(
-        name = "{}_swift_option-swift-version".format(name),
-        swiftcopts = ["-swift-version=42"],
-        expected_build_settings = {
-            "SWIFT_VERSION": "42",
-        },
-    )
-
     # Search Paths
 
     _add_test(

--- a/tools/params_processors/swift_compiler_params_processor.py
+++ b/tools/params_processors/swift_compiler_params_processor.py
@@ -44,7 +44,6 @@ _SWIFTC_SKIP_OPTS = {
     "-g": 1,
     "-incremental": 1,
     "-no-whole-module-optimization": 1,
-    "-swift-version": 2,
     "-whole-module-optimization": 1,
     "-wmo": 1,
 

--- a/xcodeproj/internal/opts.bzl
+++ b/xcodeproj/internal/opts.bzl
@@ -362,11 +362,6 @@ Using VFS overlays with `build_mode = "xcode"` is unsupported.
         if compilation_mode:
             build_settings["SWIFT_COMPILATION_MODE"] = compilation_mode
             return
-        if opt.startswith("-swift-version="):
-            version = opt[15:]
-            if version != "5.0":
-                build_settings["SWIFT_VERSION"] = version
-            return
         if opt == "-emit-objc-header-path":
             # Handled in `previous_opt` check above
             return


### PR DESCRIPTION
Trying to rely on `OTHER_SWIFT_FLAGS` as much as possible.