### PR TITLE
Capture `BAZELISK_SKIP_WRAPPER` as well

### DIFF
--- a/xcodeproj/internal/xcodeproj_macro.bzl
+++ b/xcodeproj/internal/xcodeproj_macro.bzl
@@ -311,8 +311,9 @@ removed in a future release.""")
     if not xcode_configurations:
         xcode_configurations = {"Debug": {}}
 
-    # Collect `BAZEL_REAL` from runner's env if it exist
+    # Collect `BAZEL_REAL` and `BAZELISK_SKIP_WRAPPER` from runner's env if it exist
     bazel_env["BAZEL_REAL"] = None
+    bazel_env["BAZELISK_SKIP_WRAPPER"] = None
 
     bazel_env = {
         # Null character is used to represent `None`, since `attr.string_dict`


### PR DESCRIPTION
Works around a recursion issue if your `BAZEL_REAL` is actually a `bazelisk`-like binary.