### PR TITLE
Use `Data.init` instead of `.data(using:)`

### DIFF
--- a/tools/generators/lib/PBXProj/src/ConsolidationMapEntry.swift
+++ b/tools/generators/lib/PBXProj/src/ConsolidationMapEntry.swift
@@ -48,7 +48,7 @@ extension ConsolidationMapEntry {
     }
 
     func encode(into data: inout Data) {
-        data.append(name.data(using: .utf8)!)
+        data.append(Data(name.utf8))
         data.append(Self.subSeparator)
 
         key.encode(into: &data)
@@ -65,7 +65,7 @@ extension ConsolidationMapEntry {
 extension ConsolidationMapEntry.Key {
     func encode(into data: inout Data) {
         for id in self.sortedIds {
-            data.append(id.rawValue.data(using: .utf8)!)
+            data.append(Data(id.rawValue.utf8))
             data.append(ConsolidationMapEntry.subSeparator)
         }
     }
@@ -73,8 +73,8 @@ extension ConsolidationMapEntry.Key {
 
 extension Identifiers.Targets.SubIdentifier {
     func encode(into data: inout Data) {
-        data.append(shard.data(using: .utf8)!)
-        data.append(hash.data(using: .utf8)!)
+        data.append(Data(shard.utf8))
+        data.append(Data(hash.utf8))
     }
 }
 

--- a/tools/generators/lib/PBXProj/src/Identifiers.swift
+++ b/tools/generators/lib/PBXProj/src/Identifiers.swift
@@ -166,7 +166,7 @@ FF0000000000000000000004 /* Products */
                 content = "\(hashable)\0\(retryCount)"
             }
 
-            let digest = Insecure.MD5.hash(data: content.data(using: .utf8)!)
+            let digest = Insecure.MD5.hash(data: Data(content.utf8))
             return digest
                 // Xcode identifiers are 24 characters. We are using 2
                 // characters at the front for "FE". That leaves 22 characters
@@ -342,7 +342,7 @@ FF00000000000000000001\#(String(format: "%02X", index)) \#
                 content = "\(hashable)\0\(retryCount)"
             }
 
-            let digest = Insecure.MD5.hash(data: content.data(using: .utf8)!)
+            let digest = Insecure.MD5.hash(data: Data(content.utf8))
             return digest
                 // We want an 8 character string. MD5 digests are 16 bytes (32
                 // characters) long. So we need to truncate it (by dropping 12

--- a/tools/generators/lib/PBXProj/src/Identifiers.swift
+++ b/tools/generators/lib/PBXProj/src/Identifiers.swift
@@ -1,4 +1,5 @@
 import CryptoKit
+import Foundation
 
 /// Helps set identifiers for `PBXProj` elements.
 ///

--- a/tools/generators/pbxproject_targets/src/Generator/DisambiguateTargets.swift
+++ b/tools/generators/pbxproject_targets/src/Generator/DisambiguateTargets.swift
@@ -698,7 +698,7 @@ private extension Sequence where Element == String {
         var hasher = Insecure.SHA1()
 
         for string in sorted() {
-            hasher.update(data: string.data(using: .utf8)!)
+            hasher.update(data: Data(string.utf8))
         }
 
         return hasher.finalize()

--- a/tools/generators/pbxproject_targets/src/Generator/DisambiguateTargets.swift
+++ b/tools/generators/pbxproject_targets/src/Generator/DisambiguateTargets.swift
@@ -1,4 +1,5 @@
 import CryptoKit
+import Foundation
 import GeneratorCommon
 import OrderedCollections
 import PBXProj


### PR DESCRIPTION
Prevents force unwraps.