### PR TITLE
Restrict DEVELOPER_DIR regex to the start of the line

### DIFF
--- a/xcodeproj/internal/bazel_integration_files/import_indexstores.sh
+++ b/xcodeproj/internal/bazel_integration_files/import_indexstores.sh
@@ -101,7 +101,7 @@ remaps=(
   # tools based paths as well.
   # `DEVELOPER_DIR` has an optional `./` prefix, because index-import adds `./`
   # to all relative paths.
-  -remap "(?:.*?/[^/]+/Contents/Developer|(?:./)?DEVELOPER_DIR|/PLACEHOLDER_DEVELOPER_DIR|/Library/Developer/CommandLineTools).*?/SDKs/([^\\d.]+)=$DEVELOPER_DIR/Platforms/\$1.platform/Developer/SDKs/\$1"
+  -remap "^(?:.*?/[^/]+/Contents/Developer|(?:./)?DEVELOPER_DIR|/PLACEHOLDER_DEVELOPER_DIR|/Library/Developer/CommandLineTools).*?/SDKs/([^\\d.]+)=$DEVELOPER_DIR/Platforms/\$1.platform/Developer/SDKs/\$1"
 )
 
 # Import


### PR DESCRIPTION
All these patterns should only only be replaced at the start of the line since they should always be replacing absolute paths to Xcode. This theoretically improves the regex performance but more importantly should make the regex slightly more clear.