### PR TITLE
support generate compile_commands.json bazel6 only

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,3 +4,4 @@
 - [Usage guide](usage.md)
 - [Bazel rules and macros](bazel.md)
 - [High-level design goals](design-goals.md)
+- [Compile Commands design goals](compile-commands-design-goals.md)

--- a/docs/compile-commands-design-goals.md
+++ b/docs/compile-commands-design-goals.md
@@ -1,0 +1,31 @@
+# Why generate Compile Commands
+1. I hope to use Bazel to develop C/C++/ObjC/ObjC++/Swift under VSCode. So I need to get SourceKit-LSP working on VSCode. Therefore, it is necessary to generate compilation commands to cooperate with SourceKit-LSP to be able to use code completion normally.
+2. Although Xcode's indexing mechanism may be the best among mainstream IDEs, it is often left to wait for Index Building because it is not open enough. So another goal is to quickly generate a global index through Compile Commands after having the ability to take over the Xcode global index, and to continue working in the background.
+# What are Index Compile Commands
+Index Compile Commands refers to the processing of complete compilation instructions to obtain compilation instructions that are only used for code indexing.
+1. After running through Index Compile Commands, there is no need to produce target files and IndexStoreDB can be generated at the same time. Such as -index-store-path.
+2. The IDE that supports the libClang type can execute a compilation instruction without outputting the target file and at the same time obtain the AST corresponding to the source code. For example -fsyntax-only.
+
+# Purpose of Compile Commands in rules_xcodeproj Build with Proxy (BwP)
+Although currently rules_xcodeproj does not support BwP yet. This design may not work. If BwP is supported. We can use XCBBuildService to modify IndexRequest. According to Index Compile Commands, modify IndexRequest compilation parameters to more accurate parameters for indexing. This enables the libClang module in Xcode to get a more accurate AST.
+
+# Post process rules
+Here are some post process rules.
+
+## For C/C++/ObjC/ObjC++
+|   Add   |  Delete  | Replace  |
+|  ----   |   ----   |   ----   |
+| -index-store-path  | DEBUG_PREFIX_MAP_PWD=. |   \_\_BAZEL_XCODE_SDKROOT\_\_ |
+| -index-unit-output-path  | -o <path/to/obj> |   \_\_BAZEL_XCODE_DEVELOPER_DIR\_\_ |
+| -index-ignore-macros  | --serialize-diagnostics | - |
+| -index-ignore-system-symbols  | -MMD | - |
+| -index-ignore-pcms  | -MF | - |
+| -fsyntax-only  | - | - |
+
+## For Swift
+|   Add   |  Delete  | Replace  |
+|  ----   |   ----   |   ----   |
+| -index-store-path  | DEBUG_PREFIX_MAP_PWD=. |   \_\_BAZEL_XCODE_SDKROOT\_\_ |
+| -index-unit-output-path  |  -enable-batch-mode |   \_\_BAZEL_XCODE_DEVELOPER_DIR\_\_ |
+| - |  -emit-object | - |
+| - |  -serialize-diagnostics | - |

--- a/xcodeproj/internal/library_targets.bzl
+++ b/xcodeproj/internal/library_targets.bzl
@@ -162,6 +162,8 @@ def process_library_target(
         swift_sub_params,
         c_has_fortify_source,
         cxx_has_fortify_source,
+        cargvs,
+        swiftargvs,
     ) = process_opts(
         ctx = ctx,
         build_mode = build_mode,
@@ -223,4 +225,6 @@ def process_library_target(
         outputs = provider_outputs,
         transitive_dependencies = transitive_dependencies,
         xcode_target = xcode_target,
+        cargvs = cargvs,
+        swiftargvs = swiftargvs,
     )

--- a/xcodeproj/internal/non_xcode_targets.bzl
+++ b/xcodeproj/internal/non_xcode_targets.bzl
@@ -143,4 +143,7 @@ rules_xcodeproj requires {} to have `{}` set.
         resource_bundle_informations = resource_bundle_informations,
         transitive_dependencies = transitive_dependencies,
         xcode_target = None,
+        # FIXME: Does there need pass cargvs and swiftargvs
+        cargvs = None,
+        swiftargvs = None,
     )

