### PR TITLE
Remove special handling of `ENABLE_STRICT_OBJC_MSGSEND`

### DIFF
--- a/test/internal/opts/process_compiler_opts_tests.bzl
+++ b/test/internal/opts/process_compiler_opts_tests.bzl
@@ -601,17 +601,6 @@ def process_compiler_opts_test_suite(name):
         },
     )
 
-    ## ENABLE_STRICT_OBJC_MSGSEND
-
-    _add_test(
-        name = "{}_enable_strict_objc_msgsend".format(name),
-        conlyopts = ["-DOBJC_OLD_DISPATCH_PROTOTYPES=1"],
-        expected_build_settings = {
-            "DEBUG_INFORMATION_FORMAT": "",
-            "ENABLE_STRICT_OBJC_MSGSEND": "False",
-        },
-    )
-
     ## SWIFT_OBJC_INTERFACE_HEADER_NAME
 
     _add_test(

--- a/tools/params_processors/cc_compiler_params_processor.py
+++ b/tools/params_processors/cc_compiler_params_processor.py
@@ -56,17 +56,6 @@ def _inner_process_cc_opts(opt, previous_opt):
             return "$(CURRENT_EXECUTION_ROOT)/" + opt
         return opt
 
-    if opt[0] != "-":
-        return opt
-    opt_character = opt[1]
-
-    if opt_character == "D":
-        value = opt[2:]
-        if value.startswith("OBJC_OLD_DISPATCH_PROTOTYPES"):
-            # `ENABLE_STRICT_OBJC_MSGSEND` is set in `opts.bzl``
-            return None
-        return opt
-
     # -ivfsoverlay and --config doesn't apply `-working_directory=`, so we
     # need to prefix it ourselves
     if opt.startswith("-ivfsoverlay"):


### PR DESCRIPTION
Since we set the correct default now, params files should work correctly if set differently.