### PR TITLE
Remove unnecessary dependencies from release archive

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -10,11 +10,25 @@ py_library(
 
 # Release
 
+exports_files(["MODULE.bazel"])
+
+genrule(
+    name = "release_MODULE.bazel",
+    srcs = ["MODULE.bazel"],
+    outs = ["MODULE.release.bazel"],
+    cmd = """\
+set -euo pipefail
+
+perl -0777 -pe 's/\n# Non-release dependencies.*//s' $< > $@
+    """,
+    tags = ["manual"],
+)
+
 filegroup(
     name = "release_files",
     srcs = [
         "LICENSE",
-        "MODULE.bazel",
+        ":release_MODULE.bazel",
         "//tools:release_files",
         "//xcodeproj:release_files",
     ],

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -17,6 +17,14 @@ bazel_dep(
     repo_name = "build_bazel_rules_apple",
 )
 
+non_module_deps = use_extension("//xcodeproj:extensions.bzl", "non_module_deps")
+use_repo(
+    non_module_deps,
+    "rules_xcodeproj_index_import",
+)
+
+# Non-release dependencies
+
 bazel_dep(
     name = "buildifier_prebuilt",
     version = "6.1.0",
@@ -37,7 +45,6 @@ bazel_dep(
 internal = use_extension("//xcodeproj:extensions.bzl", "internal")
 use_repo(internal, "rules_xcodeproj_generated")
 
-non_module_deps = use_extension("//xcodeproj:extensions.bzl", "non_module_deps")
 use_repo(
     non_module_deps,
     "com_github_apple_swift_argument_parser",
@@ -48,7 +55,6 @@ use_repo(
     "com_github_michaeleisel_zippyjsoncfamily",
     "com_github_tadija_aexml",
     "com_github_tuist_xcodeproj",
-    "rules_xcodeproj_index_import",
 )
 
 dev_non_module_deps = use_extension(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -17,6 +17,9 @@ bazel_dep(
     repo_name = "build_bazel_rules_apple",
 )
 
+internal = use_extension("//xcodeproj:extensions.bzl", "internal")
+use_repo(internal, "rules_xcodeproj_generated")
+
 non_module_deps = use_extension("//xcodeproj:extensions.bzl", "non_module_deps")
 use_repo(
     non_module_deps,
@@ -41,9 +44,6 @@ bazel_dep(
     dev_dependency = True,
     repo_name = "io_bazel_stardoc",
 )
-
-internal = use_extension("//xcodeproj:extensions.bzl", "internal")
-use_repo(internal, "rules_xcodeproj_generated")
 
 use_repo(
     non_module_deps,

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -58,7 +58,7 @@ use_repo(
 )
 
 dev_non_module_deps = use_extension(
-    "//xcodeproj:extensions.bzl",
+    "//xcodeproj:dev_extensions.bzl",
     "dev_non_module_deps",
     dev_dependency = True,
 )

--- a/distribution/BUILD
+++ b/distribution/BUILD
@@ -41,9 +41,11 @@ pkg_tar(
     owner = "0.0",
     package_file_name = "release.tar.gz",
     remap_paths = {
+        "MODULE.release.bazel": "MODULE.bazel",
         "tools/generators/legacy/BUILD.release.bazel": "tools/generators/legacy/BUILD",
         "tools/generators/legacy/universal_generator": "tools/generators/legacy/prebuilt_universal_generator",
         "tools/swiftc_stub/BUILD.release.bazel": "tools/swiftc_stub/BUILD",
+        "xcodeproj/repositories.release.bzl": "xcodeproj/repositories.bzl",
     },
     strip_prefix = "/",
     tags = ["manual"],

--- a/xcodeproj/BUILD
+++ b/xcodeproj/BUILD
@@ -63,6 +63,7 @@ filegroup(
         ["**"],
         exclude = [
             "**/.*",
+            "dev_extensions.bzl",
             "repositories.bzl",
             "testing.bzl",
         ],

--- a/xcodeproj/BUILD
+++ b/xcodeproj/BUILD
@@ -45,15 +45,29 @@ bzl_library(
 
 # Release
 
+genrule(
+    name = "release_repositories.bzl",
+    srcs = ["repositories.bzl"],
+    outs = ["repositories.release.bzl"],
+    cmd = """\
+set -euo pipefail
+
+perl -0777 -pe 's/\n *# Source dependencies.*//s' $< > $@
+    """,
+    tags = ["manual"],
+)
+
 filegroup(
     name = "release_files",
     srcs = glob(
         ["**"],
         exclude = [
             "**/.*",
+            "repositories.bzl",
             "testing.bzl",
         ],
     ) + [
+        ":release_repositories.bzl",
         "//" + package_name() + "/internal:release_files",
     ],
     tags = ["manual"],

--- a/xcodeproj/dev_extensions.bzl
+++ b/xcodeproj/dev_extensions.bzl
@@ -1,0 +1,8 @@
+"""Module extension for loading dev dependencies not yet compatible with bzlmod."""
+
+load(
+    "//xcodeproj:repositories.bzl",
+    "xcodeproj_rules_dev_dependencies",
+)
+
+dev_non_module_deps = module_extension(implementation = lambda _: xcodeproj_rules_dev_dependencies())

--- a/xcodeproj/extensions.bzl
+++ b/xcodeproj/extensions.bzl
@@ -3,10 +3,8 @@
 load(
     "//xcodeproj:repositories.bzl",
     "xcodeproj_rules_dependencies",
-    "xcodeproj_rules_dev_dependencies",
 )
 
 internal = module_extension(implementation = lambda _: xcodeproj_rules_dependencies(internal_only = True))
 
-dev_non_module_deps = module_extension(implementation = lambda _: xcodeproj_rules_dev_dependencies())
 non_module_deps = module_extension(implementation = lambda _: xcodeproj_rules_dependencies(include_bzlmod_ready_dependencies = False))

--- a/xcodeproj/repositories.bzl
+++ b/xcodeproj/repositories.bzl
@@ -164,6 +164,18 @@ native_binary(
         ignore_version_differences = ignore_version_differences,
     )
 
+    # Source dependencies
+    _xcodeproj_rules_source_dependencies(ignore_version_differences)
+
+# buildifier: disable=unnamed-macro
+def _xcodeproj_rules_source_dependencies(ignore_version_differences = False):
+    """Fetches repositories that are dependencies of `rules_xcodeproj` when \
+    building from source.
+
+    Args:
+        ignore_version_differences: If `True`, warnings about potentially
+            incompatible versions of dependency repositories will be silenced.
+    """
     _maybe(
         http_archive,
         name = "com_github_apple_swift_argument_parser",


### PR DESCRIPTION
This removes all dependencies that are only needed for compiling tools, which we don’t do with the release archive.