### PR TITLE
Manually escape non-dynamic build settings

### DIFF
--- a/tools/generators/pbxproj_prefix/README.md
+++ b/tools/generators/pbxproj_prefix/README.md
@@ -130,10 +130,10 @@ Here is an example output:
 				INDEX_DISABLE_SCRIPT_EXECUTION = YES;
 				LD = "";
 				LDPLUSPLUS = "";
-				LIBTOOL = "libtool";
+				LIBTOOL = libtool;
 				SUPPORTED_PLATFORMS = "$(INDEXING_SUPPORTED_PLATFORMS__$(INDEX_ENABLE_BUILD_ARENA))";
 				SUPPORTS_MACCATALYST = YES;
-				SWIFT_EXEC = "swiftc";
+				SWIFT_EXEC = swiftc;
 				TARGET_IDS_FILE = "$(BAZEL_OUT)/darwin_arm64-dbg/bin/external/_main~internal~rules_xcodeproj_generated/generator/tools/xcodeproj/xcodeproj_target_ids";
 				TARGET_NAME = BazelDependencies;
 			};
@@ -152,10 +152,10 @@ Here is an example output:
 				INDEX_DISABLE_SCRIPT_EXECUTION = YES;
 				LD = "";
 				LDPLUSPLUS = "";
-				LIBTOOL = "libtool";
+				LIBTOOL = libtool;
 				SUPPORTED_PLATFORMS = "$(INDEXING_SUPPORTED_PLATFORMS__$(INDEX_ENABLE_BUILD_ARENA))";
 				SUPPORTS_MACCATALYST = YES;
-				SWIFT_EXEC = "swiftc";
+				SWIFT_EXEC = swiftc;
 				TARGET_IDS_FILE = "$(BAZEL_OUT)/darwin_arm64-dbg/bin/external/_main~internal~rules_xcodeproj_generated/generator/tools/xcodeproj/xcodeproj_target_ids";
 				TARGET_NAME = BazelDependencies;
 			};
@@ -223,7 +223,7 @@ Here is an example output:
 				INDEXING_PROJECT_DIR__YES = "/tmp/workspace/bazel-output-base/rules_xcodeproj.noindex/indexbuild_output_base/execroot/_main";
 				INDEX_FORCE_SCRIPT_EXECUTION = YES;
 				INSTALL_PATH = "$(BAZEL_PACKAGE_BIN_DIR)/$(TARGET_NAME)/bin";
-				INTERNAL_DIR = $(PROJECT_FILE_PATH)/rules_xcodeproj;
+				INTERNAL_DIR = "$(PROJECT_FILE_PATH)/rules_xcodeproj";
 				LD = "$(BAZEL_INTEGRATION_DIR)/ld.sh";
 				LDPLUSPLUS = "$(BAZEL_INTEGRATION_DIR)/ld.sh";
 				LD_DYLIB_INSTALL_NAME = "";
@@ -289,7 +289,7 @@ Here is an example output:
 				INDEXING_PROJECT_DIR__YES = "/tmp/workspace/bazel-output-base/rules_xcodeproj.noindex/indexbuild_output_base/execroot/_main";
 				INDEX_FORCE_SCRIPT_EXECUTION = YES;
 				INSTALL_PATH = "$(BAZEL_PACKAGE_BIN_DIR)/$(TARGET_NAME)/bin";
-				INTERNAL_DIR = $(PROJECT_FILE_PATH)/rules_xcodeproj;
+				INTERNAL_DIR = "$(PROJECT_FILE_PATH)/rules_xcodeproj";
 				LD = "$(BAZEL_INTEGRATION_DIR)/ld.sh";
 				LDPLUSPLUS = "$(BAZEL_INTEGRATION_DIR)/ld.sh";
 				LD_DYLIB_INSTALL_NAME = "";

