### PR TITLE
Move generator package directory to /var/tmp

### DIFF
--- a/xcodeproj/internal/templates/installer.sh
+++ b/xcodeproj/internal/templates/installer.sh
@@ -91,7 +91,7 @@ if [[ $for_fixture -eq 1 ]]; then
 
   # Copy over generated generator
   output_base_hash=$(/sbin/md5 -q -s "${execution_root%/*/*}")
-  readonly src_generator_package_directory="/tmp/rules_xcodeproj/generated_v2/$output_base_hash/generator/$generator_package_name"
+  readonly src_generator_package_directory="/var/tmp/rules_xcodeproj/generated_v2/$output_base_hash/generator/$generator_package_name"
   readonly dest_generator_package_directory="$project_dir/generated"
   readonly dest_generator_package="${dest_generator_package_directory:?}/$generator_name"
   rm -rf "$dest_generator_package"

--- a/xcodeproj/internal/templates/runner.sh
+++ b/xcodeproj/internal/templates/runner.sh
@@ -104,7 +104,7 @@ readonly output_base="${execution_root%/*/*}"
 
 # Create files for the generator target
 output_base_hash=$(/sbin/md5 -q -s "$output_base")
-readonly generator_package_directory="/tmp/rules_xcodeproj/generated_v2/$output_base_hash/%generator_package_name%"
+readonly generator_package_directory="/var/tmp/rules_xcodeproj/generated_v2/$output_base_hash/%generator_package_name%"
 
 mkdir -p "$generator_package_directory"
 cp "$generator_build_file" "$generator_package_directory/BUILD"

--- a/xcodeproj/repositories.bzl
+++ b/xcodeproj/repositories.bzl
@@ -74,7 +74,7 @@ package_group(
     # Ensure that this repository is unique per output base
     output_base_hash = output_base_hash_result.stdout.strip()
     repository_ctx.symlink(
-        "/tmp/rules_xcodeproj/generated_v2/{}/generator".format(output_base_hash),
+        "/var/tmp/rules_xcodeproj/generated_v2/{}/generator".format(output_base_hash),
         "generator",
     )
 


### PR DESCRIPTION
This makes it so the generator package will persist across reboots and for a longer period of time. macOS can clean up periodically contents in `/tmp`. This can cause situations where for example a project is generated and the following day the package directory contents won’t exist anymore causing build failures.