--- a/xcodeproj/internal/processed_target.bzl
+++ b/xcodeproj/internal/processed_target.bzl
@@ -18,7 +18,10 @@ def processed_target(
         potential_target_merges = None,
         resource_bundle_informations = None,
         transitive_dependencies,
-        xcode_target):
+        xcode_target,
+        cargvs,
+        swiftargvs,
+        ):
     """Generates the return value for target processing functions.
 
     Args:
@@ -50,6 +53,8 @@ def processed_target(
             dependencies of this target.
         xcode_target: An optional value returned from `xcode_targets.make` that
             will be in the `XcodeProjInfo.xcode_targets` `depset`.
+        cargvs: A `lits` of C/C++ argv.
+        swiftargvs: A `lits` of Swift argv.
 
     Returns:
         A `struct` containing fields for each argument.
@@ -72,4 +77,6 @@ def processed_target(
         transitive_dependencies = transitive_dependencies,
         xcode_target = xcode_target,
         xcode_targets = [xcode_target] if xcode_target else None,
+        cargvs = cargvs,
+        swiftargvs = swiftargvs,
     )

--- a/xcodeproj/internal/providers.bzl
+++ b/xcodeproj/internal/providers.bzl
@@ -206,6 +206,12 @@ target.
 A `depset` of values returned from `xcode_targets.make`, which potentially will
 become targets in the Xcode project.
 """,
+        "cargvs": """\
+A `list` of C/C++ argv.
+""",
+        "swiftargvs": """\
+A `list` of Swift argv.
+""",
     },
 )
 

--- a/xcodeproj/internal/top_level_targets.bzl
+++ b/xcodeproj/internal/top_level_targets.bzl
@@ -426,6 +426,7 @@ def process_top_level_target(
         label.workspace_root,
         label.package,
     )
+    # FIXME: Does it need process cargvs and swiftargvs?
     (
         c_params,
         cxx_params,
@@ -433,6 +434,8 @@ def process_top_level_target(
         swift_sub_params,
         c_has_fortify_source,
         cxx_has_fortify_source,
+        _,
+        _,
     ) = process_opts(
         ctx = ctx,
         build_mode = build_mode,
@@ -562,4 +565,7 @@ def process_top_level_target(
                 ],
             ),
         ),
+        # FIXME: Does there need pass cargvs and swiftargvs
+        cargvs = None,
+        swiftargvs = None,
     )

--- a/xcodeproj/internal/xcodeproj_aspect.bzl
+++ b/xcodeproj/internal/xcodeproj_aspect.bzl
@@ -24,7 +24,7 @@ def _should_ignore_attr(attr):
         attr in _IGNORE_ATTR
     )
 
-def _transitive_infos(*, ctx, attrs):
+def transitive_infos(*, ctx, attrs):
     transitive_infos = []
 
     # TODO: Have `XcodeProjAutomaticTargetProcessingInfo` tell us which
@@ -63,7 +63,7 @@ def _xcodeproj_aspect_impl(target, ctx):
             build_mode = ctx.attr._build_mode,
             target = target,
             attrs = attrs,
