### PR TITLE
Conform `BazelPath` to `Comparable`

### DIFF
--- a/tools/generators/lib/PBXProj/src/BazelPath.swift
+++ b/tools/generators/lib/PBXProj/src/BazelPath.swift
@@ -11,6 +11,22 @@ public struct BazelPath: Hashable {
     }
 }
 
+// MARK: - Comparable
+
+extension BazelPath: Comparable {
+    public static func < (lhs: BazelPath, rhs: BazelPath) -> Bool {
+        guard lhs.path == rhs.path else {
+            return lhs.path < rhs.path
+        }
+
+        guard lhs.isFolder == rhs.isFolder else {
+            return rhs.isFolder
+        }
+
+        return false
+    }
+}
+
 // MARK: - Decodable
 
 extension BazelPath: Decodable {


### PR DESCRIPTION
Allows it to be used as a key in a dictionary.