### PR TITLE
Fix a bug with disambiguating targets with multiple Xcode configurations

### DIFF
--- a/tools/generators/legacy/src/DTO/Target.swift
+++ b/tools/generators/legacy/src/DTO/Target.swift
@@ -1,10 +1,11 @@
+import OrderedCollections
 import PathKit
 
 struct Target: Equatable {
     var name: String
     var label: BazelLabel
     let configuration: String
-    let xcodeConfigurations: Set<String>
+    let xcodeConfigurations: OrderedSet<String>
     var compileTargets: [CompileTarget]
     let packageBinDir: Path
     var platform: Platform
@@ -80,9 +81,10 @@ extension Target: Decodable {
         name = try container.decode(String.self, forKey: .name)
         label = try container.decode(BazelLabel.self, forKey: .label)
         configuration = try container.decode(String.self, forKey: .configuration)
-        xcodeConfigurations = try container
-            .decodeIfPresent(Set<String>.self, forKey: .xcodeConfigurations) ??
-            ["Debug"]
+        xcodeConfigurations = try container.decodeIfPresent(
+            OrderedSet<String>.self,
+            forKey: .xcodeConfigurations
+        ) ?? ["Debug"]
         compileTargets = try container
             .decodeIfPresent([CompileTarget].self, forKey: .compileTargets) ?? []
         packageBinDir = try container.decode(Path.self, forKey: .packageBinDir)

--- a/tools/generators/legacy/src/Generator/DisambiguateTargets.swift
+++ b/tools/generators/legacy/src/Generator/DisambiguateTargets.swift
@@ -265,7 +265,7 @@ struct ProductTypeComponents {
 struct OperatingSystemComponents {
     struct Distinguisher {
         let components: [String]
-        let xcodeConfigurations: Set<String>
+        let xcodeConfigurations: OrderedSet<String>
     }
 
     /// Collects which minimum versions each `ConsolidatedTarget` contains.
@@ -364,7 +364,7 @@ struct VersionedOperatingSystemComponents {
     struct Distinguisher {
         let prefix: String?
         let suffix: [String]
-        let xcodeConfigurations: Set<String>
+        let xcodeConfigurations: OrderedSet<String>
     }
 
     /// The set of `ConsolidatedTarget.Key`s among the targets passed to
@@ -453,7 +453,7 @@ struct EnvironmentSystemComponents {
     struct Distinguisher {
         let prefix: String?
         let suffix: String?
-        let xcodeConfigurations: Set<String>
+        let xcodeConfigurations: OrderedSet<String>
     }
 
     /// The set of `ConsolidatedTarget.Key`s among the targets passed to
@@ -521,7 +521,7 @@ struct EnvironmentSystemComponents {
 struct ArchitectureComponents {
     struct Distinguisher {
         let arch: String?
-        let xcodeConfigurations: Set<String>
+        let xcodeConfigurations: OrderedSet<String>
     }
 
     /// The set of `ConsolidatedTarget.Key`s among the targets passed to

--- a/tools/generators/legacy/test/CreateCustomXCSchemesTests.swift
+++ b/tools/generators/legacy/test/CreateCustomXCSchemesTests.swift
@@ -23,8 +23,9 @@ extension CreateCustomXCSchemesTests {
         let actual = try Generator.createCustomXCSchemes(
             schemes: [schemeA, schemeB],
             buildMode: .bazel,
-            xcodeConfigurations: targetResolver.targets["B 2"]!
-                .xcodeConfigurations,
+            xcodeConfigurations: Set(
+                targetResolver.targets["B 2"]!.xcodeConfigurations
+            ),
             defaultBuildConfigurationName: targetResolver
                 .targets["B 2"]!.xcodeConfigurations.first!,
             targetResolver: targetResolver,
@@ -41,8 +42,9 @@ extension CreateCustomXCSchemesTests {
             Generator.createCustomXCSchemes(
                 schemes: [schemeC],
                 buildMode: .bazel,
-                xcodeConfigurations: targetResolver.targets["B 2"]!
-                    .xcodeConfigurations,
+                xcodeConfigurations: Set(
+                    targetResolver.targets["B 2"]!.xcodeConfigurations
+                ),
                 defaultBuildConfigurationName: targetResolver
                     .targets["B 2"]!.xcodeConfigurations.first!,
                 targetResolver: targetResolver,

--- a/tools/generators/legacy/test/Target+Testing.swift
+++ b/tools/generators/legacy/test/Target+Testing.swift
@@ -10,7 +10,7 @@ extension Target {
     static func mock(
         label: BazelLabel? = nil,
         configuration: String = "a1b2c",
-        xcodeConfigurations: Set<String> = ["Profile"],
+        xcodeConfigurations: OrderedSet<String> = ["Profile"],
         compileTargets: [CompileTarget] = [],
         packageBinDir: Path = "bazel-out/a1b2c/some/package",
         platform: Platform? = nil,

--- a/tools/generators/legacy/test/XCSchemeInfo+BuildActionInfoTests.swift
+++ b/tools/generators/legacy/test/XCSchemeInfo+BuildActionInfoTests.swift
@@ -54,8 +54,9 @@ extension XCSchemeInfoBuildActionInfoTests {
             targetResolver: targetResolver,
             targetIDsByLabelAndConfiguration: xcodeScheme.resolveTargetIDs(
                 targetResolver: targetResolver,
-                xcodeConfigurations: targetResolver.targets["A 1"]!
-                    .xcodeConfigurations,
+                xcodeConfigurations: Set(
+                    targetResolver.targets["A 1"]!.xcodeConfigurations
+                ),
                 runnerLabel: runnerLabel
             )
         )

--- a/tools/generators/legacy/test/XCSchemeInfo+LaunchActionInfoTests.swift
+++ b/tools/generators/legacy/test/XCSchemeInfo+LaunchActionInfoTests.swift
@@ -233,8 +233,9 @@ extension XCSchemeInfoLaunchActionInfoTests {
             targetResolver: targetResolver,
             targetIDsByLabelAndConfiguration: xcodeScheme.resolveTargetIDs(
                 targetResolver: targetResolver,
-                xcodeConfigurations: targetResolver.targets["A 2"]!
-                    .xcodeConfigurations,
+                xcodeConfigurations: Set(
+                    targetResolver.targets["A 2"]!.xcodeConfigurations
+                ),
                 runnerLabel: runnerLabel
             )
         )

--- a/tools/generators/legacy/test/XCSchemeInfo+PrePostActionInfoTests.swift
+++ b/tools/generators/legacy/test/XCSchemeInfo+PrePostActionInfoTests.swift
@@ -164,8 +164,9 @@ extension XCSchemeInfoPrePostActionInfoTests {
             targetResolver: targetResolver,
             targetIDsByLabelAndConfiguration: xcodeScheme.resolveTargetIDs(
                 targetResolver: targetResolver,
-                xcodeConfigurations: targetResolver.targets["A 2"]!
-                    .xcodeConfigurations,
+                xcodeConfigurations: Set(
+                    targetResolver.targets["A 2"]!.xcodeConfigurations
+                ),
                 runnerLabel: runnerLabel
             ),
             context: "building `PrePostActionInfo`"
@@ -198,8 +199,9 @@ extension XCSchemeInfoPrePostActionInfoTests {
                 targetResolver: self.targetResolver,
                 targetIDsByLabelAndConfiguration: self.xcodeScheme.resolveTargetIDs(
                     targetResolver: self.targetResolver,
-                    xcodeConfigurations: self.targetResolver.targets["A 2"]!
-                        .xcodeConfigurations,
+                    xcodeConfigurations: Set(
+                        self.targetResolver.targets["A 2"]!.xcodeConfigurations
+                    ),
                     runnerLabel: self.runnerLabel
                 ),
                 context: "building `PrePostActionInfo`"
@@ -227,8 +229,9 @@ extension XCSchemeInfoPrePostActionInfoTests {
             targetResolver: targetResolver,
             targetIDsByLabelAndConfiguration: xcodeScheme.resolveTargetIDs(
                 targetResolver: targetResolver,
-                xcodeConfigurations: targetResolver.targets["A 2"]!
-                    .xcodeConfigurations,
+                xcodeConfigurations: Set(
+                    targetResolver.targets["A 2"]!.xcodeConfigurations
+                ),
                 runnerLabel: runnerLabel
             ),
             context: "building `PrePostActionInfo`"
@@ -256,8 +259,9 @@ extension XCSchemeInfoPrePostActionInfoTests {
             targetResolver: targetResolver,
             targetIDsByLabelAndConfiguration: xcodeScheme.resolveTargetIDs(
                 targetResolver: targetResolver,
-                xcodeConfigurations: targetResolver.targets["A 2"]!
-                    .xcodeConfigurations,
+                xcodeConfigurations: Set(
+                    targetResolver.targets["A 2"]!.xcodeConfigurations
+                ),
                 runnerLabel: runnerLabel
             ),
             context: "building `PrePostActionInfo`"
@@ -313,8 +317,9 @@ extension XCSchemeInfoPrePostActionInfoTests {
             targetResolver: targetResolver,
             targetIDsByLabelAndConfiguration: xcodeScheme.resolveTargetIDs(
                 targetResolver: targetResolver,
-                xcodeConfigurations: targetResolver.targets["A 2"]!
-                    .xcodeConfigurations,
+                xcodeConfigurations: Set(
+                    targetResolver.targets["A 2"]!.xcodeConfigurations
+                ),
                 runnerLabel: runnerLabel
             ),
             context: "building `PrePostActionInfo`"

--- a/tools/generators/legacy/test/XCSchemeInfo+ProfileActionInfoTests.swift
+++ b/tools/generators/legacy/test/XCSchemeInfo+ProfileActionInfoTests.swift
@@ -74,8 +74,9 @@ extension XCSchemeInfoProfileActionInfoTests {
             targetResolver: targetResolver,
             targetIDsByLabelAndConfiguration: xcodeScheme.resolveTargetIDs(
                 targetResolver: targetResolver,
-                xcodeConfigurations: targetResolver.targets["A 2"]!
-                    .xcodeConfigurations,
+                xcodeConfigurations: Set(
+                    targetResolver.targets["A 2"]!.xcodeConfigurations
+                ),
                 runnerLabel: runnerLabel
             )
         )

--- a/tools/generators/legacy/test/XCSchemeInfo+TestActionInfoTests.swift
+++ b/tools/generators/legacy/test/XCSchemeInfo+TestActionInfoTests.swift
@@ -112,8 +112,9 @@ extension XCSchemeInfoTestActionInfoTests {
             targetResolver: targetResolver,
             targetIDsByLabelAndConfiguration: xcodeScheme.resolveTargetIDs(
                 targetResolver: targetResolver,
-                xcodeConfigurations: targetResolver.targets["B 2"]!
-                    .xcodeConfigurations,
+                xcodeConfigurations: Set(
+                    targetResolver.targets["B 2"]!.xcodeConfigurations
+                ),
                 runnerLabel: runnerLabel
             ),
             args: [:],

--- a/tools/generators/legacy/test/XCSchemeInfoTests.swift
+++ b/tools/generators/legacy/test/XCSchemeInfoTests.swift
@@ -173,8 +173,9 @@ extension XCSchemeInfoTests {
     func test_customSchemeInit() throws {
         let actual = try XCSchemeInfo(
             scheme: xcodeScheme.withDefaults,
-            xcodeConfigurations: targetResolver.targets["A 1"]!
-                .xcodeConfigurations,
+            xcodeConfigurations: Set(
+                targetResolver.targets["A 1"]!.xcodeConfigurations
+            ),
             defaultBuildConfigurationName: "Profile",
             targetResolver: targetResolver,
             runnerLabel: runnerLabel,

--- a/tools/generators/legacy/test/XcodeScheme+ExtensionsTests.swift
+++ b/tools/generators/legacy/test/XcodeScheme+ExtensionsTests.swift
@@ -43,7 +43,7 @@ extension XcodeSchemeExtensionsTests {
     func test_resolveTargetIDs_withToolScheme() throws {
         let actual = try toolScheme.resolveTargetIDs(
             targetResolver: targetResolver,
-            xcodeConfigurations: libmacOSx8664Target.xcodeConfigurations,
+            xcodeConfigurations: Set(libmacOSx8664Target.xcodeConfigurations),
             runnerLabel: runnerLabel
         )
         let expected = [
@@ -63,7 +63,7 @@ extension XcodeSchemeExtensionsTests {
         // this iOS app is not selected.
         let actual = try iOSAppScheme.resolveTargetIDs(
             targetResolver: targetResolver,
-            xcodeConfigurations: libiOSx8664Target.xcodeConfigurations,
+            xcodeConfigurations: Set(libiOSx8664Target.xcodeConfigurations),
             runnerLabel: runnerLabel
         )
         let expected = [
@@ -81,7 +81,7 @@ extension XcodeSchemeExtensionsTests {
         // Prefer the TargetID values for the simulator.
         let actual = try tvOSAppScheme.resolveTargetIDs(
             targetResolver: targetResolver,
-            xcodeConfigurations: libtvOSx8664Target.xcodeConfigurations,
+            xcodeConfigurations: Set(libtvOSx8664Target.xcodeConfigurations),
             runnerLabel: runnerLabel
         )
         let expected = [


### PR DESCRIPTION
Because we were using `Set`, the order of `xcodeConfigurations` could vary in `distinguisherKey`. The order is stable from Starlark, so we are using `OrderedSet` to represent this.