### PR TITLE
Set `--repo_env=XCODE_VERSION` as well

### DIFF
--- a/xcodeproj/internal/templates/bazel_build.sh
+++ b/xcodeproj/internal/templates/bazel_build.sh
@@ -86,6 +86,7 @@ readonly base_pre_config_flags=(
   # `USE_CLANG_CL` is only used on Windows, we set it here to cause Bazel to
   # re-evaluate the cc_toolchain for a different Xcode version
   "--repo_env=USE_CLANG_CL=$XCODE_PRODUCT_BUILD_VERSION"
+  "--repo_env=XCODE_VERSION=$XCODE_PRODUCT_BUILD_VERSION"
 
   # Don't block the end of the build for BES upload (artifacts OR events)
   "--bes_upload_mode=NOWAIT_FOR_UPLOAD_COMPLETE"

--- a/xcodeproj/internal/templates/runner.sh
+++ b/xcodeproj/internal/templates/runner.sh
@@ -157,6 +157,7 @@ pre_config_flags=(
   # `USE_CLANG_CL` is only used on Windows, we set it here to cause Bazel to
   # re-evaluate the cc_toolchain for a different Xcode version
   "--repo_env=USE_CLANG_CL=%xcode_version%"
+  "--repo_env=XCODE_VERSION=%xcode_version%"
 )
 
 if [[ %is_fixture% -eq 1 ]]; then


### PR DESCRIPTION
Start to migrate to https://github.com/bazelbuild/apple_support/pull/222. We will need the `USE_CLANG_CL` version until we no longer support earlier `apple_support` versions.