--- a/tools/generators/pbxproj_prefix/src/Generator/BazelDependenciesBuildSettings.swift
+++ b/tools/generators/pbxproj_prefix/src/Generator/BazelDependenciesBuildSettings.swift
@@ -40,10 +40,10 @@ extension Generator {
 				INDEX_DISABLE_SCRIPT_EXECUTION = YES;
 				LD = "";
 				LDPLUSPLUS = "";
-				LIBTOOL = "libtool";
+				LIBTOOL = libtool;
 				SUPPORTED_PLATFORMS = "$(INDEXING_SUPPORTED_PLATFORMS__$(INDEX_ENABLE_BUILD_ARENA))";
 				SUPPORTS_MACCATALYST = YES;
-				SWIFT_EXEC = "swiftc";
+				SWIFT_EXEC = swiftc;
 				TARGET_IDS_FILE = \#(
                     targetIdsFile
                         .executionRootBasedBuildSettingPath

--- a/tools/generators/pbxproj_prefix/src/Generator/PBXProjectBuildSettings.swift
+++ b/tools/generators/pbxproj_prefix/src/Generator/PBXProjectBuildSettings.swift
@@ -27,84 +27,85 @@ extension Generator {
             .init(key: "BAZEL_CONFIG", value: "rules_xcodeproj"),
             .init(
                 key: "BAZEL_EXTERNAL",
-                value: "$(BAZEL_OUTPUT_BASE)/external".pbxProjEscaped
+                value: #""$(BAZEL_OUTPUT_BASE)/external""#
             ),
             .init(
                 key: "BAZEL_INTEGRATION_DIR",
-                value: "$(INTERNAL_DIR)/bazel".pbxProjEscaped
+                value: #""$(INTERNAL_DIR)/bazel""#
             ),
             .init(
                 key: "BAZEL_LLDB_INIT",
-                value: "$(HOME)/.lldbinit-rules_xcodeproj".pbxProjEscaped
+                value: #""$(HOME)/.lldbinit-rules_xcodeproj""#
             ),
             .init(
                 key: "BAZEL_OUT",
-                value: "$(PROJECT_DIR)/bazel-out".pbxProjEscaped),
+                value: #""$(PROJECT_DIR)/bazel-out""#),
             .init(
                 key: "BAZEL_OUTPUT_BASE",
-                value: "$(_BAZEL_OUTPUT_BASE:standardizepath)".pbxProjEscaped
+                value: #""$(_BAZEL_OUTPUT_BASE:standardizepath)""#
             ),
             .init(
                 key: "BAZEL_WORKSPACE_ROOT",
-                value: "$(SRCROOT)".pbxProjEscaped
+                value: #""$(SRCROOT)""#
             ),
             .init(
                 key: "BUILD_DIR",
-                value: "$(SYMROOT)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)"
-                    .pbxProjEscaped
+                value:
+                    #""$(SYMROOT)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)""#
             ),
             .init(
                 key: "BUILD_WORKSPACE_DIRECTORY",
-                value: "$(SRCROOT)".pbxProjEscaped
+                value: #""$(SRCROOT)""#
             ),
             .init(
                 key: "BUILT_PRODUCTS_DIR",
-                value: "$(INDEXING_BUILT_PRODUCTS_DIR__$(INDEX_ENABLE_BUILD_ARENA))"
-                    .pbxProjEscaped
+                value: #"""
+"$(INDEXING_BUILT_PRODUCTS_DIR__$(INDEX_ENABLE_BUILD_ARENA))"
+"""#
             ),
             .init(key: "CLANG_ENABLE_OBJC_ARC", value: "YES"),
             .init(key: "CLANG_MODULES_AUTOLINK", value: "NO"),
             .init(
                 key: "CONFIGURATION_BUILD_DIR",
-                value: "$(BUILD_DIR)/$(BAZEL_PACKAGE_BIN_DIR)"
-                    .pbxProjEscaped
+                value: #""$(BUILD_DIR)/$(BAZEL_PACKAGE_BIN_DIR)""#
             ),
             .init(key: "COPY_PHASE_STRIP", value: "NO"),
             .init(key: "DEBUG_INFORMATION_FORMAT", value: "dwarf"),
             .init(
                 key: "DEPLOYMENT_LOCATION",
-                value: "$(INDEXING_DEPLOYMENT_LOCATION__$(INDEX_ENABLE_BUILD_ARENA))"
-                    .pbxProjEscaped
+                value: #"""
+"$(INDEXING_DEPLOYMENT_LOCATION__$(INDEX_ENABLE_BUILD_ARENA))"
+"""#
             ),
-            .init(key: "DSTROOT", value: "$(PROJECT_TEMP_DIR)".pbxProjEscaped),
+            .init(key: "DSTROOT", value: #""$(PROJECT_TEMP_DIR)""#),
             .init(key: "ENABLE_DEFAULT_SEARCH_PATHS", value: "NO"),
             .init(key: "ENABLE_STRICT_OBJC_MSGSEND", value: "YES"),
             .init(key: "GCC_OPTIMIZATION_LEVEL", value: "0"),
             .init(
                 key: "INDEXING_BUILT_PRODUCTS_DIR__",
-                value: "$(INDEXING_BUILT_PRODUCTS_DIR__NO)".pbxProjEscaped
+                value: #""$(INDEXING_BUILT_PRODUCTS_DIR__NO)""#
             ),
             .init(
                 key: "INDEXING_BUILT_PRODUCTS_DIR__NO",
-                value: "$(BUILD_DIR)".pbxProjEscaped
+                value: #""$(BUILD_DIR)""#
             ),
             .init(
                 key: "INDEXING_BUILT_PRODUCTS_DIR__YES",
-                value: "$(CONFIGURATION_BUILD_DIR)".pbxProjEscaped
+                value: #""$(CONFIGURATION_BUILD_DIR)""#
             ),
             .init(
                 key: "INDEXING_DEPLOYMENT_LOCATION__",
-                value: "$(INDEXING_DEPLOYMENT_LOCATION__NO)".pbxProjEscaped
+                value: #""$(INDEXING_DEPLOYMENT_LOCATION__NO)""#
             ),
             .init(key: "INDEXING_DEPLOYMENT_LOCATION__NO", value: "YES"),
             .init(key: "INDEXING_DEPLOYMENT_LOCATION__YES", value: "NO"),
             .init(
                 key: "INDEXING_PROJECT_DIR__",
-                value: "$(INDEXING_PROJECT_DIR__NO)".pbxProjEscaped
+                value: #""$(INDEXING_PROJECT_DIR__NO)""#
             ),
             .init(
                 key: "INDEXING_PROJECT_DIR__NO",
-                value: "$(PROJECT_DIR)".pbxProjEscaped
+                value: #""$(PROJECT_DIR)""#
             ),
             .init(
                 key: "INDEXING_PROJECT_DIR__YES",
@@ -112,7 +113,7 @@ extension Generator {
             ),
             .init(
                 key: "INDEX_DATA_STORE_DIR",
-                value: "$(INDEX_DATA_STORE_DIR)".pbxProjEscaped
+                value: #""$(INDEX_DATA_STORE_DIR)""#
             ),
             .init(key: "INDEX_FORCE_SCRIPT_EXECUTION", value: "YES"),
             .init(
@@ -123,20 +124,20 @@ extension Generator {
             ),
             .init(
                 key: "INSTALL_PATH",
-                value: "$(BAZEL_PACKAGE_BIN_DIR)/$(TARGET_NAME)/bin".pbxProjEscaped
+                value: #""$(BAZEL_PACKAGE_BIN_DIR)/$(TARGET_NAME)/bin""#
             ),
             .init(
                 key: "INTERNAL_DIR",
-                value: "$(PROJECT_FILE_PATH)/rules_xcodeproj"
+                value: #""$(PROJECT_FILE_PATH)/rules_xcodeproj""#
             ),
-            .init(key: "LD_DYLIB_INSTALL_NAME", value: "".pbxProjEscaped),
-            .init(key: "LD_OBJC_ABI_VERSION", value: "".pbxProjEscaped),
-            .init(key: "LD_RUNPATH_SEARCH_PATHS", value: "".pbxProjEscaped),
+            .init(key: "LD_DYLIB_INSTALL_NAME", value: #""""#),
+            .init(key: "LD_OBJC_ABI_VERSION", value: #""""#),
+            .init(key: "LD_RUNPATH_SEARCH_PATHS", value: #""""#),
             .init(key: "ONLY_ACTIVE_ARCH", value: "YES"),
             .init(
                 key: "PROJECT_DIR",
-                value: "$(INDEXING_PROJECT_DIR__$(INDEX_ENABLE_BUILD_ARENA))"
-                    .pbxProjEscaped
+                value:
+                    #""$(INDEXING_PROJECT_DIR__$(INDEX_ENABLE_BUILD_ARENA))""#
             ),
             .init(
                 key: "RESOLVED_REPOSITORIES",
@@ -145,30 +146,24 @@ extension Generator {
             .init(key: "RULES_XCODEPROJ_BUILD_MODE", value: buildMode.rawValue),
             .init(
                 key: "SCHEME_TARGET_IDS_FILE",
-                value: "$(OBJROOT)/scheme_target_ids".pbxProjEscaped
+                value: #""$(OBJROOT)/scheme_target_ids""#
             ),
             .init(key: "SRCROOT", value: workspace.pbxProjEscaped),
             .init(key: "SUPPORTS_MACCATALYST", value: "NO"),
-            .init(
-                key: "SWIFT_OBJC_INTERFACE_HEADER_NAME",
-                value: "".pbxProjEscaped
-            ),
-            .init(
-                key: "SWIFT_OPTIMIZATION_LEVEL",
-                value: "-Onone".pbxProjEscaped
-            ),
+            .init(key: "SWIFT_OBJC_INTERFACE_HEADER_NAME", value: #""""#),
+            .init(key: "SWIFT_OPTIMIZATION_LEVEL", value: #""-Onone""#),
             .init(key: "SWIFT_VERSION", value: "5.0"),
             .init(
                 key: "TARGET_TEMP_DIR",
                 value: #"""
-$(PROJECT_TEMP_DIR)/$(BAZEL_PACKAGE_BIN_DIR)/$(COMPILE_TARGET_NAME)
-"""#.pbxProjEscaped
+"$(PROJECT_TEMP_DIR)/$(BAZEL_PACKAGE_BIN_DIR)/$(COMPILE_TARGET_NAME)"
+"""#
             ),
             .init(key: "USE_HEADERMAP", value: "NO"),
             .init(key: "VALIDATE_WORKSPACE", value: "NO"),
             .init(
                 key: "_BAZEL_OUTPUT_BASE",
-                value: "$(PROJECT_DIR)/../..".pbxProjEscaped
+                value: #""$(PROJECT_DIR)/../..""#
             ),
         ]
         
@@ -176,28 +171,28 @@ $(PROJECT_TEMP_DIR)/$(BAZEL_PACKAGE_BIN_DIR)/$(COMPILE_TARGET_NAME)
             buildSettings.append(contentsOf: [
                 .init(
                     key: "CC",
-                    value: "$(BAZEL_INTEGRATION_DIR)/clang.sh".pbxProjEscaped
+                    value: #""$(BAZEL_INTEGRATION_DIR)/clang.sh""#
                 ),
                 .init(
                     key: "CXX",
-                    value: "$(BAZEL_INTEGRATION_DIR)/clang.sh".pbxProjEscaped
+                    value: #""$(BAZEL_INTEGRATION_DIR)/clang.sh""#
                 ),
                 .init(key: "CODE_SIGNING_ALLOWED", value: "NO"),
                 .init(
                     key: "LD",
-                    value: "$(BAZEL_INTEGRATION_DIR)/ld.sh".pbxProjEscaped
+                    value: #""$(BAZEL_INTEGRATION_DIR)/ld.sh""#
                 ),
                 .init(
                     key: "LDPLUSPLUS",
-                    value: "$(BAZEL_INTEGRATION_DIR)/ld.sh".pbxProjEscaped
+                    value: #""$(BAZEL_INTEGRATION_DIR)/ld.sh""#
                 ),
                 .init(
                     key: "LIBTOOL",
-                    value: "$(BAZEL_INTEGRATION_DIR)/libtool.sh".pbxProjEscaped
+                    value: #""$(BAZEL_INTEGRATION_DIR)/libtool.sh""#
                 ),
                 .init(
                     key: "SWIFT_EXEC",
-                    value: "$(BAZEL_INTEGRATION_DIR)/swiftc".pbxProjEscaped
+                    value: #""$(BAZEL_INTEGRATION_DIR)/swiftc""#
                 ),
                 .init(key: "SWIFT_USE_INTEGRATED_DRIVER", value: "NO"),
             ])

--- a/tools/generators/pbxproj_prefix/test/BazelDependenciesBuildSettingsTests.swift
+++ b/tools/generators/pbxproj_prefix/test/BazelDependenciesBuildSettingsTests.swift
@@ -29,10 +29,10 @@ class BazelDependenciesBuildSettingsTests: XCTestCase {
 				INDEX_DISABLE_SCRIPT_EXECUTION = YES;
 				LD = "";
 				LDPLUSPLUS = "";
-				LIBTOOL = "libtool";
+				LIBTOOL = libtool;
 				SUPPORTED_PLATFORMS = "$(INDEXING_SUPPORTED_PLATFORMS__$(INDEX_ENABLE_BUILD_ARENA))";
 				SUPPORTS_MACCATALYST = YES;
-				SWIFT_EXEC = "swiftc";
+				SWIFT_EXEC = swiftc;
 				TARGET_IDS_FILE = "$(BAZEL_OUT)/target_ids_file";
 				TARGET_NAME = BazelDependencies;
 			}

--- a/tools/generators/pbxproj_prefix/test/PBXProjectBuildSettingsTests.swift
+++ b/tools/generators/pbxproj_prefix/test/PBXProjectBuildSettingsTests.swift
@@ -55,7 +55,7 @@ class PBXProjectBuildSettingsTests: XCTestCase {
 				INDEX_FORCE_SCRIPT_EXECUTION = YES;
 				INDEX_IMPORT = "$(BAZEL_EXTERNAL)/index-import";
 				INSTALL_PATH = "$(BAZEL_PACKAGE_BIN_DIR)/$(TARGET_NAME)/bin";
-				INTERNAL_DIR = $(PROJECT_FILE_PATH)/rules_xcodeproj;
+				INTERNAL_DIR = "$(PROJECT_FILE_PATH)/rules_xcodeproj";
 				LD = "$(BAZEL_INTEGRATION_DIR)/ld.sh";
 				LDPLUSPLUS = "$(BAZEL_INTEGRATION_DIR)/ld.sh";
 				LD_DYLIB_INSTALL_NAME = "";
@@ -143,7 +143,7 @@ class PBXProjectBuildSettingsTests: XCTestCase {
 				INDEX_FORCE_SCRIPT_EXECUTION = YES;
 				INDEX_IMPORT = "$(BAZEL_EXTERNAL)/index-import";
 				INSTALL_PATH = "$(BAZEL_PACKAGE_BIN_DIR)/$(TARGET_NAME)/bin";
-				INTERNAL_DIR = $(PROJECT_FILE_PATH)/rules_xcodeproj;
+				INTERNAL_DIR = "$(PROJECT_FILE_PATH)/rules_xcodeproj";
 				LD_DYLIB_INSTALL_NAME = "";
 				LD_OBJC_ABI_VERSION = "";
 				LD_RUNPATH_SEARCH_PATHS = "";


### PR DESCRIPTION
This is more efficient.

Also fixes improperly escaped `INTERNAL_DIR`, `LIBTOOL`, and `SWIFT_EXEC`.