### PR TITLE
"Internal precondition failure" when generating a project with BwB that contains a single, generated Core Data contents XML file

### DIFF
--- a/examples/integration/BUILD
+++ b/examples/integration/BUILD
@@ -58,7 +58,7 @@ string_flag(
         name = "xcodeproj-{}".format(simulator_cpu),
         associated_extra_files = ASSOCIATED_EXTRA_FILES,
         bazel_env = BAZEL_ENV,
-        build_mode = "xcode",
+        build_mode = "bazel",
         config = CONFIG,
         default_xcode_configuration = DEFAULT_XCODE_CONFIGURATION,
         extra_files = EXTRA_FILES,

--- a/examples/integration/iOSApp/Source/BUILD
+++ b/examples/integration/iOSApp/Source/BUILD
@@ -24,6 +24,7 @@ config_setting(
     },
 )
 
+GENERATED_CORE_DATA_VERSION_FILE = "GeneratedModel.xcdatamodeld/.xccurrentversion"
 GENERATED_CORE_DATA_CONTENTS_FILE = "GeneratedModel.xcdatamodeld/GeneratedModel.xcdatamodel/contents"
 
 ios_application(
@@ -55,16 +56,14 @@ ios_application(
         ":device_build": ":xcode_profile",
         "//conditions:default": None,
     }),
