### PR TITLE
macOS 13.4: Using /usr/bin/swift

### DIFF
--- a/tools/swiftc_stub/main.swift
+++ b/tools/swiftc_stub/main.swift
@@ -103,7 +103,7 @@ func handleSwiftUIPreviewThunk(_ args: [String]) throws {
     else {
         print("warning: No such argument '-sdk'")
         try exit(runSubProcess(
-            executable: "swiftc",
+            executable: "/usr/bin/swiftc",
             args: Array(args.dropFirst())
         ))
     }
@@ -119,7 +119,7 @@ func handleSwiftUIPreviewThunk(_ args: [String]) throws {
     else {
         print("warning: Failed to parse DEVELOPER_DIR from '-sdk'")
         try exit(runSubProcess(
-            executable: "swiftc",
+            executable: "/usr/bin/swiftc",
             args: Array(args.dropFirst())
         ))
     }
@@ -139,7 +139,7 @@ let args = CommandLine.arguments
 let argsSet = Set(args)
 
 if args.count == 2, args.last == "-v" {
-    try exit(runSubProcess(executable: "swiftc", args: ["-v"]))
+    try exit(runSubProcess(executable: "/usr/bin/swiftc", args: ["-v"]))
 }
 
 for arg in args {


### PR DESCRIPTION
macOS 13.4 swiftc invocations fail when Xcode requests for -v. 
Repro:
```
./App.xcodeproj/rules_xcodeproj/bazel/swiftc -v

Set elements successfully appended to file.
Swift/ErrorType.swift:200: Fatal error: Error raised at top level: Error Domain=NSCocoaErrorDomain Code=4 "The file “swiftc” doesn’t exist." UserInfo={NSFilePath=swiftc}
zsh: trace trap  ./App.xcodeproj/rules_xcodeproj/bazel/swiftc -v
```
