### PR TITLE
Fix indexing of Swift macros

### DIFF
--- a/test/internal/opts/process_compiler_opts_tests.bzl
+++ b/test/internal/opts/process_compiler_opts_tests.bzl
@@ -525,7 +525,8 @@ $(PROJECT_DIR)\
         ],
     )
 
-    # -F, -explicit-swift-module-map-file, and -vfsoverlay
+    # -F, -explicit-swift-module-map-file, -load-plugin-executable,
+    # -load-plugin-library, and -vfsoverlay
 
     _add_test(
         name = "{}_swift_other_paths".format(name),
@@ -556,6 +557,58 @@ $(PROJECT_DIR)\
             "-explicit-swift-module-map-file",
             "-Xfrontend",
             "external/relative/Path.json",
+
+            # -load-plugin-executable
+            "-load-plugin-executable",
+            "/Some/MacroPlugin#MacroPlugin",
+            "-load-plugin-executable",
+            "relative/MacroPlugin#MacroPlugin",
+            "-load-plugin-executable",
+            "bazel-out/relative/MacroPlugin#MacroPlugin",
+            "-load-plugin-executable",
+            "external/relative/MacroPlugin#MacroPlugin",
+            "-Xfrontend",
+            "-load-plugin-executable",
+            "-Xfrontend",
+            "/Some/MacroPlugin#MacroPlugin",
+            "-Xfrontend",
+            "-load-plugin-executable",
+            "-Xfrontend",
+            "relative/MacroPlugin#MacroPlugin",
+            "-Xfrontend",
+            "-load-plugin-executable",
+            "-Xfrontend",
+            "bazel-out/relative/MacroPlugin#MacroPlugin",
+            "-Xfrontend",
+            "-load-plugin-executable",
+            "-Xfrontend",
+            "external/relative/MacroPlugin#MacroPlugin",
+
+            # -load-plugin-library
+            "-load-plugin-library",
+            "/Some/MacroPlugin#MacroPlugin",
+            "-load-plugin-library",
+            "relative/MacroPlugin#MacroPlugin",
+            "-load-plugin-library",
+            "bazel-out/relative/MacroPlugin#MacroPlugin",
+            "-load-plugin-library",
+            "external/relative/MacroPlugin#MacroPlugin",
+            "-Xfrontend",
+            "-load-plugin-library",
+            "-Xfrontend",
+            "/Some/MacroPlugin#MacroPlugin",
+            "-Xfrontend",
+            "-load-plugin-library",
+            "-Xfrontend",
+            "relative/MacroPlugin#MacroPlugin",
+            "-Xfrontend",
+            "-load-plugin-library",
+            "-Xfrontend",
+            "bazel-out/relative/MacroPlugin#MacroPlugin",
+            "-Xfrontend",
+            "-load-plugin-library",
+            "-Xfrontend",
+            "external/relative/MacroPlugin#MacroPlugin",
 
             # -vfsoverlay
             "-vfsoverlay",
@@ -646,6 +699,54 @@ $(BAZEL_OUT)/relative/Path.json \
 -explicit-swift-module-map-file \
 -Xfrontend \
 $(BAZEL_EXTERNAL)/relative/Path.json \
+-load-plugin-executable \
+/Some/MacroPlugin#MacroPlugin \
+-load-plugin-executable \
+$(SRCROOT)/relative/MacroPlugin#MacroPlugin \
+-load-plugin-executable \
+$(BAZEL_OUT)/relative/MacroPlugin#MacroPlugin \
+-load-plugin-executable \
+$(BAZEL_EXTERNAL)/relative/MacroPlugin#MacroPlugin \
+-Xfrontend \
+-load-plugin-executable \
+-Xfrontend \
+/Some/MacroPlugin#MacroPlugin \
+-Xfrontend \
+-load-plugin-executable \
+-Xfrontend \
+$(SRCROOT)/relative/MacroPlugin#MacroPlugin \
+-Xfrontend \
+-load-plugin-executable \
+-Xfrontend \
+$(BAZEL_OUT)/relative/MacroPlugin#MacroPlugin \
+-Xfrontend \
+-load-plugin-executable \
+-Xfrontend \
+$(BAZEL_EXTERNAL)/relative/MacroPlugin#MacroPlugin \
+-load-plugin-library \
+/Some/MacroPlugin#MacroPlugin \
+-load-plugin-library \
+$(SRCROOT)/relative/MacroPlugin#MacroPlugin \
+-load-plugin-library \
+$(BAZEL_OUT)/relative/MacroPlugin#MacroPlugin \
+-load-plugin-library \
+$(BAZEL_EXTERNAL)/relative/MacroPlugin#MacroPlugin \
+-Xfrontend \
+-load-plugin-library \
+-Xfrontend \
+/Some/MacroPlugin#MacroPlugin \
+-Xfrontend \
+-load-plugin-library \
+-Xfrontend \
+$(SRCROOT)/relative/MacroPlugin#MacroPlugin \
+-Xfrontend \
+-load-plugin-library \
+-Xfrontend \
+$(BAZEL_OUT)/relative/MacroPlugin#MacroPlugin \
+-Xfrontend \
+-load-plugin-library \
+-Xfrontend \
+$(BAZEL_EXTERNAL)/relative/MacroPlugin#MacroPlugin \
 -vfsoverlay \
 /Some/Path.yaml \
 -vfsoverlay \

--- a/tools/params_processors/swift_compiler_params_processor.py
+++ b/tools/params_processors/swift_compiler_params_processor.py
@@ -74,6 +74,8 @@ _SWIFTC_SKIP_COMPOUND_OPTS = {
 
         # Handled in `opts.bzl` (skip 3 because of the extra `-Xfrontend` flag)
         "-explicit-swift-module-map-file": 3,
+        "-load-plugin-executable": 3,
+        "-load-plugin-library": 3,
         "-vfsoverlay": 3,
     },
 }

--- a/xcodeproj/internal/opts.bzl
+++ b/xcodeproj/internal/opts.bzl
@@ -181,6 +181,11 @@ _get_unprocessed_cc_compiler_opts = (
     _modern_get_unprocessed_cc_compiler_opts if hasattr(apple_common, "link_multi_arch_static_library") else _legacy_get_unprocessed_cc_compiler_opts
 )
 
+_LOAD_PLUGIN_OPTS = {
+    "-load-plugin-executable": None,
+    "-load-plugin-library": None,
+}
+
 _OVERLAY_OPTS = {
     "-explicit-swift-module-map-file": None,
     "-vfsoverlay": None,
@@ -372,6 +377,20 @@ under {}""".format(opt, package_bin_dir))
             if append_previous_opt:
                 project_set_opts.append(previous_opt)
             project_set_opts.append(opt)
+            continue
+
+        if opt in _LOAD_PLUGIN_OPTS:
+            if append_previous_opt:
+                project_set_opts.append(previous_opt)
+            project_set_opts.append(opt)
+            continue
+
+        if previous_opt_to_check in _LOAD_PLUGIN_OPTS:
+            path = opt
+            absolute_opt = build_setting_path(path)
+            if append_previous_opt:
+                project_set_opts.append(previous_opt)
+            project_set_opts.append(absolute_opt)
             continue
 
         if opt.startswith("-vfsoverlay"):


### PR DESCRIPTION
Another example of SourceKit ignoring the params file.