### PR TITLE
Include leading `.` in `RESOLVED_REPOSITORIES` prefixes

### DIFF
--- a/examples/cc/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -1086,7 +1086,7 @@
 				);
 				LIBTOOL = "$(BAZEL_INTEGRATION_DIR)/libtool.sh";
 				ONLY_ACTIVE_ARCH = YES;
-				RESOLVED_REPOSITORIES = "\"/external/examples_cc_external\" \"$(SRCROOT)/external\" \"\" \"$(SRCROOT)\"";
+				RESOLVED_REPOSITORIES = "\"external/examples_cc_external\" \"$(SRCROOT)/external\" \".\" \"$(SRCROOT)\"";
 				RULES_XCODEPROJ_BUILD_MODE = bazel;
 				SCHEME_TARGET_IDS_FILE = "$(OBJROOT)/scheme_target_ids";
 				SRCROOT = ../../../../..;

--- a/examples/cc/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/cc/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -999,7 +999,7 @@
 				LD_RUNPATH_SEARCH_PATHS = (
 				);
 				ONLY_ACTIVE_ARCH = YES;
-				RESOLVED_REPOSITORIES = "\"/external/examples_cc_external\" \"$(SRCROOT)/external\" \"\" \"$(SRCROOT)\"";
+				RESOLVED_REPOSITORIES = "\"external/examples_cc_external\" \"$(SRCROOT)/external\" \".\" \"$(SRCROOT)\"";
 				RULES_XCODEPROJ_BUILD_MODE = xcode;
 				SCHEME_TARGET_IDS_FILE = "$(OBJROOT)/scheme_target_ids";
 				SRCROOT = ../../../../..;

--- a/examples/integration/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -12757,7 +12757,7 @@
 				);
 				LIBTOOL = "$(BAZEL_INTEGRATION_DIR)/libtool.sh";
 				ONLY_ACTIVE_ARCH = YES;
-				RESOLVED_REPOSITORIES = "\"/external/examples_command_line_external/ImportableLibrary\" \"$(SRCROOT)/CommandLine/external/ImportableLibrary\" \"/external/examples_ios_app_external\" \"$(SRCROOT)/iOSApp/external\" \"\" \"$(SRCROOT)\"";
+				RESOLVED_REPOSITORIES = "\"external/examples_command_line_external/ImportableLibrary\" \"$(SRCROOT)/CommandLine/external/ImportableLibrary\" \"external/examples_ios_app_external\" \"$(SRCROOT)/iOSApp/external\" \".\" \"$(SRCROOT)\"";
 				RULES_XCODEPROJ_BUILD_MODE = bazel;
 				SCHEME_TARGET_IDS_FILE = "$(OBJROOT)/scheme_target_ids";
 				SRCROOT = ../../../../..;
@@ -14997,7 +14997,7 @@
 				);
 				LIBTOOL = "$(BAZEL_INTEGRATION_DIR)/libtool.sh";
 				ONLY_ACTIVE_ARCH = YES;
-				RESOLVED_REPOSITORIES = "\"/external/examples_command_line_external/ImportableLibrary\" \"$(SRCROOT)/CommandLine/external/ImportableLibrary\" \"/external/examples_ios_app_external\" \"$(SRCROOT)/iOSApp/external\" \"\" \"$(SRCROOT)\"";
+				RESOLVED_REPOSITORIES = "\"external/examples_command_line_external/ImportableLibrary\" \"$(SRCROOT)/CommandLine/external/ImportableLibrary\" \"external/examples_ios_app_external\" \"$(SRCROOT)/iOSApp/external\" \".\" \"$(SRCROOT)\"";
 				RULES_XCODEPROJ_BUILD_MODE = bazel;
 				SCHEME_TARGET_IDS_FILE = "$(OBJROOT)/scheme_target_ids";
 				SRCROOT = ../../../../..;

--- a/examples/integration/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -14407,7 +14407,7 @@
 				LD_RUNPATH_SEARCH_PATHS = (
 				);
 				ONLY_ACTIVE_ARCH = YES;
-				RESOLVED_REPOSITORIES = "\"/external/examples_command_line_external/ImportableLibrary\" \"$(SRCROOT)/CommandLine/external/ImportableLibrary\" \"/external/examples_ios_app_external\" \"$(SRCROOT)/iOSApp/external\" \"\" \"$(SRCROOT)\"";
+				RESOLVED_REPOSITORIES = "\"external/examples_command_line_external/ImportableLibrary\" \"$(SRCROOT)/CommandLine/external/ImportableLibrary\" \"external/examples_ios_app_external\" \"$(SRCROOT)/iOSApp/external\" \".\" \"$(SRCROOT)\"";
 				RULES_XCODEPROJ_BUILD_MODE = xcode;
 				SCHEME_TARGET_IDS_FILE = "$(OBJROOT)/scheme_target_ids";
 				SRCROOT = ../../../../..;
