### PR TITLE
Properly set development region in `PBXProject.knownRegions`

### DIFF
--- a/tools/generators/legacy/src/Generator/CreateFilesAndGroups.swift
+++ b/tools/generators/legacy/src/Generator/CreateFilesAndGroups.swift
@@ -57,6 +57,7 @@ extension Generator {
     static func createFilesAndGroups(
         in pbxProj: PBXProj,
         buildMode: BuildMode,
+        developmentRegion: String,
         forFixtures: Bool,
         targets: [TargetID: Target],
         extraFiles: Set<FilePath>,
@@ -752,8 +753,7 @@ extension Generator {
             rootElements.append(internalGroup)
         }
 
-        // TODO: Configure development region?
-        knownRegions.insert("en")
+        knownRegions.insert(developmentRegion)
 
         // Xcode puts "Base" last after sorting
         knownRegions.remove("Base")

--- a/tools/generators/legacy/src/Generator/Environment.swift
+++ b/tools/generators/legacy/src/Generator/Environment.swift
@@ -28,6 +28,7 @@ struct Environment {
     let createFilesAndGroups: (
         _ pbxProj: PBXProj,
         _ buildMode: BuildMode,
+        _ developmentRegion: String,
         _ forFixtures: Bool,
         _ targets: [TargetID: Target],
         _ extraFiles: Set<FilePath>,

--- a/tools/generators/legacy/src/Generator/Generator.swift
+++ b/tools/generators/legacy/src/Generator/Generator.swift
@@ -77,6 +77,7 @@ class Generator {
             try environment.createFilesAndGroups(
                 pbxProj,
                 buildMode,
+                project.options.developmentRegion,
                 forFixtures,
                 targets,
                 project.extraFiles,

--- a/tools/generators/legacy/test/CreateFilesAndGroupsTests.swift
+++ b/tools/generators/legacy/test/CreateFilesAndGroupsTests.swift
@@ -51,7 +51,7 @@ final class CreateFilesAndGroupsTests: XCTestCase {
         ]
         expectedMainGroup.addChildren(expectedRootElements)
 
-        expectedPBXProj.rootObject!.knownRegions = ["en", "Base"]
+        expectedPBXProj.rootObject!.knownRegions = ["es", "Base"]
 
         // Act
 
@@ -64,6 +64,7 @@ final class CreateFilesAndGroupsTests: XCTestCase {
         ) = try Generator.createFilesAndGroups(
             in: pbxProj,
             buildMode: .xcode,
+            developmentRegion: "es",
             forFixtures: false,
             targets: targets,
             extraFiles: extraFiles,
@@ -164,6 +165,7 @@ final class CreateFilesAndGroupsTests: XCTestCase {
         ) = try Generator.createFilesAndGroups(
             in: pbxProj,
             buildMode: .xcode,
+            developmentRegion: "es",
             forFixtures: false,
             targets: targets,
             extraFiles: extraFiles,
@@ -271,6 +273,7 @@ final class CreateFilesAndGroupsTests: XCTestCase {
         ) = try Generator.createFilesAndGroups(
             in: pbxProj,
             buildMode: .bazel,
+            developmentRegion: "es",
             forFixtures: false,
             targets: targets,
             extraFiles: extraFiles,

--- a/tools/generators/legacy/test/GeneratorTests.swift
+++ b/tools/generators/legacy/test/GeneratorTests.swift
@@ -304,6 +304,7 @@ final class GeneratorTests: XCTestCase {
         struct CreateFilesAndGroupsCalled: Equatable {
             let pbxProj: PBXProj
             let buildMode: BuildMode
+            let developmentRegion: String
             let targets: [TargetID: Target]
             let extraFiles: Set<FilePath>
             let xccurrentversions: [XCCurrentVersion]
@@ -314,6 +315,7 @@ final class GeneratorTests: XCTestCase {
         func createFilesAndGroups(
             in pbxProj: PBXProj,
             buildMode: BuildMode,
+            developmentRegion: String,
             _forFixtures _: Bool,
             targets: [TargetID: Target],
             extraFiles: Set<FilePath>,
@@ -330,6 +332,7 @@ final class GeneratorTests: XCTestCase {
             createFilesAndGroupsCalled.append(.init(
                 pbxProj: pbxProj,
                 buildMode: buildMode,
+                developmentRegion: developmentRegion,
                 targets: targets,
                 extraFiles: extraFiles,
                 xccurrentversions: xccurrentversions,
@@ -347,6 +350,7 @@ final class GeneratorTests: XCTestCase {
         let expectedCreateFilesAndGroupsCalled = [CreateFilesAndGroupsCalled(
             pbxProj: pbxProj,
             buildMode: buildMode,
+            developmentRegion: project.options.developmentRegion,
             targets: targets,
             extraFiles: project.extraFiles,
             xccurrentversions: xccurrentversions,


### PR DESCRIPTION
Should have changed this with 8dbd5eb59cfb53b5ee7dc7b593a693beb497ec15.