### PR TITLE
Move `Dictionary.value(for:context:)` to `PBXProj`

### DIFF
--- a/tools/generators/lib/PBXProj/src/Dictionary+Extensions.swift
+++ b/tools/generators/lib/PBXProj/src/Dictionary+Extensions.swift
@@ -1,7 +1,7 @@
 import GeneratorCommon
 
 extension Dictionary where Key: Comparable {
-    func value(for key: Key, context: String) throws -> Value {
+    public func value(for key: Key, context: String) throws -> Value {
         guard let value = self[key] else {
             throw PreconditionError(
                 message: """

--- a/tools/generators/lib/PBXProj/test/DictionaryExtensionTests.swift
+++ b/tools/generators/lib/PBXProj/test/DictionaryExtensionTests.swift
@@ -1,9 +1,8 @@
 import GeneratorCommon
+import PBXProj
 import XCTest
 
-@testable import pbxproject_targets
-
-final class DictionaryExtensionsTests: XCTestCase {
+final class DictionaryExtensionTests: XCTestCase {
     func test_valueForKeyContext_valid() throws {
         // Arrange
 


### PR DESCRIPTION
Will be used by more than one generator.