-            transitive_infos = _transitive_infos(
+            transitive_infos = transitive_infos(
                 ctx = ctx,
                 attrs = attrs,
             ),

--- a/xcodeproj/internal/xcodeproj_ccdb_aspect.bzl
+++ b/xcodeproj/internal/xcodeproj_ccdb_aspect.bzl
@@ -1,0 +1,313 @@
+"""Module containing functions process compile commands."""
+
+load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "use_cpp_toolchain")
+load(
+    ":providers.bzl",
+    "XcodeProjInfo",
+)
+load(":xcodeprojinfo.bzl", "create_xcodeprojinfo")
+load(":xcodeproj_aspect.bzl", "transitive_infos")
+
+_CC_COMPILE_COMMANDS_SKIP_OPTS = [
+    "DEBUG_PREFIX_MAP_PWD=.",
+    "--serialize-diagnostics",
+    "-MMD",
+    "-MF",
+    "-o",
+]
+
+_SWIFT_COMPILE_COMMANDS_SKIP_OPTS = [
+    "-enable-batch-mode",
+    "-emit-object",
+    "-serialize-diagnostics",
+]
+
+def transitive_cargvs(
+        *,
+        base = [],
+        infos):
+    transitive_argvs = depset(
+        base,
+        transitive = [
+            info.cargvs
+            for info in infos
+        ],
+    )
+    return transitive_argvs
+
+def transitive_swiftargvs(
+        *,
+        base = [],
+        infos):
+    transitive_argvs = depset(
+        base,
+        transitive = [
+            info.swiftargvs
+            for info in infos
+        ],
+    )
+    return transitive_argvs
+
+def _process_c_argv_for_compile(
+        *,
+        argv):
+    previous_arg = None
+    process_argv = []
+    src = None
+    for i in range(len(argv)):
+        arg = argv[i]
+        if previous_arg == "-c":
+            src = arg
+        previous_arg = arg
+        if " " in arg:
+            process_argv.append('"' + arg + '"')
+        else:
+            process_argv.append(arg)
+
+    return " ".join(process_argv), src
+
+def _process_swift_argv_for_compile(
+        *,
+        argv):
+    process_argv = []
+    srcs = []
+    for i in range(len(argv)):
+        arg = argv[i]
+        if arg.endswith(".swift"):
+            srcs.append(arg)
+        if " " in arg:
+            process_argv.append('"' + arg + '"')
+        else:
+            process_argv.append(arg)
+    swift_commands = []
+    for src in srcs:
+        swift_commands.append((" ".join(process_argv), src))
+    return swift_commands
+
+def _process_c_argv_for_index(
+        *,
+        argv):
+    previous_arg = None
+    process_argv = []
+    src = None
+    for i in range(len(argv)):
+        arg = argv[i]
+        if previous_arg == "-c":
+            src = arg
+        elif previous_arg == "-o":
+            previous_arg = arg
+            continue
+        previous_arg = arg
+        if arg in _CC_COMPILE_COMMANDS_SKIP_OPTS:
+            continue
+        if " " in arg:
+            process_argv.append('"' + arg + '"')
+        else:
+            process_argv.append(arg)
+
+    return " ".join(process_argv), src
+
+def _process_swift_argv_for_index(
+        *,
+        argv):
+    process_argv = []
+    srcs = []
+    for i in range(len(argv)):
+        arg = argv[i]
+        if arg.endswith(".swift"):
+            srcs.append(arg)
+        elif arg in _SWIFT_COMPILE_COMMANDS_SKIP_OPTS:
+            continue
+        if " " in arg:
+            process_argv.append('"' + arg + '"')
+        else:
+            process_argv.append(arg)
+    swift_commands = []
+    for src in srcs:
+        swift_commands.append((" ".join(process_argv), src))
+    return swift_commands
+
+def post_process_compile_commands(
+        *,
+        cargvs,
+        swiftargvs,
+        workspace_directory):
+    process_compile_commands = []
+    for item in cargvs:
+        args, file = _process_c_argv_for_compile(argv = item.argv)
+        process_compile_commands.append(struct(
+            command = args,
+            file = file,
+            dirctory = workspace_directory,
+        ))
+    for item in swiftargvs:
+        swift_commands = _process_swift_argv_for_compile(argv = item.argv)
+        for args, file in swift_commands:
+            process_compile_commands.append(struct(
+                command = args,
+                file = file,
+                dirctory = workspace_directory,
+            ))
+    return process_compile_commands
+
+def post_process_index_compile_commands(
+        *,
+        cargvs,
+        swiftargvs,
+        workspace_directory):
+    process_compile_commands = []
+    for item in cargvs:
+        args, file = _process_c_argv_for_index(argv = item.argv)
+        process_compile_commands.append(struct(
+            command = args,
+            file = file,
+            dirctory = workspace_directory,
+        ))
+    for item in swiftargvs:
+        swift_commands = _process_swift_argv_for_index(argv = item.argv)
+        for args, file in swift_commands:
+            process_compile_commands.append(struct(
+                command = args,
+                file = file,
+                dirctory = workspace_directory,
+            ))
+    return process_compile_commands
+
+def write_compile_commands_json(
+        *,
+        ctx,
+        compile_commands,
+        file_name = "compile_commands.json"):
+    actions = ctx.actions
+    compile_commands_json = actions.declare_file(file_name)
+    actions.write(
+        content = json.encode(compile_commands),
+        output = compile_commands_json,
+    )
+
+    return compile_commands_json
+
+def create_compile_commands_json_symlink(
+        *,
+        ctx,
+        compile_commands_json):
+    actions = ctx.actions
+
+    compile_commands_json_symlink = actions.declare_file("compile_commands.json")
+    actions.symlink(output = compile_commands_json_symlink, target_file = compile_commands_json)
+
+    return compile_commands_json_symlink
+
+def _xcodeproj_ccdb_aspect_impl(target, ctx):
+    providers = []
+
+    if XcodeProjInfo not in target:
+        # Only create an `XcodeProjInfo` if the target hasn't already created
+        # one
+        attrs = dir(ctx.rule.attr)
+        info = create_xcodeprojinfo(
+            ctx = ctx,
+            build_mode = "bazel",
+            target = target,
+            attrs = attrs,
+            transitive_infos = transitive_infos(
+                ctx = ctx,
+                attrs = attrs,
+            ),
+        )
+        if info:
+            providers.append(info)
+    
+    if "COMPILE_COMMANDS_HOST_TAEGET" in ctx.var:
+        host_target_label = Label(ctx.var["COMPILE_COMMANDS_HOST_TAEGET"])
+        if host_target_label.package == target.label.package and host_target_label.name == target.label.name:
+            cargvs = transitive_cargvs(infos = providers).to_list()
+            swiftargvs = transitive_swiftargvs(infos = providers).to_list()
+            workspace_directory = "__EXEC_ROOT__"
+            if "COMPILE_COMMANDS_CWD" in ctx.var:
+                workspace_directory = ctx.var["COMPILE_COMMANDS_CWD"]
+            if ctx.attr._build_mode == "alldb":
+                process_compile_commands = post_process_compile_commands(
+                    cargvs = cargvs,
+                    swiftargvs = swiftargvs,
+                    workspace_directory = workspace_directory,
+                )
+                process_index_compile_commands = post_process_index_compile_commands(
+                    cargvs = cargvs,
+                    swiftargvs = swiftargvs,
+                    workspace_directory = workspace_directory,
+                )
+                compile_commands_json = write_compile_commands_json(
+                    ctx = ctx,
+                    compile_commands = process_compile_commands,
+                )
+                index_compile_commands_json = write_compile_commands_json(
+                    ctx = ctx,
+                    compile_commands = process_index_compile_commands,
+                    file_name = "index_compile_commands.json",
+                )
+                providers.append(OutputGroupInfo(compile_commands = [compile_commands_json, index_compile_commands_json]))
+            elif ctx.attr._build_mode == "indexdb":
+                process_compile_commands = post_process_index_compile_commands(
+                    cargvs = cargvs,
+                    swiftargvs = swiftargvs,
+                    workspace_directory = workspace_directory,
+                )
+                compile_commands_json = write_compile_commands_json(
+                    ctx = ctx,
+                    compile_commands = process_compile_commands,
+                )
+                providers.append(OutputGroupInfo(compile_commands = [compile_commands_json]))
+            else:
+                process_compile_commands = post_process_compile_commands(
+                    cargvs = cargvs,
+                    swiftargvs = swiftargvs,
+                    workspace_directory = workspace_directory,
+                )
+                compile_commands_json = write_compile_commands_json(
+                    ctx = ctx,
+                    compile_commands = process_compile_commands,
+                )
+                providers.append(OutputGroupInfo(compile_commands = [compile_commands_json]))
+
+    return providers
+
+def _make_xcodeproj_ccdb_aspect(*, build_mode, generator_name):
+    return aspect(
+        implementation = _xcodeproj_ccdb_aspect_impl,
+        attr_aspects = ["*"],
+        attrs = {
+            "_build_mode": attr.string(default = build_mode),
+            "_cc_compiler_params_processor": attr.label(
+                cfg = "exec",
+                default = Label(
+                    "//tools/params_processors:cc_compiler_params_processor",
+                ),
+                executable = True,
+            ),
+            "_cc_toolchain": attr.label(default = Label(
+                "@bazel_tools//tools/cpp:current_cc_toolchain",
+            )),
+            "_generator_name": attr.string(default = generator_name),
+            "_swift_compiler_params_processor": attr.label(
+                cfg = "exec",
+                default = Label(
+                    "//tools/params_processors:swift_compiler_params_processor",
+                ),
+                executable = True,
+            ),
+            "_xcode_config": attr.label(
+                default = configuration_field(
+                    name = "xcode_config_label",
+                    fragment = "apple",
+                ),
+            ),
+        },
+        fragments = ["apple", "cpp", "objc"],
+        toolchains = use_cpp_toolchain(),
+    )
+
+# FIXME: setup a valid generator_name
+compile_commands_aspect = _make_xcodeproj_ccdb_aspect(build_mode = "compiledb", generator_name="generator_name")
+index_commands_aspect = _make_xcodeproj_ccdb_aspect(build_mode = "indexdb", generator_name="generator_name")
+all_commands_aspect = _make_xcodeproj_ccdb_aspect(build_mode = "alldb", generator_name="generator_name")

