### PR TITLE
Use Bazel 5.4.1 for Bazel 5

### DIFF
--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -14,7 +14,7 @@ x_templates:
 
     - &bazel_5
       env:
-        USE_BAZEL_VERSION: 5.4.0
+        USE_BAZEL_VERSION: 5.4.1
 
     - &normal_resources
       resource_requests: { memory: 6GB }


### PR DESCRIPTION
5.4.0 doesn’t work with newer macOS versions.