### PR TITLE
Format error in Xcode when there are no diagnostics parsed

### DIFF
--- a/xcodeproj/internal/bazel_integration_files/process_bazel_build_log.py
+++ b/xcodeproj/internal/bazel_integration_files/process_bazel_build_log.py
@@ -36,6 +36,7 @@ def _main(command: List[str]) -> None:
     relative_diagnostic = re.compile(
         r"^.+?:\d+(:\d+)?: (error|warning): ."
     )
+    has_relative_diagnostic = False
 
     def _replacement(match: re.Match) -> str:
         message = match.group(0)
@@ -75,6 +76,11 @@ def _main(command: List[str]) -> None:
             return
 
         output_line = relative_diagnostic.sub(_replacement, input_line)
+        # Record if we have performed a relative diagnostic substitution.
+        if output_line != input_line:
+            nonlocal has_relative_diagnostic
+            has_relative_diagnostic = True
+
         print(output_line, flush=True)
 
     while process.poll() is None:
@@ -82,6 +88,13 @@ def _main(command: List[str]) -> None:
 
     for line in process.stderr:
         _process_log_line(line)
+
+    # If the Bazel invocation failed and there was no formatted error found, 
+    # print a nicer error message instead of a cryptic in Xcode:
+    # 'Command PhaseScriptExecution failed with a nonzero exit code'
+    if process.returncode != 0 and not has_relative_diagnostic:
+        print("error: The bazel build failed, please check the report navigator, "
+            "which may have more context about the failure.")
 
     sys.exit(process.returncode)
 


### PR DESCRIPTION
We sometimes receive complains from our developers due to the fact that a tool invoked through a custom rule or such fails without a descriptive error. Most of the times, this can be controlled by prefixing all error messages with `error: ` when being executed from inside Xcode, but in some cases it's not. For those cases, the current output in Xcode is pretty cryptic:
<img width="461" alt="Screenshot 2023-06-09 at 1 02 46 PM" src="https://github.com/MobileNativeFoundation/rules_xcodeproj/assets/3658887/3f66ee1a-3584-445d-8bee-51f174e51091">

Many engineers don't seem to be aware that it's possible to reveal more information in the report navigator. For this reason, I propose adding an error message that suggests to do if no error was parsed in the log. The result is the following:
<img width="450" alt="Screenshot 2023-06-09 at 1 02 25 PM" src="https://github.com/MobileNativeFoundation/rules_xcodeproj/assets/3658887/83c0b39d-93b9-4667-b626-b8201ca1896d">

In case there are errors parsed instead (such as a compiler error), we don't do anything.
<img width="423" alt="Screenshot 2023-06-09 at 1 04 26 PM" src="https://github.com/MobileNativeFoundation/rules_xcodeproj/assets/3658887/d217c9f2-64b1-49c6-97a8-5db3f01e9144">

I'm happy to hear what people think about this change, and if others have encountered a similar problem.