### PR TITLE
Use an array instead of a dictionary in `pbxProjectBuildSettings()`

### DIFF
--- a/tools/generators/pbxproj_prefix/src/Generator/PBXProjectBuildSettings.swift
+++ b/tools/generators/pbxproj_prefix/src/Generator/PBXProjectBuildSettings.swift
@@ -21,94 +21,132 @@ extension Generator {
         resolvedRepositories: String,
         workspace: String
     ) -> String {
-        var settings: [String: String] = [
-            "ALWAYS_SEARCH_USER_PATHS": "NO",
-            "BAZEL_CONFIG": "rules_xcodeproj",
-            "BAZEL_EXTERNAL": "$(BAZEL_OUTPUT_BASE)/external".pbxProjEscaped,
-            "BAZEL_INTEGRATION_DIR": "$(INTERNAL_DIR)/bazel".pbxProjEscaped,
-            "BAZEL_LLDB_INIT":
-                "$(HOME)/.lldbinit-rules_xcodeproj".pbxProjEscaped,
-            "BAZEL_OUT": "$(PROJECT_DIR)/bazel-out".pbxProjEscaped,
-            "BAZEL_OUTPUT_BASE":
-                "$(_BAZEL_OUTPUT_BASE:standardizepath)".pbxProjEscaped,
-            "BAZEL_WORKSPACE_ROOT": "$(SRCROOT)".pbxProjEscaped,
-            "BUILD_DIR":
+        var settings: [(key: String, value: String)] = [
+            ("ALWAYS_SEARCH_USER_PATHS", "NO"),
+            ("BAZEL_CONFIG", "rules_xcodeproj"),
+            ("BAZEL_EXTERNAL", "$(BAZEL_OUTPUT_BASE)/external".pbxProjEscaped),
+            ("BAZEL_INTEGRATION_DIR", "$(INTERNAL_DIR)/bazel".pbxProjEscaped),
+            (
+                "BAZEL_LLDB_INIT",
+                "$(HOME)/.lldbinit-rules_xcodeproj".pbxProjEscaped
+            ),
+            ("BAZEL_OUT", "$(PROJECT_DIR)/bazel-out".pbxProjEscaped),
+            (
+                "BAZEL_OUTPUT_BASE",
+                "$(_BAZEL_OUTPUT_BASE:standardizepath)".pbxProjEscaped
+            ),
+            ("BAZEL_WORKSPACE_ROOT", "$(SRCROOT)".pbxProjEscaped),
+            (
+                "BUILD_DIR",
                 "$(SYMROOT)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)"
-                .pbxProjEscaped,
-            "BUILD_WORKSPACE_DIRECTORY": "$(SRCROOT)".pbxProjEscaped,
-            "BUILT_PRODUCTS_DIR":
+                    .pbxProjEscaped
+            ),
+            ("BUILD_WORKSPACE_DIRECTORY", "$(SRCROOT)".pbxProjEscaped),
+            (
+                "BUILT_PRODUCTS_DIR",
                 "$(INDEXING_BUILT_PRODUCTS_DIR__$(INDEX_ENABLE_BUILD_ARENA))"
-                .pbxProjEscaped,
-            "CLANG_ENABLE_OBJC_ARC": "YES",
-            "CLANG_MODULES_AUTOLINK": "NO",
-            "CONFIGURATION_BUILD_DIR": "$(BUILD_DIR)/$(BAZEL_PACKAGE_BIN_DIR)"
-                .pbxProjEscaped,
-            "COPY_PHASE_STRIP": "NO",
-            "DEBUG_INFORMATION_FORMAT": "dwarf",
-            "DEPLOYMENT_LOCATION":
+                    .pbxProjEscaped
+            ),
+            ("CLANG_ENABLE_OBJC_ARC", "YES"),
+            ("CLANG_MODULES_AUTOLINK", "NO"),
+            (
+                "CONFIGURATION_BUILD_DIR",
+                "$(BUILD_DIR)/$(BAZEL_PACKAGE_BIN_DIR)"
+                    .pbxProjEscaped
+            ),
+            ("COPY_PHASE_STRIP", "NO"),
+            ("DEBUG_INFORMATION_FORMAT", "dwarf"),
+            (
+                "DEPLOYMENT_LOCATION",
                 "$(INDEXING_DEPLOYMENT_LOCATION__$(INDEX_ENABLE_BUILD_ARENA))"
-                    .pbxProjEscaped,
-            "DSTROOT": "$(PROJECT_TEMP_DIR)".pbxProjEscaped,
-            "ENABLE_DEFAULT_SEARCH_PATHS": "NO",
-            "ENABLE_STRICT_OBJC_MSGSEND": "YES",
-            "GCC_OPTIMIZATION_LEVEL": "0",
-            "INDEXING_BUILT_PRODUCTS_DIR__":
-                "$(INDEXING_BUILT_PRODUCTS_DIR__NO)".pbxProjEscaped,
-            "INDEXING_BUILT_PRODUCTS_DIR__NO": "$(BUILD_DIR)".pbxProjEscaped,
-            "INDEXING_BUILT_PRODUCTS_DIR__YES":
-                "$(CONFIGURATION_BUILD_DIR)".pbxProjEscaped,
-            "INDEXING_DEPLOYMENT_LOCATION__":
-                "$(INDEXING_DEPLOYMENT_LOCATION__NO)".pbxProjEscaped,
-            "INDEXING_DEPLOYMENT_LOCATION__NO": "YES",
-            "INDEXING_DEPLOYMENT_LOCATION__YES": "NO",
-            "INDEXING_PROJECT_DIR__":
-                "$(INDEXING_PROJECT_DIR__NO)".pbxProjEscaped,
-            "INDEXING_PROJECT_DIR__NO": "$(PROJECT_DIR)".pbxProjEscaped,
-            "INDEXING_PROJECT_DIR__YES": indexingProjectDir.pbxProjEscaped,
-            "INDEX_DATA_STORE_DIR": "$(INDEX_DATA_STORE_DIR)".pbxProjEscaped,
-            "INDEX_FORCE_SCRIPT_EXECUTION": "YES",
-            "INDEX_IMPORT": indexImport
-                .executionRootBasedBuildSettingPath
-                .pbxProjEscaped,
-            "INSTALL_PATH":
-                "$(BAZEL_PACKAGE_BIN_DIR)/$(TARGET_NAME)/bin".pbxProjEscaped,
-            "INTERNAL_DIR": "$(PROJECT_FILE_PATH)/rules_xcodeproj",
-            "LD_DYLIB_INSTALL_NAME": "".pbxProjEscaped,
-            "LD_OBJC_ABI_VERSION": "".pbxProjEscaped,
-            "LD_RUNPATH_SEARCH_PATHS": "".pbxProjEscaped,
-            "ONLY_ACTIVE_ARCH": "YES",
-            "PROJECT_DIR":
+                    .pbxProjEscaped
+            ),
+            ("DSTROOT", "$(PROJECT_TEMP_DIR)".pbxProjEscaped),
+            ("ENABLE_DEFAULT_SEARCH_PATHS", "NO"),
+            ("ENABLE_STRICT_OBJC_MSGSEND", "YES"),
+            ("GCC_OPTIMIZATION_LEVEL", "0"),
+            (
+                "INDEXING_BUILT_PRODUCTS_DIR__",
+                "$(INDEXING_BUILT_PRODUCTS_DIR__NO)".pbxProjEscaped
+            ),
+            ("INDEXING_BUILT_PRODUCTS_DIR__NO", "$(BUILD_DIR)".pbxProjEscaped),
+            (
+                "INDEXING_BUILT_PRODUCTS_DIR__YES",
+                "$(CONFIGURATION_BUILD_DIR)".pbxProjEscaped
+            ),
+            (
+                "INDEXING_DEPLOYMENT_LOCATION__",
+                "$(INDEXING_DEPLOYMENT_LOCATION__NO)".pbxProjEscaped
+            ),
+            ("INDEXING_DEPLOYMENT_LOCATION__NO", "YES"),
+            ("INDEXING_DEPLOYMENT_LOCATION__YES", "NO"),
+            (
+                "INDEXING_PROJECT_DIR__",
+                "$(INDEXING_PROJECT_DIR__NO)".pbxProjEscaped
+            ),
+            ("INDEXING_PROJECT_DIR__NO", "$(PROJECT_DIR)".pbxProjEscaped),
+            ("INDEXING_PROJECT_DIR__YES", indexingProjectDir.pbxProjEscaped),
+            ("INDEX_DATA_STORE_DIR", "$(INDEX_DATA_STORE_DIR)".pbxProjEscaped),
+            ("INDEX_FORCE_SCRIPT_EXECUTION", "YES"),
+            (
+                "INDEX_IMPORT",
+                indexImport
+                    .executionRootBasedBuildSettingPath
+                    .pbxProjEscaped
+            ),
+            (
+                "INSTALL_PATH",
+                "$(BAZEL_PACKAGE_BIN_DIR)/$(TARGET_NAME)/bin".pbxProjEscaped
+            ),
+            ("INTERNAL_DIR", "$(PROJECT_FILE_PATH)/rules_xcodeproj"),
+            ("LD_DYLIB_INSTALL_NAME", "".pbxProjEscaped),
+            ("LD_OBJC_ABI_VERSION", "".pbxProjEscaped),
+            ("LD_RUNPATH_SEARCH_PATHS", "".pbxProjEscaped),
+            ("ONLY_ACTIVE_ARCH", "YES"),
+            (
+                "PROJECT_DIR",
                 "$(INDEXING_PROJECT_DIR__$(INDEX_ENABLE_BUILD_ARENA))"
-                .pbxProjEscaped,
-            "RESOLVED_REPOSITORIES": resolvedRepositories.pbxProjEscaped,
-            "RULES_XCODEPROJ_BUILD_MODE": buildMode.rawValue,
-            "SCHEME_TARGET_IDS_FILE":
-                "$(OBJROOT)/scheme_target_ids".pbxProjEscaped,
-            "SRCROOT": workspace.pbxProjEscaped,
-            "SUPPORTS_MACCATALYST": "NO",
-            "SWIFT_OBJC_INTERFACE_HEADER_NAME": "".pbxProjEscaped,
-            "SWIFT_OPTIMIZATION_LEVEL": "-Onone".pbxProjEscaped,
-            "SWIFT_VERSION": "5.0",
-            "TARGET_TEMP_DIR": """
+                    .pbxProjEscaped
+            ),
+            ("RESOLVED_REPOSITORIES", resolvedRepositories.pbxProjEscaped),
+            ("RULES_XCODEPROJ_BUILD_MODE", buildMode.rawValue),
+            (
+                "SCHEME_TARGET_IDS_FILE",
+                "$(OBJROOT)/scheme_target_ids".pbxProjEscaped
+            ),
+            ("SRCROOT", workspace.pbxProjEscaped),
+            ("SUPPORTS_MACCATALYST", "NO"),
+            ("SWIFT_OBJC_INTERFACE_HEADER_NAME", "".pbxProjEscaped),
+            ("SWIFT_OPTIMIZATION_LEVEL", "-Onone".pbxProjEscaped),
+            ("SWIFT_VERSION", "5.0"),
+            (
+                "TARGET_TEMP_DIR",
+                #"""
 $(PROJECT_TEMP_DIR)/$(BAZEL_PACKAGE_BIN_DIR)/$(COMPILE_TARGET_NAME)
-"""
-                .pbxProjEscaped,
-            "USE_HEADERMAP": "NO",
-            "VALIDATE_WORKSPACE": "NO",
-            "_BAZEL_OUTPUT_BASE": "$(PROJECT_DIR)/../..".pbxProjEscaped,
+"""#.pbxProjEscaped
+            ),
+            ("USE_HEADERMAP", "NO"),
+            ("VALIDATE_WORKSPACE", "NO"),
+            ("_BAZEL_OUTPUT_BASE", "$(PROJECT_DIR)/../..".pbxProjEscaped),
         ]
 
         if buildMode.usesBazelModeBuildScripts {
-            settings.merge([
-                "CC": "$(BAZEL_INTEGRATION_DIR)/clang.sh".pbxProjEscaped,
-                "CXX": "$(BAZEL_INTEGRATION_DIR)/clang.sh".pbxProjEscaped,
-                "CODE_SIGNING_ALLOWED": "NO",
-                "LD": "$(BAZEL_INTEGRATION_DIR)/ld.sh".pbxProjEscaped,
-                "LDPLUSPLUS": "$(BAZEL_INTEGRATION_DIR)/ld.sh".pbxProjEscaped,
-                "LIBTOOL": "$(BAZEL_INTEGRATION_DIR)/libtool.sh".pbxProjEscaped,
-                "SWIFT_EXEC": "$(BAZEL_INTEGRATION_DIR)/swiftc".pbxProjEscaped,
-                "SWIFT_USE_INTEGRATED_DRIVER": "NO",
-            ], uniquingKeysWith: { _, r in r })
+            settings.append(contentsOf: [
+                ("CC", "$(BAZEL_INTEGRATION_DIR)/clang.sh".pbxProjEscaped),
+                ("CXX", "$(BAZEL_INTEGRATION_DIR)/clang.sh".pbxProjEscaped),
+                ("CODE_SIGNING_ALLOWED", "NO"),
+                ("LD", "$(BAZEL_INTEGRATION_DIR)/ld.sh".pbxProjEscaped),
+                ("LDPLUSPLUS", "$(BAZEL_INTEGRATION_DIR)/ld.sh".pbxProjEscaped),
+                (
+                    "LIBTOOL",
+                    "$(BAZEL_INTEGRATION_DIR)/libtool.sh".pbxProjEscaped
+                ),
+                (
+                    "SWIFT_EXEC",
+                    "$(BAZEL_INTEGRATION_DIR)/swiftc".pbxProjEscaped
+                ),
+                ("SWIFT_USE_INTEGRATED_DRIVER", "NO"),
+            ])
         }
 
         // The tabs for indenting are intentional


### PR DESCRIPTION
We don’t use the capabilities of the dictionary, so no need for the overhead.