-    resources = [":ExampleResourceGroup", ":GeneratedCoreDataContents"] + glob(
+    resources = [":ExampleResourceGroup", ":GeneratedCoreDataContents", ":GeneratedCoreDataVersion"] + glob(
         [
             "Assets.xcassets/**",
             "Model.xcdatamodeld/**",
-            "GeneratedModel.xcdatamodeld/**",
             "*.lproj/unprocessed.json",
         ],
         exclude = [
             "Assets.xcassets/AppIcon.appiconset/**",
-            GENERATED_CORE_DATA_CONTENTS_FILE,
         ],
     ),
     strings = glob(["*.lproj/Localizable.strings"]),
@@ -139,6 +138,13 @@ filegroup(
 )
 
 generated_file(
+    name = "GeneratedCoreDataVersion",
+    source_file = GENERATED_CORE_DATA_VERSION_FILE,
+    output_name = "GeneratedModel.xcdatamodeld/.xccurrentversion",
+)
+
+generated_file(
     name = "GeneratedCoreDataContents",
     source_file = GENERATED_CORE_DATA_CONTENTS_FILE,
+    output_name = "GeneratedModel.xcdatamodeld/GeneratedModel.xcdatamodel/contents",
 )

--- a/examples/integration/iOSApp/Source/BUILD
+++ b/examples/integration/iOSApp/Source/BUILD
@@ -8,6 +8,7 @@ load(
     "IOS_BUNDLE_ID",
     "TEAMID",
 )
+load("//iOSApp/Source:file_generation.bzl", "generated_file")
 
 config_setting(
     name = "release_build",
@@ -22,6 +23,8 @@ config_setting(
         "cpu": "ios_arm64",
     },
 )
+
+GENERATED_CORE_DATA_CONTENTS_FILE = "GeneratedModel.xcdatamodeld/GeneratedModel.xcdatamodel/contents"
 
 ios_application(
     name = "iOSApp",
@@ -52,13 +55,17 @@ ios_application(
         ":device_build": ":xcode_profile",
         "//conditions:default": None,
     }),
-    resources = [":ExampleResourceGroup"] + glob(
+    resources = [":ExampleResourceGroup", ":GeneratedCoreDataContents"] + glob(
         [
             "Assets.xcassets/**",
             "Model.xcdatamodeld/**",
+            "GeneratedModel.xcdatamodeld/**",
             "*.lproj/unprocessed.json",
         ],
-        exclude = ["Assets.xcassets/AppIcon.appiconset/**"],
+        exclude = [
+            "Assets.xcassets/AppIcon.appiconset/**",
+            GENERATED_CORE_DATA_CONTENTS_FILE,
+        ],
     ),
     strings = glob(["*.lproj/Localizable.strings"]),
     version = "//iOSApp:Version",
@@ -129,4 +136,9 @@ apple_resource_group(
 filegroup(
     name = "PreviewContent",
     srcs = glob(["PreviewContent/**"]),
+)
+
+generated_file(
+    name = "GeneratedCoreDataContents",
+    source_file = GENERATED_CORE_DATA_CONTENTS_FILE,
 )

--- a/examples/integration/iOSApp/Source/GeneratedModel.xcdatamodeld/.xccurrentversion
+++ b/examples/integration/iOSApp/Source/GeneratedModel.xcdatamodeld/.xccurrentversion
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>_XCCurrentVersionName</key>
+	<string>GeneratedModel.xcdatamodel</string>
+</dict>
+</plist>

--- a/examples/integration/iOSApp/Source/GeneratedModel.xcdatamodeld/GeneratedModel.xcdatamodel/contents
+++ b/examples/integration/iOSApp/Source/GeneratedModel.xcdatamodeld/GeneratedModel.xcdatamodel/contents
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="19574" systemVersion="21C52" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="MyGeneratedEntity" representedClassName="MyGeneratedEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="name" optional="YES" attributeType="String"/>
+    </entity>
+    <elements>
+        <element name="MyGeneratedEntity" positionX="-63" positionY="-18" width="128" height="44"/>
+    </elements>
+</model>

--- a/examples/integration/iOSApp/Source/file_generation.bzl
+++ b/examples/integration/iOSApp/Source/file_generation.bzl
@@ -2,8 +2,8 @@
 Simple file generation
 """
 def _generated_file_impl(ctx):
-    out = ctx.actions.declare_file(ctx.label.name)
-    
+    out = ctx.actions.declare_file(ctx.attr.output_name)
+
     ctx.actions.run_shell(
         progress_message = "Copying file",
         command = "cp {input} {output}".format(
@@ -24,5 +24,6 @@ generated_file = rule(
     implementation = _generated_file_impl,
     attrs = {
         "source_file": attr.label(allow_single_file = True, mandatory = True),
+        "output_name": attr.string(mandatory = True),
     },
 )

--- a/examples/integration/iOSApp/Source/file_generation.bzl
+++ b/examples/integration/iOSApp/Source/file_generation.bzl
@@ -1,0 +1,28 @@
+"""
+Simple file generation
+"""
+def _generated_file_impl(ctx):
+    out = ctx.actions.declare_file(ctx.label.name)
+    
+    ctx.actions.run_shell(
+        progress_message = "Copying file",
+        command = "cp {input} {output}".format(
+            input = ctx.file.source_file.path,
+            output = out.path,
+        ),
+        arguments = [],
+        inputs = [ctx.file.source_file],
+        outputs = [out],
+        mnemonic = "CopyFile",
+    )
+
+    return [
+        DefaultInfo(files = depset([out])),
+    ]
+
+generated_file = rule(
+    implementation = _generated_file_impl,
+    attrs = {
+        "source_file": attr.label(allow_single_file = True, mandatory = True),
+    },
+)


### PR DESCRIPTION
### Generating Core Data **contents** XML file causes BwB project generation to fail

We are migrating to use a generated Core Data **.xcdatamodeld/*.xcdatamodel/contents** file using a custom Bazel rule.  Our Bazel build and the app runtime are both working well with the newly generated file.  Unfortunately we are getting the following error when trying to generate an Xcode project with BwB for the setup with the generated **contents** file:

```
ERROR: Internal precondition failure:
"path/to/OurSpecialModel.xcdatamodeld" `XCVersionGroup` not found in `elements`
```

### Reproducible Example

_This PR branch is set up to reproduce the failure.  Follow these steps to reproduce the same failure as noted above._  

1. Check out this PR branch
2. `cd examples/integration`
3. `bazel run //:xcodeproj-sim_arm64` or `//:xcodeproj-x86_64`

### Notes:

It appears that we can hit this error only under the following conditions:

- We generate the `contents` file with a custom Bazel rule
- We have an **.xcdatamodeld** folder structure with a _single_ version of the data model that looks something like this:

```
OurSpecialModel.xcdatamodeld
└── 1.0.xcdatamodel // <-- single version here
    └── contents
```

We note this because when trying to create a reproducible case, we initially failed to reproduce the error because the current model in the example integration app for `rules_xcodeproj` looks like this:

```
iOSApp/Source/Model.xcdatamodeld
├── Model.xcdatamodel // <-- replacing this model didn't fail to generate the project at all
│   └── contents
└── Model2.xcdatamodel // <-- replacing this model didn't fail to generate the project (but it did generate a version missing warning)
    └── contents
```

It was only after we removed the **Model2.xcdatamodel** tree entirely and updated the **.xccurrentversion** file to point to the remaining **Model.xcdatamodel** that we could get the issue to reproduce.