### PR TITLE
Adjust params file parsing

### DIFF
--- a/tools/generators/files_and_groups/src/FilesAndGroups.swift
+++ b/tools/generators/files_and_groups/src/FilesAndGroups.swift
@@ -15,7 +15,7 @@ struct FilesAndGroups: ParsableCommand {
     var colorize = false
 
     static func main() async {
-        await parseAsRootSupportingParamsFiles()
+        await parseAsRootSupportingParamsFile()
     }
 
     func run() throws {

--- a/tools/generators/pbxproj_prefix/src/PBXProjPrefix.swift
+++ b/tools/generators/pbxproj_prefix/src/PBXProjPrefix.swift
@@ -15,7 +15,7 @@ struct PBXProjPrefix: ParsableCommand {
     var colorize = false
 
     static func main() async {
-        await parseAsRootSupportingParamsFiles()
+        await parseAsRootSupportingParamsFile()
     }
 
     func run() throws {


### PR DESCRIPTION
Because we want to pass labels as arguments, which can start with `@`, we need to adjust our params file parsing to only check the first argument, and only if we have a single argument. This is more performant as well.