@@ -15609,7 +15609,7 @@
 				LD_RUNPATH_SEARCH_PATHS = (
 				);
 				ONLY_ACTIVE_ARCH = YES;
-				RESOLVED_REPOSITORIES = "\"/external/examples_command_line_external/ImportableLibrary\" \"$(SRCROOT)/CommandLine/external/ImportableLibrary\" \"/external/examples_ios_app_external\" \"$(SRCROOT)/iOSApp/external\" \"\" \"$(SRCROOT)\"";
+				RESOLVED_REPOSITORIES = "\"external/examples_command_line_external/ImportableLibrary\" \"$(SRCROOT)/CommandLine/external/ImportableLibrary\" \"external/examples_ios_app_external\" \"$(SRCROOT)/iOSApp/external\" \".\" \"$(SRCROOT)\"";
 				RULES_XCODEPROJ_BUILD_MODE = xcode;
 				SCHEME_TARGET_IDS_FILE = "$(OBJROOT)/scheme_target_ids";
 				SRCROOT = ../../../../..;

--- a/examples/rules_ios/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/rules_ios/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -3991,7 +3991,7 @@
 				);
 				LIBTOOL = "$(BAZEL_INTEGRATION_DIR)/libtool.sh";
 				ONLY_ACTIVE_ARCH = YES;
-				RESOLVED_REPOSITORIES = "\"\" \"$(SRCROOT)\"";
+				RESOLVED_REPOSITORIES = "\".\" \"$(SRCROOT)\"";
 				RULES_XCODEPROJ_BUILD_MODE = bazel;
 				SCHEME_TARGET_IDS_FILE = "$(OBJROOT)/scheme_target_ids";
 				SRCROOT = ../../../../..;

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -855,7 +855,7 @@
 				);
 				LIBTOOL = "$(BAZEL_INTEGRATION_DIR)/libtool.sh";
 				ONLY_ACTIVE_ARCH = YES;
-				RESOLVED_REPOSITORIES = "\"\" \"$(SRCROOT)\"";
+				RESOLVED_REPOSITORIES = "\".\" \"$(SRCROOT)\"";
 				RULES_XCODEPROJ_BUILD_MODE = bazel;
 				SCHEME_TARGET_IDS_FILE = "$(OBJROOT)/scheme_target_ids";
 				SRCROOT = ../../../../..;

--- a/examples/sanitizers/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/sanitizers/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -829,7 +829,7 @@
 				LD_RUNPATH_SEARCH_PATHS = (
 				);
 				ONLY_ACTIVE_ARCH = YES;
-				RESOLVED_REPOSITORIES = "\"\" \"$(SRCROOT)\"";
+				RESOLVED_REPOSITORIES = "\".\" \"$(SRCROOT)\"";
 				RULES_XCODEPROJ_BUILD_MODE = xcode;
 				SCHEME_TARGET_IDS_FILE = "$(OBJROOT)/scheme_target_ids";
 				SRCROOT = ../../../../..;

--- a/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
@@ -4370,7 +4370,7 @@
 				);
 				LIBTOOL = "$(BAZEL_INTEGRATION_DIR)/libtool.sh";
 				ONLY_ACTIVE_ARCH = YES;
-				RESOLVED_REPOSITORIES = "\"\" \"$(SRCROOT)\"";
+				RESOLVED_REPOSITORIES = "\".\" \"$(SRCROOT)\"";
 				RULES_XCODEPROJ_BUILD_MODE = bazel;
 				SCHEME_TARGET_IDS_FILE = "$(OBJROOT)/scheme_target_ids";
 				SRCROOT = ../../../../..;
@@ -5068,7 +5068,7 @@
 				);
 				LIBTOOL = "$(BAZEL_INTEGRATION_DIR)/libtool.sh";
 				ONLY_ACTIVE_ARCH = YES;
-				RESOLVED_REPOSITORIES = "\"\" \"$(SRCROOT)\"";
+				RESOLVED_REPOSITORIES = "\".\" \"$(SRCROOT)\"";
 				RULES_XCODEPROJ_BUILD_MODE = bazel;
 				SCHEME_TARGET_IDS_FILE = "$(OBJROOT)/scheme_target_ids";
 				SRCROOT = ../../../../..;
