### PR TITLE
Convert `BAZEL_COMPILE_TARGET_IDS` to a string

### DIFF
--- a/examples/rules_ios/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/rules_ios/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -4419,10 +4419,7 @@
 				ASAN_OTHER_CFLAGS__ = "$(ASAN_OTHER_CFLAGS__NO)";
 				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) @$(DERIVED_FILE_DIR)/c.compile.params";
 				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
-				BAZEL_COMPILE_TARGET_IDS = (
-					"//iOSApp/Test/MixedUnitTests:iOSAppMixedUnitTests_swift ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-					"//iOSApp/Test/MixedUnitTests:iOSAppMixedUnitTests_objc ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-				);
+				BAZEL_COMPILE_TARGET_IDS = "//iOSApp/Test/MixedUnitTests:iOSAppMixedUnitTests_swift ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1 //iOSApp/Test/MixedUnitTests:iOSAppMixedUnitTests_objc ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1";
 				"BAZEL_COMPILE_TARGET_IDS[sdk=iphonesimulator*]" = "$(BAZEL_COMPILE_TARGET_IDS)";
 				BAZEL_LABEL = "@//iOSApp/Test/MixedUnitTests:iOSAppMixedUnitTests";
 				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-3/bin/iOSApp/Test/MixedUnitTests/iOSAppMixedUnitTests.__internal__.__test_bundle.zip";

--- a/tools/generators/legacy/src/Generator/SetTargetConfigurations.swift
+++ b/tools/generators/legacy/src/Generator/SetTargetConfigurations.swift
@@ -297,7 +297,9 @@ $(BAZEL_OUT)\#(linkParams.path.string.dropFirst(9))
         if target.compileTargets.count > 0 {
             buildSettings.set(
                 "BAZEL_COMPILE_TARGET_IDS",
-                to: target.compileTargets.map(\.id.rawValue)
+                to: target.compileTargets
+                    .map(\.id.rawValue)
+                    .joined(separator: " ")
             )
         }
 


### PR DESCRIPTION
We only read this value in `calculate_output_groups.py`, and there it’s already treated as a string separated by spaces. By explicitly making it a string, it’s easier to create in the new incremental generators.