--- a/xcodeproj/internal/xcodeprojinfo.bzl
+++ b/xcodeproj/internal/xcodeprojinfo.bzl
@@ -134,7 +134,9 @@ def _target_info_fields(
         transitive_dependencies,
         xcode_target,
         xcode_targets,
-        xcode_required_targets):
+        xcode_required_targets,
+        cargvs,
+        swiftargvs):
     """Generates target specific fields for the `XcodeProjInfo`.
 
     This should be merged with other fields to fully create an `XcodeProjInfo`.
@@ -168,6 +170,8 @@ def _target_info_fields(
         xcode_targets: Maps to the `XcodeProjInfo.xcode_targets` field.
         xcode_required_targets: Maps to the
             `XcodeProjInfo.xcode_required_targets` field.
+        cargvs: Maps to the `XcodeProjInfo.cargvs` field.
+        swiftargvs: Maps to the `XcodeProjInfo.swiftargvs` field.
 
     Returns:
         A `dict` containing the following fields:
@@ -191,6 +195,8 @@ def _target_info_fields(
         *   `xcode_target`
         *   `xcode_targets`
         *   `xcode_required_targets`
+        *   `cargvs`
+        *   `swiftargvs`
     """
     return {
         "args": args,
@@ -212,6 +218,8 @@ def _target_info_fields(
         "xcode_target": xcode_target,
         "xcode_targets": xcode_targets,
         "xcode_required_targets": xcode_required_targets,
+        "cargvs": cargvs,
+        "swiftargvs": swiftargvs,
     }
 
 def _skip_target(
@@ -424,6 +432,9 @@ def _skip_target(
                 for info in valid_transitive_infos
             ],
         ),
+        # FIXME: Does it need process cargvs and swift argvs
+        cargvs = depset(),
+        swiftargvs = depset(),
     )
 
 def _create_args_depset(*, ctx, id, automatic_target_info):
