### PR TITLE
Move `TemporaryDirectory` to its own file

### DIFF
--- a/tools/generators/lib/PBXProj/test/ConsolidationMapEntryTests.swift
+++ b/tools/generators/lib/PBXProj/test/ConsolidationMapEntryTests.swift
@@ -46,23 +46,3 @@ final class ConsolidationMapEntryTests: XCTestCase {
         XCTAssertNoDifference(output, input)
     }
 }
-
-class TemporaryDirectory {
-    let url: URL
-
-    /// Creates a new temporary directory.
-    ///
-    /// The directory is recursively deleted when this object deallocates.
-    init() throws {
-        url = try FileManager.default.url(
-            for: .itemReplacementDirectory,
-            in: .userDomainMask,
-            appropriateFor: FileManager.default.temporaryDirectory,
-            create: true
-        )
-    }
-
-    deinit {
-        _ = try? FileManager.default.removeItem(at: url)
-    }
-}

--- a/tools/generators/lib/PBXProj/test/TemporaryDirectory.swift
+++ b/tools/generators/lib/PBXProj/test/TemporaryDirectory.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+class TemporaryDirectory {
+    let url: URL
+
+    /// Creates a new temporary directory.
+    ///
+    /// The directory is recursively deleted when this object deallocates.
+    init() throws {
+        url = try FileManager.default.url(
+            for: .itemReplacementDirectory,
+            in: .userDomainMask,
+            appropriateFor: FileManager.default.temporaryDirectory,
+            create: true
+        )
+    }
+
+    deinit {
+        _ = try? FileManager.default.removeItem(at: url)
+    }
+}


### PR DESCRIPTION
Will be reused in another test.