### PR TITLE
Fix label creation if using bzlmod

### DIFF
--- a/xcodeproj/internal/xcodeprojinfo.bzl
+++ b/xcodeproj/internal/xcodeprojinfo.bzl
@@ -287,14 +287,15 @@ def _skip_target(
         # Normalizes label to ensure this works with and without bzlmod
         # and then drop the target name because that will be replaced below
         label_str = bazel_labels.normalize_label(info.xcode_target.label)
-        label_str = label_str.split(":")[0]
+        package_label_str = label_str.split(":")[0]
 
         # As of https://github.com/bazelbuild/rules_apple/pull/1948
         # `bundle_name` can be used to name the bundle instead of the
         # target name. Because of that we use `ctx.rule.attr.generator_name`
         # here to ensure this is always a real target label.
-        label_str = "{}:{}".format(label_str, ctx.rule.attr.generator_name)
-        return Label(label_str)
+        return Label(
+            "{}:{}".format(package_label_str, ctx.rule.attr.generator_name),
+        )
 
     return _target_info_fields(
         args = memory_efficient_depset(


### PR DESCRIPTION
`cd examples/integration/` and:
```sh
bazel run --config=cache //:xcodeproj-sim_arm64
```

You'll hit this:
```sh
ERROR: Internal precondition failure:
Target @@//iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTests was not found in the transitive dependencies of @@//:xcodeproj-sim_arm64's `top_level_targets` attribute. Did you reference an alias (only actual target labels are supported in Scheme definitions)? Check that @@//iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTests is spelled correctly, and if it is, add it or a target that depends on it to @@//:xcodeproj-sim_arm64's `top_level_targets` attribute.
Please file a bug report at https://github.com/MobileNativeFoundation/rules_xcodeproj/issues/new?template=bug.md
```

That's happening because constructing the `Label` directly using `@//{}:{}` is not a good generic pattern. So changing the approach here to normalizing the original label, get a well formed one and only then do the replacement to use `generator_name`.