### PR TITLE
Extract logic from `Generator.readExecutionRootFile()`

### DIFF
--- a/tools/generators/lib/PBXProj/BUILD
+++ b/tools/generators/lib/PBXProj/BUILD
@@ -9,6 +9,7 @@ swift_library(
     module_name = "PBXProj",
     visibility = ["//tools/generators:__subpackages__"],
     deps = [
+        "//tools/generators/lib/GeneratorCommon",
         "@com_github_apple_swift_argument_parser//:ArgumentParser",
     ],
 )

--- a/tools/generators/lib/PBXProj/src/URL+Extensions.swift
+++ b/tools/generators/lib/PBXProj/src/URL+Extensions.swift
@@ -1,0 +1,24 @@
+import Foundation
+import GeneratorCommon
+
+extension URL {
+    /// Reads the file at `self`, returning the absolute path to the Bazel
+    /// execution root.
+    public func readExecutionRootFile() throws -> String {
+        let lines: [String.SubSequence]
+        do {
+            lines = try String(contentsOf: self).split(separator: "\n")
+        } catch {
+            throw PreconditionError(message: error.localizedDescription)
+        }
+
+        guard lines.count == 1 else {
+            throw PreconditionError(message: """
+The execution_root_file must contain one line: the absolute path to the Bazel \
+execution root.
+""")
+        }
+
+        return String(lines[0])
+    }
+}

--- a/tools/generators/pbxproj_prefix/src/Generator/ReadExecutionRootFile.swift
+++ b/tools/generators/pbxproj_prefix/src/Generator/ReadExecutionRootFile.swift
@@ -1,24 +1,10 @@
 import Foundation
-import GeneratorCommon
+import PBXProj
 
 extension Generator {
     /// Reads the file at `url`, returning the absolute path to the Bazel
     /// execution root.
     static func readExecutionRootFile(_ url: URL) throws -> String {
-        let lines: [String.SubSequence]
-        do {
-            lines = try String(contentsOf: url).split(separator: "\n")
-        } catch {
-            throw PreconditionError(message: error.localizedDescription)
-        }
-
-        guard lines.count == 1 else {
-            throw PreconditionError(message: """
-The execution_root_file must contain one line: the absolute path to the Bazel \
-execution root.
-""")
-        }
-
-        return String(lines[0])
+        return try url.readExecutionRootFile()
     }
 }


### PR DESCRIPTION
This will be used by multiple `PBXProj` partial generators.