### PR TITLE
Allow same-name, different-productType disambiguated targets

### DIFF
--- a/tools/generators/legacy/src/Generator/DisambiguateTargets.swift
+++ b/tools/generators/legacy/src/Generator/DisambiguateTargets.swift
@@ -28,13 +28,15 @@ extension Generator {
         let targets = consolidatedTargets.targets
 
         // Gather all information needed to distinguish the targets
-        var labelsByName: [String: Set<String>] = [:]
+        var labelsByNameAndProductType:
+            [NameAndProductType: Set<String>] = [:]
         var names: [String: TargetComponents] = [:]
         var labels: [String: TargetComponents] = [:]
         for (key, target) in targets {
             let normalizedName = target.normalizedName
             let normalizedLabel = target.normalizedLabel
-            labelsByName[normalizedName, default: []].insert(normalizedLabel)
+            labelsByNameAndProductType[.init(target: target), default: []]
+                .insert(normalizedLabel)
             names[normalizedName, default: .init()]
                 .add(target: target, key: key)
             labels[normalizedLabel, default: .init()]
@@ -49,10 +51,10 @@ extension Generator {
             let name: String
             let componentKey: String
             let components: [String: TargetComponents]
-            let normalizedName = target.normalizedName
-            if labelsByName[normalizedName]!.count == 1 {
+            let nameAndProductType = NameAndProductType(target: target)
+            if labelsByNameAndProductType[nameAndProductType]!.count == 1 {
                 name = target.name
-                componentKey = normalizedName
+                componentKey = nameAndProductType.normalizedName
                 components = names
             } else {
                 name = "\(target.label)"
@@ -71,6 +73,16 @@ extension Generator {
             keys: consolidatedTargets.keys,
             targets: uniqueValues
         )
+    }
+}
+
+private struct NameAndProductType: Equatable, Hashable {
+    let normalizedName: String
+    let productType: PBXProductType
+
+    init(target: ConsolidatedTarget) {
+        self.normalizedName = target.normalizedName
+        self.productType = target.product.type
     }
 }
 

--- a/tools/generators/legacy/test/DisambiguateTargetsTests.swift
+++ b/tools/generators/legacy/test/DisambiguateTargetsTests.swift
@@ -119,7 +119,7 @@ final class DisambiguateTargetsTests: XCTestCase {
         )
     }
 
-    func test_productType_sameName() throws {
+    func test_productType_sameLabel() throws {
         // Arrange
 
         let targets: [TargetID: Target] = [
@@ -128,6 +128,51 @@ final class DisambiguateTargetsTests: XCTestCase {
                 product: .init(type: .application, name: "A", path: "")
             ),
             "A 2": Target.mock(
+                platform: .simulator(os: .watchOS),
+                product: .init(type: .watch2App, name: "A", path: "")
+            ),
+            "B": Target.mock(
+                product: .init(type: .staticLibrary, name: "B", path: "")
+            ),
+        ]
+        let consolidatedTargets = ConsolidatedTargets(targets: targets)
+        let expectedTargetNames: [ConsolidatedTarget.Key: String] = [
+            "A 1": "A (iOS)",
+            "A 2": "A (watchOS)",
+            "B": "B",
+        ]
+
+        // Act
+
+        let disambiguatedTargets = Generator.disambiguateTargets(
+            consolidatedTargets
+        )
+
+        // Assert
+
+        XCTAssertNoDifference(
+            disambiguatedTargets.targets.mapValues(\.name)
+                .map(KeyAndValue.init).sorted(),
+            expectedTargetNames.map(KeyAndValue.init).sorted()
+        )
+        XCTAssertNoDifference(
+            disambiguatedTargets.targets.mapValues(\.target)
+                .map(KeyAndValue.init).sorted(),
+            consolidatedTargets.targets.map(KeyAndValue.init).sorted()
+        )
+    }
+
+    func test_productType_differentLabel_sameName() throws {
+        // Arrange
+
+        let targets: [TargetID: Target] = [
+            "A 1": Target.mock(
+                label: "@//a/package:A",
+                platform: .device(os: .iOS),
+                product: .init(type: .application, name: "A", path: "")
+            ),
+            "A 2": Target.mock(
+                label: "@//another/package:A",
                 platform: .simulator(os: .watchOS),
                 product: .init(type: .watch2App, name: "A", path: "")
             ),

--- a/tools/generators/pbxproject_targets/src/Generator/DisambiguateTargets.swift
+++ b/tools/generators/pbxproject_targets/src/Generator/DisambiguateTargets.swift
@@ -47,13 +47,17 @@ extension Generator.DisambiguateTargets {
         _ consolidatedTargets: [ConsolidatedTarget]
     ) -> [DisambiguatedTarget] {
         // Gather all information needed to distinguish the targets
-        var labelsByName: [String: Set<String>] = [:]
+        var labelsByNameAndProductType:
+            [NameAndProductType: Set<String>] = [:]
         var names: [String: TargetComponents] = [:]
         var labels: [String: TargetComponents] = [:]
         for consolidatedTarget in consolidatedTargets {
             let normalizedName = consolidatedTarget.normalizedName
             let normalizedLabel = consolidatedTarget.normalizedLabel
-            labelsByName[normalizedName, default: []].insert(normalizedLabel)
+            labelsByNameAndProductType[
+                .init(target: consolidatedTarget),
+                default: []
+            ].insert(normalizedLabel)
             names[normalizedName, default: .init()]
                 .add(target: consolidatedTarget)
             labels[normalizedLabel, default: .init()]
@@ -66,10 +70,10 @@ extension Generator.DisambiguateTargets {
             let name: String
             let componentKey: String
             let components: [String: TargetComponents]
-            let normalizedName = consolidatedTarget.normalizedName
-            if labelsByName[normalizedName]!.count == 1 {
+            let nameAndProductType = NameAndProductType(target: consolidatedTarget)
+            if labelsByNameAndProductType[nameAndProductType]!.count == 1 {
                 name = consolidatedTarget.name
-                componentKey = normalizedName
+                componentKey = nameAndProductType.normalizedName
                 components = names
             } else {
                 name = "\(consolidatedTarget.label)"
@@ -91,6 +95,16 @@ extension Generator.DisambiguateTargets {
         return disambiguatedTargets.sorted { lhs, rhs in
             lhs.name.localizedStandardCompare(rhs.name) == .orderedAscending
         }
+    }
+}
+
+private struct NameAndProductType: Equatable, Hashable {
+    let normalizedName: String
+    let productType: PBXProductType
+
+    init(target: ConsolidatedTarget) {
+        self.normalizedName = target.normalizedName
+        self.productType = target.productType
     }
 }
 

--- a/tools/generators/pbxproject_targets/test/Generator/DisambiguateTargetsTests.swift
+++ b/tools/generators/pbxproject_targets/test/Generator/DisambiguateTargetsTests.swift
@@ -187,7 +187,7 @@ final class DisambiguateTargetsTests: XCTestCase {
         )
     }
 
-    func test_productType_sameName() throws {
+    func test_productType_sameLabel() throws {
         // Arrange
 
         let targets: [Target] = [
@@ -200,6 +200,51 @@ final class DisambiguateTargetsTests: XCTestCase {
             .mock(
                 id: "A 2",
                 label: "//:A",
+                productType: .watch2App,
+                platform: .watchOSSimulator
+            ),
+            .mock(
+                id: "B",
+                label: "//:B",
+                productType: .staticLibrary,
+                platform: .macOS
+            ),
+        ]
+        let consolidatedTargets = Array<ConsolidatedTarget>(targets: targets)
+
+        let expectedTargetNames: [ConsolidatedTarget.Key: String] = [
+            ["A 1"]: "A (iOS)",
+            ["A 2"]: "A (watchOS)",
+            ["B"]: "B",
+        ]
+
+        // Act
+
+        let disambiguatedTargets =
+            Generator.DisambiguateTargets.defaultCallable(consolidatedTargets)
+
+        // Assert
+
+        XCTAssertNoDifference(
+            disambiguatedTargets,
+            names: expectedTargetNames,
+            targets: consolidatedTargets
+        )
+    }
+
+    func test_productType_differentLabel_sameName() throws {
+        // Arrange
+
+        let targets: [Target] = [
+            .mock(
+                id: "A 1",
+                label: "//some:A",
+                productType: .application,
+                platform: .iOSDevice
+            ),
+            .mock(
+                id: "A 2",
+                label: "//another:A",
                 productType: .watch2App,
                 platform: .watchOSSimulator
             ),


### PR DESCRIPTION
This used to be the case, but we regressed along the way.