@@ -466,6 +477,7 @@ def _create_xcodeprojinfo(
         A `dict` of fields to be merged into the `XcodeProjInfo`. See
         `_target_info_fields`.
     """
+    
     if not _should_create_provider(ctx = ctx, target = target):
         return None
 
@@ -515,7 +527,6 @@ def _create_xcodeprojinfo(
             automatic_target_info = automatic_target_info,
             transitive_infos = valid_transitive_infos,
         )
-
     return _target_info_fields(
         args = memory_efficient_depset(
             transitive = [
@@ -589,6 +600,20 @@ def _create_xcodeprojinfo(
             transitive = [
                 info.xcode_required_targets
                 for info in valid_transitive_infos
+            ],
+        ),
+        cargvs = depset(
+            processed_target.cargvs,
+            transitive = [
+                info.cargvs
+                for _, info in transitive_infos
+            ],
+        ),
+        swiftargvs = depset(
+            processed_target.swiftargvs,
+            transitive = [
+                info.swiftargvs
+                for _, info in transitive_infos
             ],
         ),
     )


### PR DESCRIPTION
support generate compile_commands.json with different style.
for index
```
bazel build //macOSApp/Source:macOSApp --aspects @rules_xcodeproj//xcodeproj/internal:xcodeproj_ccdb_aspect.bzl%index_commands_aspect --output_groups=compile_commands --define=COMPILE_COMMANDS_HOST_TAEGET=//macOSApp/Source:macOSApp
```
for compile
```
bazel build //macOSApp/Source:macOSApp --aspects @rules_xcodeproj//xcodeproj/internal:xcodeproj_ccdb_aspect.bzl%compile_commands_aspect --output_groups=compile_commands --define=COMPILE_COMMANDS_HOST_TAEGET=//macOSApp/Source:macOSApp
```
both index and compile
```
bazel build //macOSApp/Source:macOSApp --aspects @rules_xcodeproj//xcodeproj/internal:xcodeproj_ccdb_aspect.bzl%all_commands_aspect --output_groups=compile_commands --define=COMPILE_COMMANDS_HOST_TAEGET=//macOSApp/Source:macOSApp
```
generate project with index compile_commands.json
```
bazel run  //.bitsky/xcodeproj:xcodeproj  --@rules_xcodeproj//xcodeproj:extra_generator_flags='--output_groups=+compile_commands'
```
generate index compile_commands.json only
```
bazel build  //.bitsky/xcodeproj:xcodeproj  --output_groups=compile_commands
```