@@ -5464,7 +5464,7 @@
 				);
 				LIBTOOL = "$(BAZEL_INTEGRATION_DIR)/libtool.sh";
 				ONLY_ACTIVE_ARCH = YES;
-				RESOLVED_REPOSITORIES = "\"\" \"$(SRCROOT)\"";
+				RESOLVED_REPOSITORIES = "\".\" \"$(SRCROOT)\"";
 				RULES_XCODEPROJ_BUILD_MODE = bazel;
 				SCHEME_TARGET_IDS_FILE = "$(OBJROOT)/scheme_target_ids";
 				SRCROOT = ../../../../..;

--- a/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
@@ -4665,7 +4665,7 @@
 				LD_RUNPATH_SEARCH_PATHS = (
 				);
 				ONLY_ACTIVE_ARCH = YES;
-				RESOLVED_REPOSITORIES = "\"\" \"$(SRCROOT)\"";
+				RESOLVED_REPOSITORIES = "\".\" \"$(SRCROOT)\"";
 				RULES_XCODEPROJ_BUILD_MODE = xcode;
 				SCHEME_TARGET_IDS_FILE = "$(OBJROOT)/scheme_target_ids";
 				SRCROOT = ../../../../..;
@@ -5015,7 +5015,7 @@
 				LD_RUNPATH_SEARCH_PATHS = (
 				);
 				ONLY_ACTIVE_ARCH = YES;
-				RESOLVED_REPOSITORIES = "\"\" \"$(SRCROOT)\"";
+				RESOLVED_REPOSITORIES = "\".\" \"$(SRCROOT)\"";
 				RULES_XCODEPROJ_BUILD_MODE = xcode;
 				SCHEME_TARGET_IDS_FILE = "$(OBJROOT)/scheme_target_ids";
 				SRCROOT = ../../../../..;
@@ -5316,7 +5316,7 @@
 				LD_RUNPATH_SEARCH_PATHS = (
 				);
 				ONLY_ACTIVE_ARCH = YES;
-				RESOLVED_REPOSITORIES = "\"\" \"$(SRCROOT)\"";
+				RESOLVED_REPOSITORIES = "\".\" \"$(SRCROOT)\"";
 				RULES_XCODEPROJ_BUILD_MODE = xcode;
 				SCHEME_TARGET_IDS_FILE = "$(OBJROOT)/scheme_target_ids";
 				SRCROOT = ../../../../..;

--- a/tools/generators/legacy/src/Generator/CreateFilesAndGroups.swift
+++ b/tools/generators/legacy/src/Generator/CreateFilesAndGroups.swift
@@ -76,7 +76,7 @@ extension Generator {
         var xcVersionGroups: [FilePath: XCVersionGroup] = [:]
         var knownRegions: Set<String> = []
         var resolvedRepositories: [(Path, Path)] = [
-            ("", forFixtures ? "$(SRCROOT)" : directories.workspace),
+            (".", forFixtures ? "$(SRCROOT)" : directories.workspace),
         ]
 
         /// Calculates the needed `sourceTree`, `name`, and `path` for a file
@@ -142,7 +142,7 @@ extension Generator {
                     if addToResolvedRepositories {
                         resolvedRepositories.append(
                             (
-                                "/external" + relativePath,
+                                "./external" + relativePath,
                                 "$(SRCROOT)" + resolvedRelativePath
                             )
                         )
@@ -158,7 +158,7 @@ extension Generator {
 
             if addToResolvedRepositories {
                 resolvedRepositories.append(
-                    ("/external" + relativePath, absolutePath)
+                    ("./external" + relativePath, absolutePath)
                 )
             }
 

--- a/xcodeproj/internal/bazel_integration_files/create_lldbinit.sh
+++ b/xcodeproj/internal/bazel_integration_files/create_lldbinit.sh
@@ -57,7 +57,7 @@ if [[ -n "${RESOLVED_REPOSITORIES:-}" ]]; then
   for (( i=0; i<${#repos[@]}; i+=2 )); do
     prefix="${repos[$i]}"
     path="${repos[$i+1]}"
-    echo "settings append target.source-map \".$prefix/\" \"$path\""
+    echo "settings append target.source-map \"$prefix/\" \"$path\""
   done
 fi
 


### PR DESCRIPTION
When adding support for `--experimental_sibling_repository_layout`, it’s less confusing to see `".."` than `"."` for the prefix.