### PR TITLE
Stop using i386 for watchOS

### DIFF
--- a/examples/integration/platform_mappings
+++ b/examples/integration/platform_mappings
@@ -35,9 +35,6 @@ platforms:
   @build_bazel_apple_support//platforms:tvos_arm64
     --cpu=tvos_arm64
 
-  @build_bazel_apple_support//platforms:watchos_i386
-    --cpu=watchos_i386
-
   @build_bazel_apple_support//platforms:watchos_x86_64
     --cpu=watchos_x86_64
 
@@ -98,10 +95,6 @@ flags:
   --cpu=tvos_arm64
   --apple_platform_type=tvos
     @build_bazel_apple_support//platforms:tvos_arm64
-
-  --cpu=watchos_i386
-  --apple_platform_type=watchos
-    @build_bazel_apple_support//platforms:watchos_i386
 
   --cpu=watchos_x86_64
   --apple_platform_type=watchos

--- a/examples/integration/platform_mappings-bzlmod
+++ b/examples/integration/platform_mappings-bzlmod
@@ -35,9 +35,6 @@ platforms:
   @@apple_support~1.4.1//platforms:tvos_arm64
     --cpu=tvos_arm64
 
-  @@apple_support~1.4.1//platforms:watchos_i386
-    --cpu=watchos_i386
-
   @@apple_support~1.4.1//platforms:watchos_x86_64
     --cpu=watchos_x86_64
 
@@ -62,10 +59,6 @@ flags:
   --cpu=darwin_arm64e
   --apple_platform_type=macos
     @@apple_support~1.4.1//platforms:macos_arm64e
-
-  --cpu=ios_i386
-  --apple_platform_type=ios
-    @@apple_support~1.4.1//platforms:ios_i386
 
   --cpu=ios_x86_64
   --apple_platform_type=ios
@@ -98,10 +91,6 @@ flags:
   --cpu=tvos_arm64
   --apple_platform_type=tvos
     @@apple_support~1.4.1//platforms:tvos_arm64
-
-  --cpu=watchos_i386
-  --apple_platform_type=watchos
-    @@apple_support~1.4.1//platforms:watchos_i386
 
   --cpu=watchos_x86_64
   --apple_platform_type=watchos

--- a/shared.bazelrc
+++ b/shared.bazelrc
@@ -8,6 +8,9 @@ build --experimental_action_cache_store_output_metadata
 build --remote_default_exec_properties=OSFamily=darwin
 build --remote_default_exec_properties=cache_bust=macOS_12.0/4
 
+# Use x86_64 instead of i386 for watchOS
+build --watchos_cpus=x86_64
+
 # In-repo output_base makes fixtures relative
 startup --output_base=bazel-output-base
 


### PR DESCRIPTION
Not supported with Xcode 14.3+.