### PR TITLE
Add back special handling for `-swift-version`

### DIFF
--- a/test/internal/opts/process_compiler_opts_tests.bzl
+++ b/test/internal/opts/process_compiler_opts_tests.bzl
@@ -660,6 +660,16 @@ def process_compiler_opts_test_suite(name):
         },
     )
 
+    ## SWIFT_VERSION
+
+    _add_test(
+        name = "{}_swift_option-swift-version".format(name),
+        swiftcopts = ["-swift-version=42"],
+        expected_build_settings = {
+            "SWIFT_VERSION": "42",
+        },
+    )
+
     # Search Paths
 
     _add_test(

--- a/tools/params_processors/swift_compiler_params_processor.py
+++ b/tools/params_processors/swift_compiler_params_processor.py
@@ -44,6 +44,7 @@ _SWIFTC_SKIP_OPTS = {
     "-g": 1,
     "-incremental": 1,
     "-no-whole-module-optimization": 1,
+    "-swift-version": 2,
     "-whole-module-optimization": 1,
     "-wmo": 1,
 

--- a/xcodeproj/internal/opts.bzl
+++ b/xcodeproj/internal/opts.bzl
@@ -284,6 +284,12 @@ def _process_swiftcopts(
             build_settings["SWIFT_COMPILATION_MODE"] = compilation_mode
             continue
 
+        if opt.startswith("-swift-version="):
+            version = opt[15:]
+            if version != "5.0":
+                build_settings["SWIFT_VERSION"] = version
+            continue
+
         if previous_opt == "-emit-objc-header-path":
             if not opt.startswith(package_bin_dir):
                 fail("""\


### PR DESCRIPTION
Reverts 77a5ac6ffc0946ea953b753e11a886d77fd47375.

Xcode sets `-swift-version` after where it places `OTHER_SWIFT_FLAGS` values, so we need to let Xcode handle this.