### PR TITLE
Add missing disambiguation when a config hash is shown

### DIFF
--- a/examples/integration/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -27,40 +27,41 @@
 		07ED4FAC271EDB8E59AFF1B5 /* c_lib.c in Sources */ = {isa = PBXBuildFile; fileRef = 3AEDEEABC4913622A9147C75 /* c_lib.c */; };
 		099990600DA37A1CEDDFAC42 /* UITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7DD5DC08825B46B051D74B0 /* UITests.swift */; };
 		0AD6C294B129C8943456C601 /* private_lib.c in Sources */ = {isa = PBXBuildFile; fileRef = FDE262D83CA79BF809694381 /* private_lib.c */; };
-		0CF2EB07A5AC19DFEC6C708E /* c_lib.c in Sources */ = {isa = PBXBuildFile; fileRef = 3AEDEEABC4913622A9147C75 /* c_lib.c */; };
 		0D38F4C869767F1A3B4648CA /* tvOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B56D9298492068E642846F0 /* tvOSApp.swift */; };
-		0D7889713AE97EEA494CD3C0 /* lib.m in Sources */ = {isa = PBXBuildFile; fileRef = C7D6E9EA886ACE2FD42D136F /* lib.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		0E08B65DFBF1BA46778B7781 /* Lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25D0C338C5048912A38F6507 /* Lib.swift */; };
 		0F10E1E66B5D243245850C73 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = F430FA1AB345C9D772DC1948 /* main.m */; };
 		1DC498C43B37ECA2C807A327 /* Intents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D03FAD13073EAE50DCFB8EC /* Intents.swift */; };
 		22C85D332BB1DCA8EEA1AB2C /* RealAnswer.h in Headers */ = {isa = PBXBuildFile; fileRef = BEEA406D7D2D485AEDBB4F40 /* RealAnswer.h */; };
+		29BD1379FB12A3ADCDA231B8 /* private_lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34051E31629F66435DD61AF0 /* private_lib.swift */; };
 		2BD74950D211A4072C51A73B /* WatchOSAppExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B175955D9351877CB9A87F1D /* WatchOSAppExtensionTests.swift */; };
 		360B96836FE8A752496FEEF0 /* UITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3011BD0422D96A2C7321B982 /* UITestsLaunchTests.swift */; };
 		37A264D4244A371BCF944571 /* UI.h in Headers */ = {isa = PBXBuildFile; fileRef = 7012DFA199E3E0FCA0E6EEBF /* UI.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3AAB3E92C7F9C36DD0D7EB6E /* Lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DA8D643FEC854A0C5705423 /* Lib.swift */; };
+		4343DBC50C9579E39E490AD8 /* c_lib.c in Sources */ = {isa = PBXBuildFile; fileRef = 3AEDEEABC4913622A9147C75 /* c_lib.c */; };
 		43C779D161AA0465C0DDE95E /* UITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3A45A0819673348AC1A7EEE /* UITests.swift */; };
 		44A7E746741295D2382B2173 /* Lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15833304DE0816B599377D45 /* Lib.swift */; };
+		492B70FA876AE0B3F3F500DF /* private_lib.c in Sources */ = {isa = PBXBuildFile; fileRef = FDE262D83CA79BF809694381 /* private_lib.c */; };
 		4BFB62FFBB1CA26E01D65B26 /* Lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2214ABF62385578C03DED265 /* Lib.swift */; };
 		4D9923CE9713ABD3F5C193E3 /* SwiftUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62A6DC8C0E0B91CA7A026111 /* SwiftUnitTests.swift */; };
 		4FD4120329A466F92FC394E8 /* Lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BECCADF4C068C1CFEF8E5B8 /* Lib.swift */; };
 		53E23014C111CFD291259C97 /* private_lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34051E31629F66435DD61AF0 /* private_lib.swift */; };
 		54CD08F33D9E8D0FEF192DC7 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43483C0C029D669DC6D9079A /* ContentView.swift */; };
+		55C9079E7A44D7276DF79A75 /* lib.m in Sources */ = {isa = PBXBuildFile; fileRef = C7D6E9EA886ACE2FD42D136F /* lib.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		5E729B2C5DEB3DC2100ACBF8 /* TestingUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64B5971D03B36435F28C3771 /* TestingUtils.swift */; };
-		5ECAEC810B3886023A0B9EE3 /* c_lib.c in Sources */ = {isa = PBXBuildFile; fileRef = 3AEDEEABC4913622A9147C75 /* c_lib.c */; };
 		5FB8DE696A4FA2F82D0A6109 /* Resources.swift in Sources */ = {isa = PBXBuildFile; fileRef = 930A52F1C2814B98802A80A4 /* Resources.swift */; };
-		64E43A57A15DFF1E63E7FAB2 /* lib.m in Sources */ = {isa = PBXBuildFile; fileRef = C7D6E9EA886ACE2FD42D136F /* lib.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		6A7413D8D6BE154EDEB5CF58 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43483C0C029D669DC6D9079A /* ContentView.swift */; };
 		6AC8196A1EDF105D3DB2806D /* TestingUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 355750C0149618879E4F6A26 /* TestingUtils.swift */; };
+		71D56384656A4E3A9E5EA030 /* c_lib.c in Sources */ = {isa = PBXBuildFile; fileRef = 3AEDEEABC4913622A9147C75 /* c_lib.c */; };
 		73A4643BBFD5E4FD5FA75612 /* Intents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 342A0C17CAE0AC6E1DEEBF75 /* Intents.swift */; };
 		760ABF9512C3850DE96C7C85 /* BasicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FCEA6FBBD853B4BDA57B3E8 /* BasicTests.swift */; };
 		798751511348F37448E1B040 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = F430FA1AB345C9D772DC1948 /* main.m */; };
-		7A499297D96A6AFD86796FE7 /* private_lib.c in Sources */ = {isa = PBXBuildFile; fileRef = FDE262D83CA79BF809694381 /* private_lib.c */; };
-		7B4DA1AE3F4852E55D4FE590 /* lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5363C149251A898407013539 /* lib.swift */; };
 		7B6708BF1E70C0A3A0F46689 /* UITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 880946C1160FA32CCC519C3A /* UITestsLaunchTests.swift */; };
 		81CC6C81626E5A04DE8BB44E /* Intents.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7E3031F4C8B19A1D7D9737D /* Intents.swift */; };
 		83F3FC7CC1B3DAC64048DBDF /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43483C0C029D669DC6D9079A /* ContentView.swift */; };
 		85B2C53FD5B171FED2E04820 /* Lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36856C67C34B62676114B567 /* Lib.swift */; };
+		89A6056E7F7BDFDBB8048BD3 /* lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5363C149251A898407013539 /* lib.swift */; };
 		8A450FA8A0475BF3A30BE557 /* Lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17C099CF33C628F19DA3A809 /* Lib.swift */; };
+		8BABF1F079754DE7B03C028C /* private_lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34051E31629F66435DD61AF0 /* private_lib.swift */; };
 		8BD39600399E346EF1480FC1 /* ObjCUnitTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7EFD33DA1BC7E7196649D05D /* ObjCUnitTests.m */; };
 		8C245551933F863CC3B84FFA /* UITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3011BD0422D96A2C7321B982 /* UITestsLaunchTests.swift */; };
 		8D2B96BB8D5B7198799AD2F6 /* Lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0690DBA417BA6D7F38E2EEA5 /* Lib.swift */; };
@@ -69,6 +70,9 @@
 		95590E651D57AFA08355EBA9 /* lib.m in Sources */ = {isa = PBXBuildFile; fileRef = C7D6E9EA886ACE2FD42D136F /* lib.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		957DCAF2A74340B0EB9489B0 /* iOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBF5E8B112A0F9856E6CB2D4 /* iOSApp.swift */; };
 		972384D709D7AEC178D78608 /* Foo.m in Sources */ = {isa = PBXBuildFile; fileRef = 10FD9C062371287B427F5031 /* Foo.m */; };
+		9897D64B431508F971871AA4 /* lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5363C149251A898407013539 /* lib.swift */; };
+		9AA0B7A728BC3540C82A0233 /* private_lib.c in Sources */ = {isa = PBXBuildFile; fileRef = FDE262D83CA79BF809694381 /* private_lib.c */; };
+		9B2597590521D97B08B66AAC /* lib.m in Sources */ = {isa = PBXBuildFile; fileRef = C7D6E9EA886ACE2FD42D136F /* lib.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		9F7F69679259E801761A5541 /* _CompileStub_.m in Sources */ = {isa = PBXBuildFile; fileRef = E84DBAC32A7C151ED97289BA /* _CompileStub_.m */; };
 		A54CECFF6EF787FC488F031B /* UITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BCCEF56742B7F970DDBFBD4 /* UITestsLaunchTests.swift */; };
 		A670A9F7CC0456BB8A9CDCD4 /* Lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E5644922EB50A517EE1B9B9 /* Lib.swift */; };
@@ -77,14 +81,12 @@
 		AA14ADB9AB55FC901FA19C7B /* WatchOSAppUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BBEFC3129595A4FBE25EC1D /* WatchOSAppUITestsLaunchTests.swift */; };
 		AAC2A3728B87AA1C1033E2EB /* BasicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FCEA6FBBD853B4BDA57B3E8 /* BasicTests.swift */; };
 		AC68EAC0B2AD0CB7F70B9942 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = F430FA1AB345C9D772DC1948 /* main.m */; };
-		B0A54DD90110037219C3C057 /* private_lib.c in Sources */ = {isa = PBXBuildFile; fileRef = FDE262D83CA79BF809694381 /* private_lib.c */; };
 		B212C1F654EC979A41615291 /* Intents.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB9A0DD82142A76C9AA28FAE /* Intents.swift */; };
 		B2BBC17FF84C00D5DE654466 /* UnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A195462C22D04EEE52ADA1 /* UnitTests.swift */; };
 		B57BEBDCCED2712EC6550D85 /* UITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4881EEC5A32BE56448E19924 /* UITests.swift */; };
 		B5D252B5AB30D9AC8DE4DE9D /* TestingUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3F3C4F4AC7B78A566595E43 /* TestingUtils.swift */; };
 		B8412D62076B6CB5A5AA0F0C /* Lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1F7FE91071F76DA48B41A8E /* Lib.swift */; };
 		B8F23CB7A70D7CADA6795DFA /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 847B3D46C150D0CF60A9F5F8 /* ContentView.swift */; };
-		BAF99126980CD484309719A4 /* private_lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34051E31629F66435DD61AF0 /* private_lib.swift */; };
 		BB6BBB09B0265531587609B1 /* _CompileStub_.m in Sources */ = {isa = PBXBuildFile; fileRef = E84DBAC32A7C151ED97289BA /* _CompileStub_.m */; };
 		BDAF89A193BCB1F16727DC25 /* watchOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9C5A40EB514C4EC147C976B /* watchOSApp.swift */; };
 		BF62E9DBA5328359A728A14F /* _CompileStub_.m in Sources */ = {isa = PBXBuildFile; fileRef = E84DBAC32A7C151ED97289BA /* _CompileStub_.m */; };
@@ -95,12 +97,10 @@
 		D0BB2670F90CF218A2FE518B /* WatchOSAppUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30A4069AA00E60D0D648E673 /* WatchOSAppUITests.swift */; };
 		D251520E5D0BA9F5042019DF /* Lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D46AE9611C26BD1AF60B452 /* Lib.swift */; };
 		D870FF78A16015EC55F80CD4 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E3C67424F456D9FF51EEBDA /* ContentView.swift */; };
-		DC95ED13C69EF1FC531D1F99 /* lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5363C149251A898407013539 /* lib.swift */; };
 		DE7D9F82D6B71F86B1620305 /* Resources.swift in Sources */ = {isa = PBXBuildFile; fileRef = 930A52F1C2814B98802A80A4 /* Resources.swift */; };
 		E181E3C1D66A093B4E414B2D /* TestingUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50AE41EFE8E84D5CEFDC6A4B /* TestingUtils.swift */; };
 		E48D3BC4D5BA7C22214BB9BF /* watchOSAppExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 0982B680A74E8BD8A971CC76 /* watchOSAppExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		E4D37243E160FD1EA0C3965A /* FXPageControl.m in Sources */ = {isa = PBXBuildFile; fileRef = CCB9EDDAC48EA2A043A5D901 /* FXPageControl.m */; };
-		E556150B5BC80DD08DE2D5F1 /* private_lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34051E31629F66435DD61AF0 /* private_lib.swift */; };
 		E66604D967169C5470384FC1 /* ObjCUnitTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7EFD33DA1BC7E7196649D05D /* ObjCUnitTests.m */; };
 		E9EDC8C43E023AD8F43A4263 /* macOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67496CA997EE1999978DD2D4 /* macOSApp.swift */; };
 		ED655B35633C9B26824521B6 /* _CompileStub_.m in Sources */ = {isa = PBXBuildFile; fileRef = E84DBAC32A7C151ED97289BA /* _CompileStub_.m */; };
@@ -118,13 +118,6 @@
 			remoteGlobalIDString = 7E7D155EBCA520F35DEA3571;
 			remoteInfo = BazelDependencies;
 		};
-		0BAF583DC95C1BEED58E1DE8 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 0805833D09730531AD081697 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 7E7D155EBCA520F35DEA3571;
-			remoteInfo = BazelDependencies;
-		};
 		142AF6D695098870D7A8190C /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
@@ -133,6 +126,13 @@
 			remoteInfo = BazelDependencies;
 		};
 		1AD51B418C8BE1F5FA15FEDC /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 7E7D155EBCA520F35DEA3571;
+			remoteInfo = BazelDependencies;
+		};
+		1CC7591B03DA965A7011F1D8 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
 			proxyType = 1;
@@ -154,6 +154,13 @@
 			remoteInfo = BazelDependencies;
 		};
 		3207304E24A789F062BCC801 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 7E7D155EBCA520F35DEA3571;
+			remoteInfo = BazelDependencies;
+		};
+		323FC9FEBDFC31B4801836DB /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
 			proxyType = 1;
@@ -216,6 +223,13 @@
 			remoteGlobalIDString = 7E7D155EBCA520F35DEA3571;
 			remoteInfo = BazelDependencies;
 		};
+		4EF5793E0066E245ED58ECED /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 7E7D155EBCA520F35DEA3571;
+			remoteInfo = BazelDependencies;
+		};
 		53B0D201209D5FC678C09FF3 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
@@ -259,6 +273,13 @@
 			remoteInfo = BazelDependencies;
 		};
 		6C3C83ECCB88380A8CA2D009 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 7E7D155EBCA520F35DEA3571;
+			remoteInfo = BazelDependencies;
+		};
+		6F86637C70D750078F5DED1D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
 			proxyType = 1;
@@ -321,7 +342,7 @@
 			remoteGlobalIDString = 7E7D155EBCA520F35DEA3571;
 			remoteInfo = BazelDependencies;
 		};
-		893869D083BA5BB2CD24EFC8 /* PBXContainerItemProxy */ = {
+		8B378D053F6D1CF801115643 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
 			proxyType = 1;
@@ -329,13 +350,6 @@
 			remoteInfo = BazelDependencies;
 		};
 		8B8EB48B9E8241F59FEC2E8A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 0805833D09730531AD081697 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 7E7D155EBCA520F35DEA3571;
-			remoteInfo = BazelDependencies;
-		};
-		909807B6ECA663409845A82C /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
 			proxyType = 1;
@@ -356,28 +370,7 @@
 			remoteGlobalIDString = 7E7D155EBCA520F35DEA3571;
 			remoteInfo = BazelDependencies;
 		};
-		9607287A4BA58348EDA824CB /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 0805833D09730531AD081697 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 7E7D155EBCA520F35DEA3571;
-			remoteInfo = BazelDependencies;
-		};
 		9640C65DAC8F88CB5F8B9AB6 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 0805833D09730531AD081697 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 7E7D155EBCA520F35DEA3571;
-			remoteInfo = BazelDependencies;
-		};
-		9B6E8E6D94991D5DF0FB0336 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 0805833D09730531AD081697 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 7E7D155EBCA520F35DEA3571;
-			remoteInfo = BazelDependencies;
-		};
-		9D3DA7890C0D51F4BA83D3F2 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
 			proxyType = 1;
@@ -392,13 +385,6 @@
 			remoteInfo = BazelDependencies;
 		};
 		9E1293FAB8D5CB7D608E5E4C /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 0805833D09730531AD081697 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 7E7D155EBCA520F35DEA3571;
-			remoteInfo = BazelDependencies;
-		};
-		A24415F7D745F5A414B35FBB /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
 			proxyType = 1;
@@ -426,13 +412,6 @@
 			remoteGlobalIDString = 7E7D155EBCA520F35DEA3571;
 			remoteInfo = BazelDependencies;
 		};
-		B047048EA4CF625A40036808 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 0805833D09730531AD081697 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 7E7D155EBCA520F35DEA3571;
-			remoteInfo = BazelDependencies;
-		};
 		B3ABD492E3DA9C3BA85F7BA0 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
@@ -440,7 +419,14 @@
 			remoteGlobalIDString = 7E7D155EBCA520F35DEA3571;
 			remoteInfo = BazelDependencies;
 		};
-		C37430805EB5FC228F053FCE /* PBXContainerItemProxy */ = {
+		BE38CC9065EB6D0AF75837F4 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 7E7D155EBCA520F35DEA3571;
+			remoteInfo = BazelDependencies;
+		};
+		C2602A62CCDF8F5D34A14650 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
 			proxyType = 1;
@@ -468,6 +454,13 @@
 			remoteGlobalIDString = 7E7D155EBCA520F35DEA3571;
 			remoteInfo = BazelDependencies;
 		};
+		D5E7F3561DDA3FC5BC934F63 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 7E7D155EBCA520F35DEA3571;
+			remoteInfo = BazelDependencies;
+		};
 		DA3D8D1E0394587D9F6140FE /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
@@ -482,14 +475,14 @@
 			remoteGlobalIDString = 7E7D155EBCA520F35DEA3571;
 			remoteInfo = BazelDependencies;
 		};
-		EA86503F87522DE0CA1AC4B2 /* PBXContainerItemProxy */ = {
+		E8C51C6976E6333DE99FE506 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 7E7D155EBCA520F35DEA3571;
 			remoteInfo = BazelDependencies;
 		};
-		EAD5378EECD89ECFD779837A /* PBXContainerItemProxy */ = {
+		EA86503F87522DE0CA1AC4B2 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
 			proxyType = 1;
@@ -525,6 +518,13 @@
 			remoteInfo = tvOSApp;
 		};
 		EF32126AD0F7C7C0F95407EC /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 7E7D155EBCA520F35DEA3571;
+			remoteInfo = BazelDependencies;
+		};
+		F1C96B97D5B069ECE75DC735 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
 			proxyType = 1;
@@ -7105,6 +7105,23 @@
 			productReference = 65FE043974334DC5DC5E16DD /* AppClip.app */;
 			productType = "com.apple.product-type.application.on-demand-install-capable";
 		};
+		1732C9B70F9B5BDB60B7FC26 /* lib_impl (x86_64) (AppStore, Debug) (7d2e3) */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 7F64EDB10B3995D384B30E39 /* Build configuration list for PBXNativeTarget "lib_impl (x86_64) (AppStore, Debug) (7d2e3)" */;
+			buildPhases = (
+				7002D6187F54C28026BC9195 /* Copy Bazel Outputs / Generate Bazel Dependencies (Index Build) */,
+				2FFCBBAD00B9E490934E35CF /* Create Compile Dependencies */,
+				A723B300F5109BC6204F82F4 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				39B8157633C6750E72D5EBF2 /* PBXTargetDependency */,
+			);
+			name = "lib_impl (x86_64) (AppStore, Debug) (7d2e3)";
+			productName = lib_impl;
+			productType = "com.apple.product-type.library.static";
+		};
 		173A118A49AD58E8AE0BD5E8 /* lib_impl (arm64) */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 248193F9AD97D6446B9BE3D8 /* Build configuration list for PBXNativeTarget "lib_impl (arm64)" */;
@@ -7178,21 +7195,21 @@
 			productReference = 222CF04F551342682A2DEA9D /* LibFramework.watchOS.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		219FC92FC257657B7BEA0B7B /* lib_swift (7d2e3) */ = {
+		21F5BEC07AF0B26EF4B4B151 /* private_lib (x86_64) (AppStore, Debug) (7d2e3) */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = CD1746947AC8A564C2527D1A /* Build configuration list for PBXNativeTarget "lib_swift (7d2e3)" */;
+			buildConfigurationList = 4861D7D3DEF812E48C499E00 /* Build configuration list for PBXNativeTarget "private_lib (x86_64) (AppStore, Debug) (7d2e3)" */;
 			buildPhases = (
-				D90624BD492C95DBF1652C56 /* Copy Bazel Outputs / Generate Bazel Dependencies (Index Build) */,
-				1FD342EE21C1E1A7F943E76E /* Create Compile Dependencies */,
-				EBEF5ECD48B6BF0A5832EDE7 /* Sources */,
+				0E88A86C6A45F13832273A66 /* Copy Bazel Outputs / Generate Bazel Dependencies (Index Build) */,
+				0C42B16528E86C751ED16916 /* Create Compile Dependencies */,
+				6FF754472620C7CFAD73E960 /* Sources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				AC914D5BB4301A9E45BA68B8 /* PBXTargetDependency */,
+				93CDA115ED33747E41A86002 /* PBXTargetDependency */,
 			);
-			name = "lib_swift (7d2e3)";
-			productName = lib_swift;
+			name = "private_lib (x86_64) (AppStore, Debug) (7d2e3)";
+			productName = private_lib;
 			productType = "com.apple.product-type.library.static";
 		};
 		252CA33FB4DD1F73A46CE0A6 /* iOS */ = {
@@ -7212,6 +7229,23 @@
 			productName = Lib;
 			productReference = FDC975FBEFB4C3DC4E3AB334 /* Lib.framework */;
 			productType = "com.apple.product-type.framework";
+		};
+		28F896144BD31E78D7D9AF3A /* c_lib (x86_64) (AppStore, Debug) (7d2e3) */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 76F21EAF8FFDB9E0CC388C27 /* Build configuration list for PBXNativeTarget "c_lib (x86_64) (AppStore, Debug) (7d2e3)" */;
+			buildPhases = (
+				CC7B932F9C3800F3EFA03049 /* Copy Bazel Outputs / Generate Bazel Dependencies (Index Build) */,
+				8ADCA5248671DA9FEA435AC9 /* Create Compile Dependencies */,
+				3EEA10CC7DEB136A20CEB353 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				0AB2CBDB52D47D2E2F987BC6 /* PBXTargetDependency */,
+			);
+			name = "c_lib (x86_64) (AppStore, Debug) (7d2e3)";
+			productName = c_lib;
+			productType = "com.apple.product-type.library.static";
 		};
 		2BECDF067E07C69468ED23A3 /* iMessageAppExtension */ = {
 			isa = PBXNativeTarget;
@@ -7287,6 +7321,23 @@
 			productReference = 0982B680A74E8BD8A971CC76 /* watchOSAppExtension.appex */;
 			productType = "com.apple.product-type.watchkit2-extension";
 		};
+		2EAE603EA49BECFF614EDC09 /* lib_swift (x86_64) (AppStore, Debug) (f321a) */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 01912229FFC8DF4B36E1F925 /* Build configuration list for PBXNativeTarget "lib_swift (x86_64) (AppStore, Debug) (f321a)" */;
+			buildPhases = (
+				CFF2CD110CC670248822A651 /* Copy Bazel Outputs / Generate Bazel Dependencies (Index Build) */,
+				1309AFC648DE3412ADF9176E /* Create Compile Dependencies */,
+				8634EFAC486E5A18A0974652 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				19843D1FC5183FA844238927 /* PBXTargetDependency */,
+			);
+			name = "lib_swift (x86_64) (AppStore, Debug) (f321a)";
+			productName = lib_swift;
+			productType = "com.apple.product-type.library.static";
+		};
 		343F031FB3DF1E87C3568525 /* iMessageApp */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = D879581B52FB0834A869F005 /* Build configuration list for PBXNativeTarget "iMessageApp" */;
@@ -7320,23 +7371,6 @@
 			productName = Utils;
 			productType = "com.apple.product-type.library.static";
 		};
-		383BE46EAF3E45FAC4CA665C /* lib_swift (f321a) */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = C2B1537C85417BBA01E113F7 /* Build configuration list for PBXNativeTarget "lib_swift (f321a)" */;
-			buildPhases = (
-				DAF86BA209B12A4403427CE4 /* Copy Bazel Outputs / Generate Bazel Dependencies (Index Build) */,
-				D69871BA5CBBA0DDDAD885AC /* Create Compile Dependencies */,
-				EAE59CBC633B8156A84181CE /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				ACC5BE11082168E94DC3FB70 /* PBXTargetDependency */,
-			);
-			name = "lib_swift (f321a)";
-			productName = lib_swift;
-			productType = "com.apple.product-type.library.static";
-		};
 		41EA1ABC35FAFDF6B7FE0600 /* iOSAppObjCUnitTests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 87E0D1E918B094F507DEAC40 /* Build configuration list for PBXNativeTarget "iOSAppObjCUnitTests" */;
@@ -7356,23 +7390,6 @@
 			productName = iOSAppObjCUnitTests;
 			productReference = 2389FC2E3790FF01911CDBCC /* iOSAppObjCUnitTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
-		};
-		49DFB89FFA70419624B2A930 /* private_swift_lib (7d2e3) */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = DAA656300AFF26A087CECD4F /* Build configuration list for PBXNativeTarget "private_swift_lib (7d2e3)" */;
-			buildPhases = (
-				6B4C5642691FC718BA2C7CB2 /* Copy Bazel Outputs / Generate Bazel Dependencies (Index Build) */,
-				D2ED38335D54C2EBC917B420 /* Create Compile Dependencies */,
-				94CBFC39B171BAC478B80709 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				9D84C0968ECA2C9568083024 /* PBXTargetDependency */,
-			);
-			name = "private_swift_lib (7d2e3)";
-			productName = private_swift_lib;
-			productType = "com.apple.product-type.library.static";
 		};
 		4CFF47C3FBF2E6C24127D667 /* UIFramework.iOS */ = {
 			isa = PBXNativeTarget;
@@ -7451,6 +7468,23 @@
 			productReference = 26E5833F2697196812B9D228 /* watchOSApp.app */;
 			productType = "com.apple.product-type.application.watchapp2";
 		};
+		63CEFAD4966431863BF44E2E /* private_swift_lib (x86_64) (AppStore, Debug) (7d2e3) */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = AF297CF0F0D2BF6560D7BFC4 /* Build configuration list for PBXNativeTarget "private_swift_lib (x86_64) (AppStore, Debug) (7d2e3)" */;
+			buildPhases = (
+				C5F35A377F859B422A254109 /* Copy Bazel Outputs / Generate Bazel Dependencies (Index Build) */,
+				67F03EBFBDB9535C30BB78F9 /* Create Compile Dependencies */,
+				47FEB5AD087B4CC4AA8943D3 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				2E050975756DCCF33CBBD88C /* PBXTargetDependency */,
+			);
+			name = "private_swift_lib (x86_64) (AppStore, Debug) (7d2e3)";
+			productName = private_swift_lib;
+			productType = "com.apple.product-type.library.static";
+		};
 		656BB6FF8F9415647D9307E7 /* watchOS */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 4E7EF44C093AE79EB56488A9 /* Build configuration list for PBXNativeTarget "watchOS" */;
@@ -7468,23 +7502,6 @@
 			productName = Lib;
 			productReference = E4976A0A8B1D38CB8334D1E4 /* Lib.framework */;
 			productType = "com.apple.product-type.framework";
-		};
-		6BF04914EEB0EEB5E420D297 /* c_lib (7d2e3) */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 9E6E9AF105F3B379699434F2 /* Build configuration list for PBXNativeTarget "c_lib (7d2e3)" */;
-			buildPhases = (
-				365C98BB517C53030BD9C423 /* Copy Bazel Outputs / Generate Bazel Dependencies (Index Build) */,
-				05A613C82D0DA24E18F37A0F /* Create Compile Dependencies */,
-				AA561124335F9162478F39CA /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				B2285BAE9AFCBFE8120B55B1 /* PBXTargetDependency */,
-			);
-			name = "c_lib (7d2e3)";
-			productName = c_lib;
-			productType = "com.apple.product-type.library.static";
 		};
 		703D7AC89C4B9C9E4B61A58F /* FXPageControl */ = {
 			isa = PBXNativeTarget;
@@ -7523,21 +7540,21 @@
 			productReference = 1E84E717BC47B0961159FC23 /* tvOSAppUnitTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
-		7E8B099583E4DC09BD4F352E /* lib_impl (f321a) */ = {
+		7C0C9AEF7453D9B751FA7B88 /* private_swift_lib (x86_64) (AppStore, Debug) (f321a) */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = F4BBD4A2DBB7AC84FB67D4C0 /* Build configuration list for PBXNativeTarget "lib_impl (f321a)" */;
+			buildConfigurationList = A36C362F4C75B0BAB71FA1D6 /* Build configuration list for PBXNativeTarget "private_swift_lib (x86_64) (AppStore, Debug) (f321a)" */;
 			buildPhases = (
-				02569A64BFDC3570936299C5 /* Copy Bazel Outputs / Generate Bazel Dependencies (Index Build) */,
-				6538360C0450B2E747E67E45 /* Create Compile Dependencies */,
-				1DE1786D634C55CD11A2F1A9 /* Sources */,
+				A81C07B0486885CE46CAD9AB /* Copy Bazel Outputs / Generate Bazel Dependencies (Index Build) */,
+				DAFD205B312D6E2CCB295938 /* Create Compile Dependencies */,
+				EF5D5262A2C0572A833928CA /* Sources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				C58F4BAFFA37250334C86FE8 /* PBXTargetDependency */,
+				E5B1586D18484914FA681087 /* PBXTargetDependency */,
 			);
-			name = "lib_impl (f321a)";
-			productName = lib_impl;
+			name = "private_swift_lib (x86_64) (AppStore, Debug) (f321a)";
+			productName = private_swift_lib;
 			productType = "com.apple.product-type.library.static";
 		};
 		7F21C434B520AB441229E270 /* FrameworkCoreUtilsObjC */ = {
@@ -7686,6 +7703,57 @@
 			productReference = FE0CE46FA0CA3A3880DC4937 /* UIFramework.tvOS.framework */;
 			productType = "com.apple.product-type.framework";
 		};
+		A5885841514C75A20817CE98 /* c_lib (x86_64) (AppStore, Debug) (f321a) */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = EAB016539A35B9B425C38865 /* Build configuration list for PBXNativeTarget "c_lib (x86_64) (AppStore, Debug) (f321a)" */;
+			buildPhases = (
+				A6959C26CA80B8129A90741C /* Copy Bazel Outputs / Generate Bazel Dependencies (Index Build) */,
+				C003CFFF13888727F7F9964C /* Create Compile Dependencies */,
+				F80DDFB34575642F1A3BC7CB /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				6C22CBC259EA0CC6DB5E45F3 /* PBXTargetDependency */,
+			);
+			name = "c_lib (x86_64) (AppStore, Debug) (f321a)";
+			productName = c_lib;
+			productType = "com.apple.product-type.library.static";
+		};
+		A5E9FDD0476FFCEE458F4679 /* lib_swift (x86_64) (AppStore, Debug) (7d2e3) */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 57C1FB17A5F60A33D2447364 /* Build configuration list for PBXNativeTarget "lib_swift (x86_64) (AppStore, Debug) (7d2e3)" */;
+			buildPhases = (
+				7CCBD0F9CFE5776C39BF5C20 /* Copy Bazel Outputs / Generate Bazel Dependencies (Index Build) */,
+				907617C445F9AC381C1A8564 /* Create Compile Dependencies */,
+				04DC4F217A7376A4EB57AFAA /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				677F56A9D9089663A5834EC7 /* PBXTargetDependency */,
+			);
+			name = "lib_swift (x86_64) (AppStore, Debug) (7d2e3)";
+			productName = lib_swift;
+			productType = "com.apple.product-type.library.static";
+		};
+		A7138F8D1198A6F3EFCB7D9F /* lib_impl (x86_64) (AppStore, Debug) (f321a) */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F8787A42308EA0E966AD1C92 /* Build configuration list for PBXNativeTarget "lib_impl (x86_64) (AppStore, Debug) (f321a)" */;
+			buildPhases = (
+				ACAA071E041A82214DD3816C /* Copy Bazel Outputs / Generate Bazel Dependencies (Index Build) */,
+				DB6432041F4AE470B743AD35 /* Create Compile Dependencies */,
+				9E3BB66234A48E11EE3C8E6A /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				A7521604745892D90C67F7BA /* PBXTargetDependency */,
+			);
+			name = "lib_impl (x86_64) (AppStore, Debug) (f321a)";
+			productName = lib_impl;
+			productType = "com.apple.product-type.library.static";
+		};
 		A7DC0A48644EFD0FCDE5EF90 /* c_lib (arm64) */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 2AB75A19776007D35E06C07F /* Build configuration list for PBXNativeTarget "c_lib (arm64)" */;
@@ -7778,23 +7846,6 @@
 			productName = MixedAnswerLib_Swift;
 			productType = "com.apple.product-type.library.static";
 		};
-		BA52C6F37366B8B20D17ADBE /* private_lib (f321a) */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 8C9DF43C4A8A9357E49AA789 /* Build configuration list for PBXNativeTarget "private_lib (f321a)" */;
-			buildPhases = (
-				189CFBF9E08040773B706E38 /* Copy Bazel Outputs / Generate Bazel Dependencies (Index Build) */,
-				F2EB51DD642BA8DEE5C8ACEB /* Create Compile Dependencies */,
-				16C57B6813982BA852B1DC27 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				2CAE8DA0DAE2792B7DD04042 /* PBXTargetDependency */,
-			);
-			name = "private_lib (f321a)";
-			productName = private_lib;
-			productType = "com.apple.product-type.library.static";
-		};
 		C03F5C0CA2104493AE9E52C9 /* LibFramework.tvOS */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 7F8E2A0098A7975FCB21C148 /* Build configuration list for PBXNativeTarget "LibFramework.tvOS" */;
@@ -7812,23 +7863,6 @@
 			productName = LibFramework.tvOS;
 			productReference = 1D1177806FD1B277EEDB91BB /* LibFramework.tvOS.framework */;
 			productType = "com.apple.product-type.framework";
-		};
-		C41577B6AE75D0FB7EF37BAD /* lib_impl (7d2e3) */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 695A147C26D0BBB8656AA480 /* Build configuration list for PBXNativeTarget "lib_impl (7d2e3)" */;
-			buildPhases = (
-				D038EF4F5844EFC906FFA41F /* Copy Bazel Outputs / Generate Bazel Dependencies (Index Build) */,
-				363414DFBE9EF8D9C51D3FDF /* Create Compile Dependencies */,
-				427FA4B21CC21CDEEE4E3634 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				21EEFAD4C485BD5BC41791A6 /* PBXTargetDependency */,
-			);
-			name = "lib_impl (7d2e3)";
-			productName = lib_impl;
-			productType = "com.apple.product-type.library.static";
 		};
 		C9EB85EDD4934E0A73AC195A /* Bundle */ = {
 			isa = PBXNativeTarget;
@@ -7888,40 +7922,6 @@
 			productReference = F6F1090237FF04C38B58E42A /* iOSAppUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
 		};
-		CF2B52D46610C73C56C4C5B1 /* private_swift_lib (f321a) */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 7732DBB228206F99D22CD4B3 /* Build configuration list for PBXNativeTarget "private_swift_lib (f321a)" */;
-			buildPhases = (
-				E44442B489982329C2B21628 /* Copy Bazel Outputs / Generate Bazel Dependencies (Index Build) */,
-				4E5F3802E181491A325F0F0B /* Create Compile Dependencies */,
-				3C871AC71A78BCAFE422D28A /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				143C87FA1F48A4230E84C240 /* PBXTargetDependency */,
-			);
-			name = "private_swift_lib (f321a)";
-			productName = private_swift_lib;
-			productType = "com.apple.product-type.library.static";
-		};
-		D1C427A70AABE7276459D0C4 /* c_lib (f321a) */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 64283CA4B08CF9184F238626 /* Build configuration list for PBXNativeTarget "c_lib (f321a)" */;
-			buildPhases = (
-				47BEACB636E1665B3CC96220 /* Copy Bazel Outputs / Generate Bazel Dependencies (Index Build) */,
-				856EDD3A74B44D4191E475F6 /* Create Compile Dependencies */,
-				923A8E52654BC7B577C7D5F7 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				C73AD8C9C493E5909101C287 /* PBXTargetDependency */,
-			);
-			name = "c_lib (f321a)";
-			productName = c_lib;
-			productType = "com.apple.product-type.library.static";
-		};
 		D2B147BDA8E8FC10D91B53BB /* iOSAppSwiftUnitTests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 95D60D8205A86F653A4B94A4 /* Build configuration list for PBXNativeTarget "iOSAppSwiftUnitTests" */;
@@ -7941,6 +7941,23 @@
 			productName = iOSAppSwiftUnitTests;
 			productReference = 9E9A34CF7D39ABC67B25D278 /* iOSAppSwiftUnitTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		D4FE36D30F79C14A49159CAD /* private_lib (x86_64) (AppStore, Debug) (f321a) */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D90C3C6C901499086E329E75 /* Build configuration list for PBXNativeTarget "private_lib (x86_64) (AppStore, Debug) (f321a)" */;
+			buildPhases = (
+				6609EA0E982124D78DD73354 /* Copy Bazel Outputs / Generate Bazel Dependencies (Index Build) */,
+				F7839F8EDC269ABB0E81418F /* Create Compile Dependencies */,
+				203C4740029337A54CEB13F6 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				2FCEEDAD536917EDBBC3E451 /* PBXTargetDependency */,
+			);
+			name = "private_lib (x86_64) (AppStore, Debug) (f321a)";
+			productName = private_lib;
+			productType = "com.apple.product-type.library.static";
 		};
 		D72E91668AA84CA0E91BC0E9 /* watchOSAppExtensionUnitTests */ = {
 			isa = PBXNativeTarget;
@@ -8017,23 +8034,6 @@
 			productName = Lib;
 			productReference = A9721D8883D73A3F13BF89BB /* Lib.framework */;
 			productType = "com.apple.product-type.framework";
-		};
-		EC377162E15E765DA8DDC9D3 /* private_lib (7d2e3) */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = A60859ACA1047EC1FD9A1E0A /* Build configuration list for PBXNativeTarget "private_lib (7d2e3)" */;
-			buildPhases = (
-				C253AF7633C80793612DFAFF /* Copy Bazel Outputs / Generate Bazel Dependencies (Index Build) */,
-				4C0EE567DA9EA026C8378601 /* Create Compile Dependencies */,
-				4CEAB55F4A77E8482323A6CB /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				62C7B2B5AC25806A9D31559E /* PBXTargetDependency */,
-			);
-			name = "private_lib (7d2e3)";
-			productName = private_lib;
-			productType = "com.apple.product-type.library.static";
 		};
 		F175A7E1019A952CA7F66BBC /* TestingUtils */ = {
 			isa = PBXNativeTarget;
@@ -8127,6 +8127,10 @@
 						CreatedOnToolsVersion = 13.0.0;
 						LastSwiftMigration = 9999;
 					};
+					1732C9B70F9B5BDB60B7FC26 = {
+						CreatedOnToolsVersion = 13.0.0;
+						LastSwiftMigration = 9999;
+					};
 					173A118A49AD58E8AE0BD5E8 = {
 						CreatedOnToolsVersion = 13.0.0;
 						LastSwiftMigration = 9999;
@@ -8143,11 +8147,15 @@
 						CreatedOnToolsVersion = 13.0.0;
 						LastSwiftMigration = 9999;
 					};
-					219FC92FC257657B7BEA0B7B = {
+					21F5BEC07AF0B26EF4B4B151 = {
 						CreatedOnToolsVersion = 13.0.0;
 						LastSwiftMigration = 9999;
 					};
 					252CA33FB4DD1F73A46CE0A6 = {
+						CreatedOnToolsVersion = 13.0.0;
+						LastSwiftMigration = 9999;
+					};
+					28F896144BD31E78D7D9AF3A = {
 						CreatedOnToolsVersion = 13.0.0;
 						LastSwiftMigration = 9999;
 					};
@@ -8167,6 +8175,10 @@
 						CreatedOnToolsVersion = 13.0.0;
 						LastSwiftMigration = 9999;
 					};
+					2EAE603EA49BECFF614EDC09 = {
+						CreatedOnToolsVersion = 13.0.0;
+						LastSwiftMigration = 9999;
+					};
 					343F031FB3DF1E87C3568525 = {
 						CreatedOnToolsVersion = 13.0.0;
 						LastSwiftMigration = 9999;
@@ -8175,18 +8187,10 @@
 						CreatedOnToolsVersion = 13.0.0;
 						LastSwiftMigration = 9999;
 					};
-					383BE46EAF3E45FAC4CA665C = {
-						CreatedOnToolsVersion = 13.0.0;
-						LastSwiftMigration = 9999;
-					};
 					41EA1ABC35FAFDF6B7FE0600 = {
 						CreatedOnToolsVersion = 13.0.0;
 						LastSwiftMigration = 9999;
 						TestTargetID = 1765D91CC168F25A5BC51603;
-					};
-					49DFB89FFA70419624B2A930 = {
-						CreatedOnToolsVersion = 13.0.0;
-						LastSwiftMigration = 9999;
 					};
 					4CFF47C3FBF2E6C24127D667 = {
 						CreatedOnToolsVersion = 13.0.0;
@@ -8205,11 +8209,11 @@
 						CreatedOnToolsVersion = 13.0.0;
 						LastSwiftMigration = 9999;
 					};
-					656BB6FF8F9415647D9307E7 = {
+					63CEFAD4966431863BF44E2E = {
 						CreatedOnToolsVersion = 13.0.0;
 						LastSwiftMigration = 9999;
 					};
-					6BF04914EEB0EEB5E420D297 = {
+					656BB6FF8F9415647D9307E7 = {
 						CreatedOnToolsVersion = 13.0.0;
 						LastSwiftMigration = 9999;
 					};
@@ -8222,12 +8226,12 @@
 						LastSwiftMigration = 9999;
 						TestTargetID = ACEF2F653E0F6BEA37D2C7B6;
 					};
-					7E7D155EBCA520F35DEA3571 = {
-						CreatedOnToolsVersion = 13.0.0;
-					};
-					7E8B099583E4DC09BD4F352E = {
+					7C0C9AEF7453D9B751FA7B88 = {
 						CreatedOnToolsVersion = 13.0.0;
 						LastSwiftMigration = 9999;
+					};
+					7E7D155EBCA520F35DEA3571 = {
+						CreatedOnToolsVersion = 13.0.0;
 					};
 					7F21C434B520AB441229E270 = {
 						CreatedOnToolsVersion = 13.0.0;
@@ -8262,6 +8266,18 @@
 						CreatedOnToolsVersion = 13.0.0;
 						LastSwiftMigration = 9999;
 					};
+					A5885841514C75A20817CE98 = {
+						CreatedOnToolsVersion = 13.0.0;
+						LastSwiftMigration = 9999;
+					};
+					A5E9FDD0476FFCEE458F4679 = {
+						CreatedOnToolsVersion = 13.0.0;
+						LastSwiftMigration = 9999;
+					};
+					A7138F8D1198A6F3EFCB7D9F = {
+						CreatedOnToolsVersion = 13.0.0;
+						LastSwiftMigration = 9999;
+					};
 					A7DC0A48644EFD0FCDE5EF90 = {
 						CreatedOnToolsVersion = 13.0.0;
 						LastSwiftMigration = 9999;
@@ -8283,15 +8299,7 @@
 						CreatedOnToolsVersion = 13.0.0;
 						LastSwiftMigration = 9999;
 					};
-					BA52C6F37366B8B20D17ADBE = {
-						CreatedOnToolsVersion = 13.0.0;
-						LastSwiftMigration = 9999;
-					};
 					C03F5C0CA2104493AE9E52C9 = {
-						CreatedOnToolsVersion = 13.0.0;
-						LastSwiftMigration = 9999;
-					};
-					C41577B6AE75D0FB7EF37BAD = {
 						CreatedOnToolsVersion = 13.0.0;
 						LastSwiftMigration = 9999;
 					};
@@ -8309,18 +8317,14 @@
 						LastSwiftMigration = 9999;
 						TestTargetID = 1765D91CC168F25A5BC51603;
 					};
-					CF2B52D46610C73C56C4C5B1 = {
-						CreatedOnToolsVersion = 13.0.0;
-						LastSwiftMigration = 9999;
-					};
-					D1C427A70AABE7276459D0C4 = {
-						CreatedOnToolsVersion = 13.0.0;
-						LastSwiftMigration = 9999;
-					};
 					D2B147BDA8E8FC10D91B53BB = {
 						CreatedOnToolsVersion = 13.0.0;
 						LastSwiftMigration = 9999;
 						TestTargetID = 1765D91CC168F25A5BC51603;
+					};
+					D4FE36D30F79C14A49159CAD = {
+						CreatedOnToolsVersion = 13.0.0;
+						LastSwiftMigration = 9999;
 					};
 					D72E91668AA84CA0E91BC0E9 = {
 						CreatedOnToolsVersion = 13.0.0;
@@ -8336,10 +8340,6 @@
 						TestTargetID = AE02B41E521B2C6360C30D20;
 					};
 					EACAA4186ECECF71B7BC09C6 = {
-						CreatedOnToolsVersion = 13.0.0;
-						LastSwiftMigration = 9999;
-					};
-					EC377162E15E765DA8DDC9D3 = {
 						CreatedOnToolsVersion = 13.0.0;
 						LastSwiftMigration = 9999;
 					};
@@ -8380,9 +8380,9 @@
 				13A68B4984727F4B3DAE6AFB /* AppClip */,
 				9EE241A38E73332743D808C4 /* BasicTests */,
 				C9EB85EDD4934E0A73AC195A /* Bundle */,
-				6BF04914EEB0EEB5E420D297 /* c_lib (7d2e3) */,
 				A7DC0A48644EFD0FCDE5EF90 /* c_lib (arm64) */,
-				D1C427A70AABE7276459D0C4 /* c_lib (f321a) */,
+				28F896144BD31E78D7D9AF3A /* c_lib (x86_64) (AppStore, Debug) (7d2e3) */,
+				A5885841514C75A20817CE98 /* c_lib (x86_64) (AppStore, Debug) (f321a) */,
 				1A40783EF59C680645DD16E1 /* CommandLineTool */,
 				5826810F86C049E80D55353A /* CommandLineToolTests */,
 				7F21C434B520AB441229E270 /* FrameworkCoreUtilsObjC */,
@@ -8399,24 +8399,24 @@
 				F36F253D9F3EB5CAC3409272 /* iOSAppUITestSuite */,
 				9D6BB9A04FEC771667C78F54 /* Lib (iOS, tvOS) */,
 				83D00AD7532094902D925C83 /* Lib (watchOS) */,
-				C41577B6AE75D0FB7EF37BAD /* lib_impl (7d2e3) */,
 				173A118A49AD58E8AE0BD5E8 /* lib_impl (arm64) */,
-				7E8B099583E4DC09BD4F352E /* lib_impl (f321a) */,
-				219FC92FC257657B7BEA0B7B /* lib_swift (7d2e3) */,
+				1732C9B70F9B5BDB60B7FC26 /* lib_impl (x86_64) (AppStore, Debug) (7d2e3) */,
+				A7138F8D1198A6F3EFCB7D9F /* lib_impl (x86_64) (AppStore, Debug) (f321a) */,
 				9B2255D9DE767A905FA0A70B /* lib_swift (arm64) */,
-				383BE46EAF3E45FAC4CA665C /* lib_swift (f321a) */,
+				A5E9FDD0476FFCEE458F4679 /* lib_swift (x86_64) (AppStore, Debug) (7d2e3) */,
+				2EAE603EA49BECFF614EDC09 /* lib_swift (x86_64) (AppStore, Debug) (f321a) */,
 				C03F5C0CA2104493AE9E52C9 /* LibFramework.tvOS */,
 				1EF2B99D58C7884FED2A0769 /* LibFramework.watchOS */,
 				AE02B41E521B2C6360C30D20 /* macOSApp */,
 				DBA520153E51B3D6E3103986 /* macOSAppUITests */,
 				A1593696756F76082BF2BE5E /* MixedAnswer */,
 				B921D1A513161BE6BAD826B3 /* MixedAnswerLib_Swift */,
-				EC377162E15E765DA8DDC9D3 /* private_lib (7d2e3) */,
 				2D6C8CD4DE56B84C277D9C46 /* private_lib (arm64) */,
-				BA52C6F37366B8B20D17ADBE /* private_lib (f321a) */,
-				49DFB89FFA70419624B2A930 /* private_swift_lib (7d2e3) */,
+				21F5BEC07AF0B26EF4B4B151 /* private_lib (x86_64) (AppStore, Debug) (7d2e3) */,
+				D4FE36D30F79C14A49159CAD /* private_lib (x86_64) (AppStore, Debug) (f321a) */,
 				FA984D215315633CCB7A6267 /* private_swift_lib (arm64) */,
-				CF2B52D46610C73C56C4C5B1 /* private_swift_lib (f321a) */,
+				63CEFAD4966431863BF44E2E /* private_swift_lib (x86_64) (AppStore, Debug) (7d2e3) */,
+				7C0C9AEF7453D9B751FA7B88 /* private_swift_lib (x86_64) (AppStore, Debug) (f321a) */,
 				F175A7E1019A952CA7F66BBC /* TestingUtils */,
 				EACAA4186ECECF71B7BC09C6 /* tvOS */,
 				ACEF2F653E0F6BEA37D2C7B6 /* tvOSApp */,
@@ -8470,39 +8470,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -euo pipefail\n\nif [[ \"$ACTION\" == \"indexbuild\" ]]; then\n  cd \"$SRCROOT\"\n\n  \"$BAZEL_INTEGRATION_DIR/generate_index_build_bazel_dependencies.sh\"\nelse\n  \"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n    \"_BazelForcedCompile_.swift\" \\\n    \"\"\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		02569A64BFDC3570936299C5 /* Copy Bazel Outputs / Generate Bazel Dependencies (Index Build) */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Copy Bazel Outputs / Generate Bazel Dependencies (Index Build)";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -euo pipefail\n\nif [[ \"$ACTION\" == \"indexbuild\" ]]; then\n  cd \"$SRCROOT\"\n\n  \"$BAZEL_INTEGRATION_DIR/generate_index_build_bazel_dependencies.sh\"\nelse\n  \"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n    \"_BazelForcedCompile_.swift\" \\\n    \"\"\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		05A613C82D0DA24E18F37A0F /* Create Compile Dependencies */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(C_PARAMS_FILE)",
-			);
-			name = "Create Compile Dependencies";
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/c.compile.params",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -euo pipefail\n\nperl -pe '\n  s/__BAZEL_XCODE_DEVELOPER_DIR__/\\$(DEVELOPER_DIR)/g;\n  s/__BAZEL_XCODE_SDKROOT__/\\$(SDKROOT)/g;\n  s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/gx;\n' \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
 			showEnvVarsInLog = 0;
 		};
 		06758B4DDCFAE11AE0702005 /* Create Link Dependencies */ = {
@@ -8591,6 +8558,39 @@
 			shellScript = "set -euo pipefail\n\nperl -pe '\n  s/__BAZEL_XCODE_DEVELOPER_DIR__/\\$(DEVELOPER_DIR)/g;\n  s/__BAZEL_XCODE_SDKROOT__/\\$(SDKROOT)/g;\n  s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/gx;\n' \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
 			showEnvVarsInLog = 0;
 		};
+		0C42B16528E86C751ED16916 /* Create Compile Dependencies */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(C_PARAMS_FILE)",
+			);
+			name = "Create Compile Dependencies";
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/c.compile.params",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -euo pipefail\n\nperl -pe '\n  s/__BAZEL_XCODE_DEVELOPER_DIR__/\\$(DEVELOPER_DIR)/g;\n  s/__BAZEL_XCODE_SDKROOT__/\\$(SDKROOT)/g;\n  s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/gx;\n' \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
+			showEnvVarsInLog = 0;
+		};
+		0E88A86C6A45F13832273A66 /* Copy Bazel Outputs / Generate Bazel Dependencies (Index Build) */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Copy Bazel Outputs / Generate Bazel Dependencies (Index Build)";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -euo pipefail\n\nif [[ \"$ACTION\" == \"indexbuild\" ]]; then\n  cd \"$SRCROOT\"\n\n  \"$BAZEL_INTEGRATION_DIR/generate_index_build_bazel_dependencies.sh\"\nelse\n  \"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n    \"_BazelForcedCompile_.swift\" \\\n    \"\"\nfi\n";
+			showEnvVarsInLog = 0;
+		};
 		11A10D0B6D772419B6B0D52C /* Copy Bazel Outputs / Generate Bazel Dependencies (Index Build) */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -8625,20 +8625,21 @@
 			shellScript = "set -euo pipefail\n\nperl -pe '\n  s/__BAZEL_XCODE_DEVELOPER_DIR__/\\$(DEVELOPER_DIR)/g;\n  s/__BAZEL_XCODE_SDKROOT__/\\$(SDKROOT)/g;\n  s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/gx;\n' \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
 			showEnvVarsInLog = 0;
 		};
-		189CFBF9E08040773B706E38 /* Copy Bazel Outputs / Generate Bazel Dependencies (Index Build) */ = {
+		1309AFC648DE3412ADF9176E /* Create Compile Dependencies */ = {
 			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
+				"$(SWIFT_PARAMS_FILE)",
 			);
-			name = "Copy Bazel Outputs / Generate Bazel Dependencies (Index Build)";
+			name = "Create Compile Dependencies";
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/swift.compile.params",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -euo pipefail\n\nif [[ \"$ACTION\" == \"indexbuild\" ]]; then\n  cd \"$SRCROOT\"\n\n  \"$BAZEL_INTEGRATION_DIR/generate_index_build_bazel_dependencies.sh\"\nelse\n  \"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n    \"_BazelForcedCompile_.swift\" \\\n    \"\"\nfi\n";
+			shellScript = "set -euo pipefail\n\nperl -pe '\n  s/__BAZEL_XCODE_DEVELOPER_DIR__/\\$(DEVELOPER_DIR)/g;\n  s/__BAZEL_XCODE_SDKROOT__/\\$(SDKROOT)/g;\n  s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/gx;\n' \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
 			showEnvVarsInLog = 0;
 		};
 		18BA97D82970A5D213DDF6D6 /* Create Link Dependencies */ = {
@@ -8673,23 +8674,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -euo pipefail\n\nif [[ \"${ENABLE_PREVIEWS:-}\" == \"YES\" ]]; then\nperl -pe 's/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\nelse\n  touch \"$SCRIPT_OUTPUT_FILE_0\"\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		1FD342EE21C1E1A7F943E76E /* Create Compile Dependencies */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(SWIFT_PARAMS_FILE)",
-			);
-			name = "Create Compile Dependencies";
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/swift.compile.params",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -euo pipefail\n\nperl -pe '\n  s/__BAZEL_XCODE_DEVELOPER_DIR__/\\$(DEVELOPER_DIR)/g;\n  s/__BAZEL_XCODE_SDKROOT__/\\$(SDKROOT)/g;\n  s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/gx;\n' \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
 			showEnvVarsInLog = 0;
 		};
 		20BEB4AE7798C11A8A904F5E /* Create swift_debug_settings.py */ = {
@@ -8847,6 +8831,23 @@
 			shellScript = "set -euo pipefail\n\nperl -pe '\n  s/__BAZEL_XCODE_DEVELOPER_DIR__/\\$(DEVELOPER_DIR)/g;\n  s/__BAZEL_XCODE_SDKROOT__/\\$(SDKROOT)/g;\n  s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/gx;\n' \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
 			showEnvVarsInLog = 0;
 		};
+		2FFCBBAD00B9E490934E35CF /* Create Compile Dependencies */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(C_PARAMS_FILE)",
+			);
+			name = "Create Compile Dependencies";
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/c.compile.params",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -euo pipefail\n\nperl -pe '\n  s/__BAZEL_XCODE_DEVELOPER_DIR__/\\$(DEVELOPER_DIR)/g;\n  s/__BAZEL_XCODE_SDKROOT__/\\$(SDKROOT)/g;\n  s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/gx;\n' \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
+			showEnvVarsInLog = 0;
+		};
 		30EF458473146480255A4DCA /* Create Link Dependencies */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -8929,39 +8930,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -euo pipefail\n\nif [[ \"$ACTION\" == \"indexbuild\" ]]; then\n  cd \"$SRCROOT\"\n\n  \"$BAZEL_INTEGRATION_DIR/generate_index_build_bazel_dependencies.sh\"\nelse\n  \"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n    \"_BazelForcedCompile_.swift\" \\\n    \"$BAZEL_INTEGRATION_DIR/xctest.exclude.rsynclist\"\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		363414DFBE9EF8D9C51D3FDF /* Create Compile Dependencies */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(C_PARAMS_FILE)",
-			);
-			name = "Create Compile Dependencies";
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/c.compile.params",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -euo pipefail\n\nperl -pe '\n  s/__BAZEL_XCODE_DEVELOPER_DIR__/\\$(DEVELOPER_DIR)/g;\n  s/__BAZEL_XCODE_SDKROOT__/\\$(SDKROOT)/g;\n  s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/gx;\n' \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
-			showEnvVarsInLog = 0;
-		};
-		365C98BB517C53030BD9C423 /* Copy Bazel Outputs / Generate Bazel Dependencies (Index Build) */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Copy Bazel Outputs / Generate Bazel Dependencies (Index Build)";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -euo pipefail\n\nif [[ \"$ACTION\" == \"indexbuild\" ]]; then\n  cd \"$SRCROOT\"\n\n  \"$BAZEL_INTEGRATION_DIR/generate_index_build_bazel_dependencies.sh\"\nelse\n  \"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n    \"_BazelForcedCompile_.swift\" \\\n    \"\"\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		37A1BAB686B26E3A87FB6810 /* Create Link Dependencies */ = {
@@ -9117,22 +9085,6 @@
 			shellScript = "set -euo pipefail\n\nperl -pe '\n  s/__BAZEL_XCODE_DEVELOPER_DIR__/\\$(DEVELOPER_DIR)/g;\n  s/__BAZEL_XCODE_SDKROOT__/\\$(SDKROOT)/g;\n  s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/gx;\n' \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
 			showEnvVarsInLog = 0;
 		};
-		47BEACB636E1665B3CC96220 /* Copy Bazel Outputs / Generate Bazel Dependencies (Index Build) */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Copy Bazel Outputs / Generate Bazel Dependencies (Index Build)";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -euo pipefail\n\nif [[ \"$ACTION\" == \"indexbuild\" ]]; then\n  cd \"$SRCROOT\"\n\n  \"$BAZEL_INTEGRATION_DIR/generate_index_build_bazel_dependencies.sh\"\nelse\n  \"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n    \"_BazelForcedCompile_.swift\" \\\n    \"\"\nfi\n";
-			showEnvVarsInLog = 0;
-		};
 		49C47E4B4230B80A3F36104B /* Copy Bazel Outputs / Generate Bazel Dependencies (Index Build) */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -9151,40 +9103,6 @@
 			showEnvVarsInLog = 0;
 		};
 		4AB1DEA0DF1CB1F08FACA5A6 /* Create Compile Dependencies */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(SWIFT_PARAMS_FILE)",
-			);
-			name = "Create Compile Dependencies";
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/swift.compile.params",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -euo pipefail\n\nperl -pe '\n  s/__BAZEL_XCODE_DEVELOPER_DIR__/\\$(DEVELOPER_DIR)/g;\n  s/__BAZEL_XCODE_SDKROOT__/\\$(SDKROOT)/g;\n  s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/gx;\n' \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
-			showEnvVarsInLog = 0;
-		};
-		4C0EE567DA9EA026C8378601 /* Create Compile Dependencies */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(C_PARAMS_FILE)",
-			);
-			name = "Create Compile Dependencies";
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/c.compile.params",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -euo pipefail\n\nperl -pe '\n  s/__BAZEL_XCODE_DEVELOPER_DIR__/\\$(DEVELOPER_DIR)/g;\n  s/__BAZEL_XCODE_SDKROOT__/\\$(SDKROOT)/g;\n  s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/gx;\n' \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
-			showEnvVarsInLog = 0;
-		};
-		4E5F3802E181491A325F0F0B /* Create Compile Dependencies */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -9371,21 +9289,20 @@
 			shellScript = "set -euo pipefail\n\nif [[ \"$ACTION\" == \"indexbuild\" ]]; then\n  cd \"$SRCROOT\"\n\n  \"$BAZEL_INTEGRATION_DIR/generate_index_build_bazel_dependencies.sh\"\nelse\n  \"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n    \"_BazelForcedCompile_.swift\" \\\n    \"$BAZEL_INTEGRATION_DIR/app.exclude.rsynclist\"\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		6538360C0450B2E747E67E45 /* Create Compile Dependencies */ = {
+		6609EA0E982124D78DD73354 /* Copy Bazel Outputs / Generate Bazel Dependencies (Index Build) */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
-				"$(C_PARAMS_FILE)",
 			);
-			name = "Create Compile Dependencies";
+			name = "Copy Bazel Outputs / Generate Bazel Dependencies (Index Build)";
 			outputPaths = (
-				"$(DERIVED_FILE_DIR)/c.compile.params",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -euo pipefail\n\nperl -pe '\n  s/__BAZEL_XCODE_DEVELOPER_DIR__/\\$(DEVELOPER_DIR)/g;\n  s/__BAZEL_XCODE_SDKROOT__/\\$(SDKROOT)/g;\n  s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/gx;\n' \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
+			shellScript = "set -euo pipefail\n\nif [[ \"$ACTION\" == \"indexbuild\" ]]; then\n  cd \"$SRCROOT\"\n\n  \"$BAZEL_INTEGRATION_DIR/generate_index_build_bazel_dependencies.sh\"\nelse\n  \"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n    \"_BazelForcedCompile_.swift\" \\\n    \"\"\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		67983698B1BB9E6420AC3872 /* Create Compile Dependencies */ = {
@@ -9405,20 +9322,21 @@
 			shellScript = "set -euo pipefail\n\nperl -pe '\n  s/__BAZEL_XCODE_DEVELOPER_DIR__/\\$(DEVELOPER_DIR)/g;\n  s/__BAZEL_XCODE_SDKROOT__/\\$(SDKROOT)/g;\n  s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/gx;\n' \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
 			showEnvVarsInLog = 0;
 		};
-		6B4C5642691FC718BA2C7CB2 /* Copy Bazel Outputs / Generate Bazel Dependencies (Index Build) */ = {
+		67F03EBFBDB9535C30BB78F9 /* Create Compile Dependencies */ = {
 			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
+				"$(SWIFT_PARAMS_FILE)",
 			);
-			name = "Copy Bazel Outputs / Generate Bazel Dependencies (Index Build)";
+			name = "Create Compile Dependencies";
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/swift.compile.params",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -euo pipefail\n\nif [[ \"$ACTION\" == \"indexbuild\" ]]; then\n  cd \"$SRCROOT\"\n\n  \"$BAZEL_INTEGRATION_DIR/generate_index_build_bazel_dependencies.sh\"\nelse\n  \"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n    \"_BazelForcedCompile_.swift\" \\\n    \"\"\nfi\n";
+			shellScript = "set -euo pipefail\n\nperl -pe '\n  s/__BAZEL_XCODE_DEVELOPER_DIR__/\\$(DEVELOPER_DIR)/g;\n  s/__BAZEL_XCODE_SDKROOT__/\\$(SDKROOT)/g;\n  s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/gx;\n' \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
 			showEnvVarsInLog = 0;
 		};
 		6C69C01CB4CD65C3B941F0B6 /* Create Link Dependencies */ = {
@@ -9454,6 +9372,22 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -euo pipefail\n\nif [[ \"${ENABLE_PREVIEWS:-}\" == \"YES\" ]]; then\nperl -pe 's/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\nelse\n  touch \"$SCRIPT_OUTPUT_FILE_0\"\nfi\n\ntouch \"$SCRIPT_OUTPUT_FILE_1\"\n";
+			showEnvVarsInLog = 0;
+		};
+		7002D6187F54C28026BC9195 /* Copy Bazel Outputs / Generate Bazel Dependencies (Index Build) */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Copy Bazel Outputs / Generate Bazel Dependencies (Index Build)";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -euo pipefail\n\nif [[ \"$ACTION\" == \"indexbuild\" ]]; then\n  cd \"$SRCROOT\"\n\n  \"$BAZEL_INTEGRATION_DIR/generate_index_build_bazel_dependencies.sh\"\nelse\n  \"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n    \"_BazelForcedCompile_.swift\" \\\n    \"\"\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		755E7BFB3E956E06F2425F62 /* Create Link Dependencies */ = {
@@ -9538,6 +9472,22 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -euo pipefail\n\nif [[ \"$ACTION\" == \"indexbuild\" ]]; then\n  cd \"$SRCROOT\"\n\n  \"$BAZEL_INTEGRATION_DIR/generate_index_build_bazel_dependencies.sh\"\nelse\n  \"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n    \"_BazelForcedCompile_.swift\" \\\n    \"$BAZEL_INTEGRATION_DIR/framework.exclude.rsynclist\"\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		7CCBD0F9CFE5776C39BF5C20 /* Copy Bazel Outputs / Generate Bazel Dependencies (Index Build) */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Copy Bazel Outputs / Generate Bazel Dependencies (Index Build)";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -euo pipefail\n\nif [[ \"$ACTION\" == \"indexbuild\" ]]; then\n  cd \"$SRCROOT\"\n\n  \"$BAZEL_INTEGRATION_DIR/generate_index_build_bazel_dependencies.sh\"\nelse\n  \"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n    \"_BazelForcedCompile_.swift\" \\\n    \"\"\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		7DF5BDC46788B12AE3F38E40 /* Create Compile Dependencies */ = {
@@ -9643,23 +9593,6 @@
 			shellScript = "set -euo pipefail\n\nperl -pe '\n  s/__BAZEL_XCODE_DEVELOPER_DIR__/\\$(DEVELOPER_DIR)/g;\n  s/__BAZEL_XCODE_SDKROOT__/\\$(SDKROOT)/g;\n  s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/gx;\n' \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
 			showEnvVarsInLog = 0;
 		};
-		856EDD3A74B44D4191E475F6 /* Create Compile Dependencies */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(C_PARAMS_FILE)",
-			);
-			name = "Create Compile Dependencies";
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/c.compile.params",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -euo pipefail\n\nperl -pe '\n  s/__BAZEL_XCODE_DEVELOPER_DIR__/\\$(DEVELOPER_DIR)/g;\n  s/__BAZEL_XCODE_SDKROOT__/\\$(SDKROOT)/g;\n  s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/gx;\n' \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
-			showEnvVarsInLog = 0;
-		};
 		85D2DCFA5F937383290C1EC9 /* Copy Bazel Outputs / Generate Bazel Dependencies (Index Build) */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -9726,6 +9659,23 @@
 			shellScript = "set -euo pipefail\n\nif [[ \"$ACTION\" == \"indexbuild\" ]]; then\n  cd \"$SRCROOT\"\n\n  \"$BAZEL_INTEGRATION_DIR/generate_index_build_bazel_dependencies.sh\"\nelse\n  \"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n    \"_BazelForcedCompile_.swift\" \\\n    \"\"\nfi\n";
 			showEnvVarsInLog = 0;
 		};
+		8ADCA5248671DA9FEA435AC9 /* Create Compile Dependencies */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(C_PARAMS_FILE)",
+			);
+			name = "Create Compile Dependencies";
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/c.compile.params",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -euo pipefail\n\nperl -pe '\n  s/__BAZEL_XCODE_DEVELOPER_DIR__/\\$(DEVELOPER_DIR)/g;\n  s/__BAZEL_XCODE_SDKROOT__/\\$(SDKROOT)/g;\n  s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/gx;\n' \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
+			showEnvVarsInLog = 0;
+		};
 		8D7D98DBED97611E7EEDAD70 /* Create Compile Dependencies */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -9744,6 +9694,23 @@
 			showEnvVarsInLog = 0;
 		};
 		90096657531EFE05F65C1F64 /* Create Compile Dependencies */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SWIFT_PARAMS_FILE)",
+			);
+			name = "Create Compile Dependencies";
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/swift.compile.params",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -euo pipefail\n\nperl -pe '\n  s/__BAZEL_XCODE_DEVELOPER_DIR__/\\$(DEVELOPER_DIR)/g;\n  s/__BAZEL_XCODE_SDKROOT__/\\$(SDKROOT)/g;\n  s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/gx;\n' \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
+			showEnvVarsInLog = 0;
+		};
+		907617C445F9AC381C1A8564 /* Create Compile Dependencies */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -9995,6 +9962,38 @@
 			shellScript = "set -euo pipefail\n\nperl -pe '\n  s/__BAZEL_XCODE_DEVELOPER_DIR__/\\$(DEVELOPER_DIR)/g;\n  s/__BAZEL_XCODE_SDKROOT__/\\$(SDKROOT)/g;\n  s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/gx;\n' \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
 			showEnvVarsInLog = 0;
 		};
+		A6959C26CA80B8129A90741C /* Copy Bazel Outputs / Generate Bazel Dependencies (Index Build) */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Copy Bazel Outputs / Generate Bazel Dependencies (Index Build)";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -euo pipefail\n\nif [[ \"$ACTION\" == \"indexbuild\" ]]; then\n  cd \"$SRCROOT\"\n\n  \"$BAZEL_INTEGRATION_DIR/generate_index_build_bazel_dependencies.sh\"\nelse\n  \"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n    \"_BazelForcedCompile_.swift\" \\\n    \"\"\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		A81C07B0486885CE46CAD9AB /* Copy Bazel Outputs / Generate Bazel Dependencies (Index Build) */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Copy Bazel Outputs / Generate Bazel Dependencies (Index Build)";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -euo pipefail\n\nif [[ \"$ACTION\" == \"indexbuild\" ]]; then\n  cd \"$SRCROOT\"\n\n  \"$BAZEL_INTEGRATION_DIR/generate_index_build_bazel_dependencies.sh\"\nelse\n  \"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n    \"_BazelForcedCompile_.swift\" \\\n    \"\"\nfi\n";
+			showEnvVarsInLog = 0;
+		};
 		A854613397FB835668971607 /* Create Compile Dependencies */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -10044,6 +10043,22 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -euo pipefail\n\nif [[ \"$ACTION\" == \"indexbuild\" ]]; then\n  cd \"$SRCROOT\"\n\n  \"$BAZEL_INTEGRATION_DIR/generate_index_build_bazel_dependencies.sh\"\nelse\n  \"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n    \"_BazelForcedCompile_.swift\" \\\n    \"$BAZEL_INTEGRATION_DIR/xctest.exclude.rsynclist\"\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		ACAA071E041A82214DD3816C /* Copy Bazel Outputs / Generate Bazel Dependencies (Index Build) */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Copy Bazel Outputs / Generate Bazel Dependencies (Index Build)";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -euo pipefail\n\nif [[ \"$ACTION\" == \"indexbuild\" ]]; then\n  cd \"$SRCROOT\"\n\n  \"$BAZEL_INTEGRATION_DIR/generate_index_build_bazel_dependencies.sh\"\nelse\n  \"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n    \"_BazelForcedCompile_.swift\" \\\n    \"\"\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		B1415830A74A92B8347FE068 /* Create Compile Dependencies */ = {
@@ -10179,6 +10194,23 @@
 			shellScript = "set -euo pipefail\n\nif [[ \"${ENABLE_PREVIEWS:-}\" == \"YES\" ]]; then\nperl -pe 's/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\nelse\n  touch \"$SCRIPT_OUTPUT_FILE_0\"\nfi\n";
 			showEnvVarsInLog = 0;
 		};
+		C003CFFF13888727F7F9964C /* Create Compile Dependencies */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(C_PARAMS_FILE)",
+			);
+			name = "Create Compile Dependencies";
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/c.compile.params",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -euo pipefail\n\nperl -pe '\n  s/__BAZEL_XCODE_DEVELOPER_DIR__/\\$(DEVELOPER_DIR)/g;\n  s/__BAZEL_XCODE_SDKROOT__/\\$(SDKROOT)/g;\n  s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/gx;\n' \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
+			showEnvVarsInLog = 0;
+		};
 		C0395C7D0ADC398827F8EC81 /* Copy Bazel Outputs / Generate Bazel Dependencies (Index Build) */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -10196,7 +10228,7 @@
 			shellScript = "set -euo pipefail\n\nif [[ \"$ACTION\" == \"indexbuild\" ]]; then\n  cd \"$SRCROOT\"\n\n  \"$BAZEL_INTEGRATION_DIR/generate_index_build_bazel_dependencies.sh\"\nelse\n  \"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n    \"_BazelForcedCompile_.swift\" \\\n    \"$BAZEL_INTEGRATION_DIR/xctest.exclude.rsynclist\"\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		C253AF7633C80793612DFAFF /* Copy Bazel Outputs / Generate Bazel Dependencies (Index Build) */ = {
+		C5F35A377F859B422A254109 /* Copy Bazel Outputs / Generate Bazel Dependencies (Index Build) */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
@@ -10262,6 +10294,22 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -euo pipefail\n\nif [[ \"${ENABLE_PREVIEWS:-}\" == \"YES\" ]]; then\nperl -pe 's/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\nelse\n  touch \"$SCRIPT_OUTPUT_FILE_0\"\nfi\n\ntouch \"$SCRIPT_OUTPUT_FILE_1\"\n";
+			showEnvVarsInLog = 0;
+		};
+		CC7B932F9C3800F3EFA03049 /* Copy Bazel Outputs / Generate Bazel Dependencies (Index Build) */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Copy Bazel Outputs / Generate Bazel Dependencies (Index Build)";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -euo pipefail\n\nif [[ \"$ACTION\" == \"indexbuild\" ]]; then\n  cd \"$SRCROOT\"\n\n  \"$BAZEL_INTEGRATION_DIR/generate_index_build_bazel_dependencies.sh\"\nelse\n  \"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n    \"_BazelForcedCompile_.swift\" \\\n    \"\"\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		CD701971409C68680509A332 /* Create Link Dependencies */ = {
@@ -10331,7 +10379,7 @@
 			shellScript = "set -euo pipefail\n\nperl -pe '\n  s/__BAZEL_XCODE_DEVELOPER_DIR__/\\$(DEVELOPER_DIR)/g;\n  s/__BAZEL_XCODE_SDKROOT__/\\$(SDKROOT)/g;\n  s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/gx;\n' \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
 			showEnvVarsInLog = 0;
 		};
-		D038EF4F5844EFC906FFA41F /* Copy Bazel Outputs / Generate Bazel Dependencies (Index Build) */ = {
+		CFF2CD110CC670248822A651 /* Copy Bazel Outputs / Generate Bazel Dependencies (Index Build) */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
@@ -10348,23 +10396,6 @@
 			showEnvVarsInLog = 0;
 		};
 		D054BA9F815355F6F7B8E447 /* Create Compile Dependencies */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(SWIFT_PARAMS_FILE)",
-			);
-			name = "Create Compile Dependencies";
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/swift.compile.params",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -euo pipefail\n\nperl -pe '\n  s/__BAZEL_XCODE_DEVELOPER_DIR__/\\$(DEVELOPER_DIR)/g;\n  s/__BAZEL_XCODE_SDKROOT__/\\$(SDKROOT)/g;\n  s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/gx;\n' \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
-			showEnvVarsInLog = 0;
-		};
-		D2ED38335D54C2EBC917B420 /* Create Compile Dependencies */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -10415,23 +10446,6 @@
 			shellScript = "set -euo pipefail\n\nif [[ \"$ACTION\" == \"indexbuild\" ]]; then\n  cd \"$SRCROOT\"\n\n  \"$BAZEL_INTEGRATION_DIR/generate_index_build_bazel_dependencies.sh\"\nelse\n  \"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n    \"_BazelForcedCompile_.swift\" \\\n    \"$BAZEL_INTEGRATION_DIR/framework.exclude.rsynclist\"\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		D69871BA5CBBA0DDDAD885AC /* Create Compile Dependencies */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(SWIFT_PARAMS_FILE)",
-			);
-			name = "Create Compile Dependencies";
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/swift.compile.params",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -euo pipefail\n\nperl -pe '\n  s/__BAZEL_XCODE_DEVELOPER_DIR__/\\$(DEVELOPER_DIR)/g;\n  s/__BAZEL_XCODE_SDKROOT__/\\$(SDKROOT)/g;\n  s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/gx;\n' \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
-			showEnvVarsInLog = 0;
-		};
 		D7E098A26D0F2D038D474228 /* Create Compile Dependencies */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -10447,22 +10461,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -euo pipefail\n\nperl -pe '\n  s/__BAZEL_XCODE_DEVELOPER_DIR__/\\$(DEVELOPER_DIR)/g;\n  s/__BAZEL_XCODE_SDKROOT__/\\$(SDKROOT)/g;\n  s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/gx;\n' \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
-			showEnvVarsInLog = 0;
-		};
-		D90624BD492C95DBF1652C56 /* Copy Bazel Outputs / Generate Bazel Dependencies (Index Build) */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Copy Bazel Outputs / Generate Bazel Dependencies (Index Build)";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -euo pipefail\n\nif [[ \"$ACTION\" == \"indexbuild\" ]]; then\n  cd \"$SRCROOT\"\n\n  \"$BAZEL_INTEGRATION_DIR/generate_index_build_bazel_dependencies.sh\"\nelse\n  \"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n    \"_BazelForcedCompile_.swift\" \\\n    \"\"\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		DAA1A46D15045C0F095C999A /* Create Compile Dependencies */ = {
@@ -10482,20 +10480,38 @@
 			shellScript = "set -euo pipefail\n\nperl -pe '\n  s/__BAZEL_XCODE_DEVELOPER_DIR__/\\$(DEVELOPER_DIR)/g;\n  s/__BAZEL_XCODE_SDKROOT__/\\$(SDKROOT)/g;\n  s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/gx;\n' \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
 			showEnvVarsInLog = 0;
 		};
-		DAF86BA209B12A4403427CE4 /* Copy Bazel Outputs / Generate Bazel Dependencies (Index Build) */ = {
+		DAFD205B312D6E2CCB295938 /* Create Compile Dependencies */ = {
 			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
+				"$(SWIFT_PARAMS_FILE)",
 			);
-			name = "Copy Bazel Outputs / Generate Bazel Dependencies (Index Build)";
+			name = "Create Compile Dependencies";
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/swift.compile.params",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -euo pipefail\n\nif [[ \"$ACTION\" == \"indexbuild\" ]]; then\n  cd \"$SRCROOT\"\n\n  \"$BAZEL_INTEGRATION_DIR/generate_index_build_bazel_dependencies.sh\"\nelse\n  \"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n    \"_BazelForcedCompile_.swift\" \\\n    \"\"\nfi\n";
+			shellScript = "set -euo pipefail\n\nperl -pe '\n  s/__BAZEL_XCODE_DEVELOPER_DIR__/\\$(DEVELOPER_DIR)/g;\n  s/__BAZEL_XCODE_SDKROOT__/\\$(SDKROOT)/g;\n  s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/gx;\n' \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
+			showEnvVarsInLog = 0;
+		};
+		DB6432041F4AE470B743AD35 /* Create Compile Dependencies */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(C_PARAMS_FILE)",
+			);
+			name = "Create Compile Dependencies";
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/c.compile.params",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -euo pipefail\n\nperl -pe '\n  s/__BAZEL_XCODE_DEVELOPER_DIR__/\\$(DEVELOPER_DIR)/g;\n  s/__BAZEL_XCODE_SDKROOT__/\\$(SDKROOT)/g;\n  s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/gx;\n' \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
 			showEnvVarsInLog = 0;
 		};
 		DE57386042D4F22AE2A87245 /* Create Link Dependencies */ = {
@@ -10581,22 +10597,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -euo pipefail\n\nif [[ \"${ENABLE_PREVIEWS:-}\" == \"YES\" ]]; then\nperl -pe 's/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\nelse\n  touch \"$SCRIPT_OUTPUT_FILE_0\"\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		E44442B489982329C2B21628 /* Copy Bazel Outputs / Generate Bazel Dependencies (Index Build) */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Copy Bazel Outputs / Generate Bazel Dependencies (Index Build)";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -euo pipefail\n\nif [[ \"$ACTION\" == \"indexbuild\" ]]; then\n  cd \"$SRCROOT\"\n\n  \"$BAZEL_INTEGRATION_DIR/generate_index_build_bazel_dependencies.sh\"\nelse\n  \"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n    \"_BazelForcedCompile_.swift\" \\\n    \"\"\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		E5B075768AAACDAA9F674380 /* Create Link Dependencies */ = {
@@ -10717,23 +10717,6 @@
 			shellScript = "set -euo pipefail\n\nif [[ \"${ENABLE_PREVIEWS:-}\" == \"YES\" ]]; then\nperl -pe 's/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\nelse\n  touch \"$SCRIPT_OUTPUT_FILE_0\"\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		F2EB51DD642BA8DEE5C8ACEB /* Create Compile Dependencies */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(C_PARAMS_FILE)",
-			);
-			name = "Create Compile Dependencies";
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/c.compile.params",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -euo pipefail\n\nperl -pe '\n  s/__BAZEL_XCODE_DEVELOPER_DIR__/\\$(DEVELOPER_DIR)/g;\n  s/__BAZEL_XCODE_SDKROOT__/\\$(SDKROOT)/g;\n  s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/gx;\n' \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
-			showEnvVarsInLog = 0;
-		};
 		F3296BEE0C260DD20BABFD11 /* Create Compile Dependencies */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -10818,6 +10801,23 @@
 			shellScript = "set -euo pipefail\n\nif [[ \"$ACTION\" == \"indexbuild\" ]]; then\n  cd \"$SRCROOT\"\n\n  \"$BAZEL_INTEGRATION_DIR/generate_index_build_bazel_dependencies.sh\"\nelse\n  \"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n    \"_BazelForcedCompile_.swift\" \\\n    \"$BAZEL_INTEGRATION_DIR/xctest.exclude.rsynclist\"\nfi\n";
 			showEnvVarsInLog = 0;
 		};
+		F7839F8EDC269ABB0E81418F /* Create Compile Dependencies */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(C_PARAMS_FILE)",
+			);
+			name = "Create Compile Dependencies";
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/c.compile.params",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -euo pipefail\n\nperl -pe '\n  s/__BAZEL_XCODE_DEVELOPER_DIR__/\\$(DEVELOPER_DIR)/g;\n  s/__BAZEL_XCODE_SDKROOT__/\\$(SDKROOT)/g;\n  s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/gx;\n' \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
+			showEnvVarsInLog = 0;
+		};
 		F99125C784B3739144A6F3A9 /* Create Compile Dependencies */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -10855,6 +10855,14 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		04DC4F217A7376A4EB57AFAA /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				89A6056E7F7BDFDBB8048BD3 /* lib.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		11F55043033A5E7E8C4F3F0A /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -10863,27 +10871,19 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		16C57B6813982BA852B1DC27 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				B0A54DD90110037219C3C057 /* private_lib.c in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		1DE1786D634C55CD11A2F1A9 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				0D7889713AE97EEA494CD3C0 /* lib.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		1F746A1B44018EB020FE3D80 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				0F10E1E66B5D243245850C73 /* main.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		203C4740029337A54CEB13F6 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				492B70FA876AE0B3F3F500DF /* private_lib.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -10935,19 +10935,11 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		3C871AC71A78BCAFE422D28A /* Sources */ = {
+		3EEA10CC7DEB136A20CEB353 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BAF99126980CD484309719A4 /* private_lib.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		427FA4B21CC21CDEEE4E3634 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				64E43A57A15DFF1E63E7FAB2 /* lib.m in Sources */,
+				4343DBC50C9579E39E490AD8 /* c_lib.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -10975,6 +10967,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		47FEB5AD087B4CC4AA8943D3 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				29BD1379FB12A3ADCDA231B8 /* private_lib.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		49E604CF100EF12B62E4F2B0 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -10992,14 +10992,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				E66604D967169C5470384FC1 /* ObjCUnitTests.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		4CEAB55F4A77E8482323A6CB /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				7A499297D96A6AFD86796FE7 /* private_lib.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11073,6 +11065,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		6FF754472620C7CFAD73E960 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9AA0B7A728BC3540C82A0233 /* private_lib.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		7100FB0210568CEE273028F6 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -11107,6 +11107,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		8634EFAC486E5A18A0974652 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9897D64B431508F971871AA4 /* lib.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		8C852A596739FBD5C4896574 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -11123,14 +11131,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		923A8E52654BC7B577C7D5F7 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				5ECAEC810B3886023A0B9EE3 /* c_lib.c in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		92DE4E832DB82B983FAA0764 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -11139,11 +11139,11 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		94CBFC39B171BAC478B80709 /* Sources */ = {
+		9E3BB66234A48E11EE3C8E6A /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E556150B5BC80DD08DE2D5F1 /* private_lib.swift in Sources */,
+				55C9079E7A44D7276DF79A75 /* lib.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11172,11 +11172,11 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		AA561124335F9162478F39CA /* Sources */ = {
+		A723B300F5109BC6204F82F4 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0CF2EB07A5AC19DFEC6C708E /* c_lib.c in Sources */,
+				9B2597590521D97B08B66AAC /* lib.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11257,19 +11257,11 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		EAE59CBC633B8156A84181CE /* Sources */ = {
+		EF5D5262A2C0572A833928CA /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DC95ED13C69EF1FC531D1F99 /* lib.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		EBEF5ECD48B6BF0A5832EDE7 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				7B4DA1AE3F4852E55D4FE590 /* lib.swift in Sources */,
+				8BABF1F079754DE7B03C028C /* private_lib.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11305,6 +11297,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		F80DDFB34575642F1A3BC7CB /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				71D56384656A4E3A9E5EA030 /* c_lib.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F90AB663AB242C7317551B94 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -11334,6 +11334,12 @@
 			name = macOSApp;
 			target = AE02B41E521B2C6360C30D20 /* macOSApp */;
 			targetProxy = 7699AD76B28DC4F10D3E2421 /* PBXContainerItemProxy */;
+		};
+		0AB2CBDB52D47D2E2F987BC6 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = BazelDependencies;
+			target = 7E7D155EBCA520F35DEA3571 /* BazelDependencies */;
+			targetProxy = C2602A62CCDF8F5D34A14650 /* PBXContainerItemProxy */;
 		};
 		0E37CB141FC60EFF528BACC9 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -11365,23 +11371,17 @@
 			target = 7E7D155EBCA520F35DEA3571 /* BazelDependencies */;
 			targetProxy = 334E33C35297EDCE3D14FD82 /* PBXContainerItemProxy */;
 		};
-		143C87FA1F48A4230E84C240 /* PBXTargetDependency */ = {
+		19843D1FC5183FA844238927 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = BazelDependencies;
 			target = 7E7D155EBCA520F35DEA3571 /* BazelDependencies */;
-			targetProxy = 0BAF583DC95C1BEED58E1DE8 /* PBXContainerItemProxy */;
+			targetProxy = F1C96B97D5B069ECE75DC735 /* PBXContainerItemProxy */;
 		};
 		216ACAA73877561C3F7572A9 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = tvOSApp;
 			target = ACEF2F653E0F6BEA37D2C7B6 /* tvOSApp */;
 			targetProxy = EE7E8B6AE1E795335A7051CB /* PBXContainerItemProxy */;
-		};
-		21EEFAD4C485BD5BC41791A6 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = BazelDependencies;
-			target = 7E7D155EBCA520F35DEA3571 /* BazelDependencies */;
-			targetProxy = EAD5378EECD89ECFD779837A /* PBXContainerItemProxy */;
 		};
 		24DB9924D58A426ABF3035C3 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -11395,11 +11395,17 @@
 			target = 7E7D155EBCA520F35DEA3571 /* BazelDependencies */;
 			targetProxy = 815C265E0DA2C8EFF7408A27 /* PBXContainerItemProxy */;
 		};
-		2CAE8DA0DAE2792B7DD04042 /* PBXTargetDependency */ = {
+		2E050975756DCCF33CBBD88C /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = BazelDependencies;
 			target = 7E7D155EBCA520F35DEA3571 /* BazelDependencies */;
-			targetProxy = A24415F7D745F5A414B35FBB /* PBXContainerItemProxy */;
+			targetProxy = 6F86637C70D750078F5DED1D /* PBXContainerItemProxy */;
+		};
+		2FCEEDAD536917EDBBC3E451 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = BazelDependencies;
+			target = 7E7D155EBCA520F35DEA3571 /* BazelDependencies */;
+			targetProxy = D5E7F3561DDA3FC5BC934F63 /* PBXContainerItemProxy */;
 		};
 		33BA16F607DA61F43E6C9597 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -11412,6 +11418,12 @@
 			name = BazelDependencies;
 			target = 7E7D155EBCA520F35DEA3571 /* BazelDependencies */;
 			targetProxy = EF32126AD0F7C7C0F95407EC /* PBXContainerItemProxy */;
+		};
+		39B8157633C6750E72D5EBF2 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = BazelDependencies;
+			target = 7E7D155EBCA520F35DEA3571 /* BazelDependencies */;
+			targetProxy = 323FC9FEBDFC31B4801836DB /* PBXContainerItemProxy */;
 		};
 		42955B98D55F02972C1C0908 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -11473,11 +11485,17 @@
 			target = 7E7D155EBCA520F35DEA3571 /* BazelDependencies */;
 			targetProxy = F5E9D31D539D4E97AACBE385 /* PBXContainerItemProxy */;
 		};
-		62C7B2B5AC25806A9D31559E /* PBXTargetDependency */ = {
+		677F56A9D9089663A5834EC7 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = BazelDependencies;
 			target = 7E7D155EBCA520F35DEA3571 /* BazelDependencies */;
-			targetProxy = 9D3DA7890C0D51F4BA83D3F2 /* PBXContainerItemProxy */;
+			targetProxy = E8C51C6976E6333DE99FE506 /* PBXContainerItemProxy */;
+		};
+		6C22CBC259EA0CC6DB5E45F3 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = BazelDependencies;
+			target = 7E7D155EBCA520F35DEA3571 /* BazelDependencies */;
+			targetProxy = 4EF5793E0066E245ED58ECED /* PBXContainerItemProxy */;
 		};
 		739B225CF815B8C8C47146F7 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -11533,6 +11551,12 @@
 			target = 7E7D155EBCA520F35DEA3571 /* BazelDependencies */;
 			targetProxy = 936C731BDC2BAF97738C187A /* PBXContainerItemProxy */;
 		};
+		93CDA115ED33747E41A86002 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = BazelDependencies;
+			target = 7E7D155EBCA520F35DEA3571 /* BazelDependencies */;
+			targetProxy = BE38CC9065EB6D0AF75837F4 /* PBXContainerItemProxy */;
+		};
 		96160E1B8AE0CFB0577BE6A9 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = BazelDependencies;
@@ -11544,12 +11568,6 @@
 			name = BazelDependencies;
 			target = 7E7D155EBCA520F35DEA3571 /* BazelDependencies */;
 			targetProxy = FCF9E5BF1611C5A1EC3C9302 /* PBXContainerItemProxy */;
-		};
-		9D84C0968ECA2C9568083024 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = BazelDependencies;
-			target = 7E7D155EBCA520F35DEA3571 /* BazelDependencies */;
-			targetProxy = 893869D083BA5BB2CD24EFC8 /* PBXContainerItemProxy */;
 		};
 		A3FA33D2339398D7EF50574C /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -11569,29 +11587,17 @@
 			target = 7E7D155EBCA520F35DEA3571 /* BazelDependencies */;
 			targetProxy = 002C813E6768FE3D1961BAA5 /* PBXContainerItemProxy */;
 		};
-		AC914D5BB4301A9E45BA68B8 /* PBXTargetDependency */ = {
+		A7521604745892D90C67F7BA /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = BazelDependencies;
 			target = 7E7D155EBCA520F35DEA3571 /* BazelDependencies */;
-			targetProxy = 9B6E8E6D94991D5DF0FB0336 /* PBXContainerItemProxy */;
-		};
-		ACC5BE11082168E94DC3FB70 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = BazelDependencies;
-			target = 7E7D155EBCA520F35DEA3571 /* BazelDependencies */;
-			targetProxy = B047048EA4CF625A40036808 /* PBXContainerItemProxy */;
+			targetProxy = 1CC7591B03DA965A7011F1D8 /* PBXContainerItemProxy */;
 		};
 		B040424B8F138957D0E22A3D /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = BazelDependencies;
 			target = 7E7D155EBCA520F35DEA3571 /* BazelDependencies */;
 			targetProxy = 8B8EB48B9E8241F59FEC2E8A /* PBXContainerItemProxy */;
-		};
-		B2285BAE9AFCBFE8120B55B1 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = BazelDependencies;
-			target = 7E7D155EBCA520F35DEA3571 /* BazelDependencies */;
-			targetProxy = 909807B6ECA663409845A82C /* PBXContainerItemProxy */;
 		};
 		B7E9DB92193A8D7F82B0C0CB /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -11616,18 +11622,6 @@
 			name = BazelDependencies;
 			target = 7E7D155EBCA520F35DEA3571 /* BazelDependencies */;
 			targetProxy = 48A06F53FB95F16B34C5A3B4 /* PBXContainerItemProxy */;
-		};
-		C58F4BAFFA37250334C86FE8 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = BazelDependencies;
-			target = 7E7D155EBCA520F35DEA3571 /* BazelDependencies */;
-			targetProxy = 9607287A4BA58348EDA824CB /* PBXContainerItemProxy */;
-		};
-		C73AD8C9C493E5909101C287 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = BazelDependencies;
-			target = 7E7D155EBCA520F35DEA3571 /* BazelDependencies */;
-			targetProxy = C37430805EB5FC228F053FCE /* PBXContainerItemProxy */;
 		};
 		C9C9DADA79BC31148CA0E926 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -11694,6 +11688,12 @@
 			name = BazelDependencies;
 			target = 7E7D155EBCA520F35DEA3571 /* BazelDependencies */;
 			targetProxy = 9DBF02CAC6C6AC4B7C3505BA /* PBXContainerItemProxy */;
+		};
+		E5B1586D18484914FA681087 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = BazelDependencies;
+			target = 7E7D155EBCA520F35DEA3571 /* BazelDependencies */;
+			targetProxy = 8B378D053F6D1CF801115643 /* PBXContainerItemProxy */;
 		};
 		E5FE011C5AF76DB113DF642E /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -11794,27 +11794,28 @@
 			};
 			name = AppStore;
 		};
-		0174EB2E3EF79496ECE60688 /* Debug */ = {
+		028C6B01F864D3D6DE8C830E /* AppStore */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
-				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:lib_swift";
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35/bin/CommandLine/CommandLineToolLib";
-				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:lib_swift macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35";
+				ASAN_OTHER_CFLAGS__ = "$(ASAN_OTHER_CFLAGS__NO)";
+				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) -ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/c.compile.params";
+				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
+				BAZEL_LABEL = "@//CommandLine/swift_c_module:c_lib";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38/bin/CommandLine/swift_c_module";
+				BAZEL_TARGET_ID = "//CommandLine/swift_c_module:c_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38";
 				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
-				COMPILE_TARGET_NAME = lib_swift;
+				COMPILE_TARGET_NAME = c_lib;
+				C_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38/bin/CommandLine/swift_c_module/c_lib.rules_xcodeproj.c.compile.params";
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				OTHER_SWIFT_FLAGS = "-Xcc -working-directory -Xcc $(PROJECT_DIR) -working-directory $(PROJECT_DIR) -Xcc -ivfsoverlay -Xcc $(OBJROOT)/bazel-out-overlay.yaml -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/swift.compile.params -I$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35/bin/CommandLine/CommandLineToolLib -F$(BAZEL_EXTERNAL)/examples_command_line_external";
-				PRODUCT_MODULE_NAME = LibSwift;
-				PRODUCT_NAME = lib_swift;
+				OTHER_CFLAGS = "$(ASAN_OTHER_CFLAGS__$(CLANG_ADDRESS_SANITIZER))";
+				PRODUCT_NAME = c_lib;
 				SDKROOT = macosx;
 				SUPPORTED_PLATFORMS = macosx;
-				SWIFT_OBJC_INTERFACE_HEADER_NAME = "private/LibSwift-Swift.h";
-				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35/bin/CommandLine/CommandLineToolLib/lib_swift.rules_xcodeproj.swift.compile.params";
-				TARGET_NAME = lib_swift;
+				TARGET_NAME = c_lib;
 			};
-			name = Debug;
+			name = AppStore;
 		};
 		0385CFC849BD643C77E5ED19 /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -12061,6 +12062,29 @@
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				TARGETED_DEVICE_FAMILY = 1;
 				TARGET_NAME = iOS;
+			};
+			name = Debug;
+		};
+		0A1FF83C1814537445CDCE99 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				ASAN_OTHER_CFLAGS__ = "$(ASAN_OTHER_CFLAGS__NO)";
+				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) -ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/c.compile.params";
+				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
+				BAZEL_LABEL = "@//CommandLine/swift_c_module:c_lib";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/CommandLine/swift_c_module";
+				BAZEL_TARGET_ID = "//CommandLine/swift_c_module:c_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
+				COMPILE_TARGET_NAME = c_lib;
+				C_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/CommandLine/swift_c_module/c_lib.rules_xcodeproj.c.compile.params";
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				OTHER_CFLAGS = "$(ASAN_OTHER_CFLAGS__$(CLANG_ADDRESS_SANITIZER))";
+				PRODUCT_NAME = c_lib;
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				TARGET_NAME = c_lib;
 			};
 			name = Debug;
 		};
@@ -12316,6 +12340,52 @@
 				TARGET_NAME = TestingUtils;
 			};
 			name = Debug;
+		};
+		1BAC8A32FA5F4F54029BE31B /* AppStore */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				ASAN_OTHER_CFLAGS__ = "$(ASAN_OTHER_CFLAGS__NO)";
+				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) -ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/c.compile.params";
+				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
+				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:lib_impl";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36/bin/CommandLine/CommandLineToolLib";
+				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:lib_impl macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
+				COMPILE_TARGET_NAME = lib_impl;
+				C_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36/bin/CommandLine/CommandLineToolLib/lib_impl.rules_xcodeproj.c.compile.params";
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				OTHER_CFLAGS = "$(ASAN_OTHER_CFLAGS__$(CLANG_ADDRESS_SANITIZER))";
+				PRODUCT_NAME = lib_impl;
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				TARGET_NAME = lib_impl;
+			};
+			name = AppStore;
+		};
+		206A2C6CF6BBDFE4B54218B4 /* AppStore */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				ASAN_OTHER_CFLAGS__ = "$(ASAN_OTHER_CFLAGS__NO)";
+				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) -ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/c.compile.params";
+				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
+				BAZEL_LABEL = "@//CommandLine/swift_c_module:c_lib";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36/bin/CommandLine/swift_c_module";
+				BAZEL_TARGET_ID = "//CommandLine/swift_c_module:c_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
+				COMPILE_TARGET_NAME = c_lib;
+				C_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36/bin/CommandLine/swift_c_module/c_lib.rules_xcodeproj.c.compile.params";
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				OTHER_CFLAGS = "$(ASAN_OTHER_CFLAGS__$(CLANG_ADDRESS_SANITIZER))";
+				PRODUCT_NAME = c_lib;
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				TARGET_NAME = c_lib;
+			};
+			name = AppStore;
 		};
 		20B7DDF18B9D9BC947F83A78 /* AppStore */ = {
 			isa = XCBuildConfiguration;
@@ -12591,6 +12661,29 @@
 			};
 			name = AppStore;
 		};
+		2CD3B4F96957BFA9EB0E1275 /* AppStore */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				ASAN_OTHER_CFLAGS__ = "$(ASAN_OTHER_CFLAGS__NO)";
+				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) -ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/c.compile.params";
+				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
+				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:private_lib";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38/bin/CommandLine/CommandLineToolLib";
+				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:private_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
+				COMPILE_TARGET_NAME = private_lib;
+				C_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38/bin/CommandLine/CommandLineToolLib/private_lib.rules_xcodeproj.c.compile.params";
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				OTHER_CFLAGS = "$(ASAN_OTHER_CFLAGS__$(CLANG_ADDRESS_SANITIZER))";
+				PRODUCT_NAME = private_lib;
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				TARGET_NAME = private_lib;
+			};
+			name = AppStore;
+		};
 		2FF3D262DB16899B5E086153 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -12841,6 +12934,28 @@
 			};
 			name = Debug;
 		};
+		36BD0C03CA24148A7B8020BB /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:lib_swift";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/CommandLine/CommandLineToolLib";
+				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:lib_swift macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
+				COMPILE_TARGET_NAME = lib_swift;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				OTHER_SWIFT_FLAGS = "-Xcc -working-directory -Xcc $(PROJECT_DIR) -working-directory $(PROJECT_DIR) -Xcc -ivfsoverlay -Xcc $(OBJROOT)/bazel-out-overlay.yaml -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/swift.compile.params -I$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/CommandLine/CommandLineToolLib -F$(BAZEL_EXTERNAL)/examples_command_line_external";
+				PRODUCT_MODULE_NAME = LibSwift;
+				PRODUCT_NAME = lib_swift;
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "private/LibSwift-Swift.h";
+				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/CommandLine/CommandLineToolLib/lib_swift.rules_xcodeproj.swift.compile.params";
+				TARGET_NAME = lib_swift;
+			};
+			name = Debug;
+		};
 		395552AF763821AA24020045 /* AppStore */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -12876,6 +12991,29 @@
 				TARGET_NAME = CommandLineTool;
 			};
 			name = AppStore;
+		};
+		3B5081F64B422DC060EBE720 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				ASAN_OTHER_CFLAGS__ = "$(ASAN_OTHER_CFLAGS__NO)";
+				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) -ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/c.compile.params";
+				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
+				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:lib_impl";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/CommandLine/CommandLineToolLib";
+				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:lib_impl macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
+				COMPILE_TARGET_NAME = lib_impl;
+				C_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/CommandLine/CommandLineToolLib/lib_impl.rules_xcodeproj.c.compile.params";
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				OTHER_CFLAGS = "$(ASAN_OTHER_CFLAGS__$(CLANG_ADDRESS_SANITIZER))";
+				PRODUCT_NAME = lib_impl;
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				TARGET_NAME = lib_impl;
+			};
+			name = Debug;
 		};
 		3CEC82A4D8115D22902AB91F /* AppStore */ = {
 			isa = XCBuildConfiguration;
@@ -13195,51 +13333,26 @@
 			};
 			name = Debug;
 		};
-		486DCB7BFCA19245D09582D3 /* AppStore */ = {
+		478C7B8A91269BF13AF95DE4 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
-				ASAN_OTHER_CFLAGS__ = "$(ASAN_OTHER_CFLAGS__NO)";
-				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) -ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/c.compile.params";
-				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
-				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:lib_impl";
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38/bin/CommandLine/CommandLineToolLib";
-				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:lib_impl macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38";
+				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:private_swift_lib";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35/bin/CommandLine/CommandLineToolLib";
+				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:private_swift_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35";
 				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
-				COMPILE_TARGET_NAME = lib_impl;
-				C_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38/bin/CommandLine/CommandLineToolLib/lib_impl.rules_xcodeproj.c.compile.params";
+				COMPILE_TARGET_NAME = private_swift_lib;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				OTHER_CFLAGS = "$(ASAN_OTHER_CFLAGS__$(CLANG_ADDRESS_SANITIZER))";
-				PRODUCT_NAME = lib_impl;
+				OTHER_SWIFT_FLAGS = "-Xcc -working-directory -Xcc $(PROJECT_DIR) -working-directory $(PROJECT_DIR) -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/swift.compile.params";
+				PRODUCT_MODULE_NAME = _SwiftLib;
+				PRODUCT_NAME = private_swift_lib;
 				SDKROOT = macosx;
 				SUPPORTED_PLATFORMS = macosx;
-				TARGET_NAME = lib_impl;
+				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35/bin/CommandLine/CommandLineToolLib/private_swift_lib.rules_xcodeproj.swift.compile.params";
+				TARGET_NAME = private_swift_lib;
 			};
-			name = AppStore;
-		};
-		491089F252D7FA8E5CD46925 /* AppStore */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = x86_64;
-				ASAN_OTHER_CFLAGS__ = "$(ASAN_OTHER_CFLAGS__NO)";
-				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) -ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/c.compile.params";
-				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
-				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:private_lib";
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38/bin/CommandLine/CommandLineToolLib";
-				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:private_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38";
-				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
-				COMPILE_TARGET_NAME = private_lib;
-				C_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38/bin/CommandLine/CommandLineToolLib/private_lib.rules_xcodeproj.c.compile.params";
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				OTHER_CFLAGS = "$(ASAN_OTHER_CFLAGS__$(CLANG_ADDRESS_SANITIZER))";
-				PRODUCT_NAME = private_lib;
-				SDKROOT = macosx;
-				SUPPORTED_PLATFORMS = macosx;
-				TARGET_NAME = private_lib;
-			};
-			name = AppStore;
+			name = Debug;
 		};
 		4A783B223C0966FC856C1212 /* AppStore */ = {
 			isa = XCBuildConfiguration;
@@ -13312,6 +13425,29 @@
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-30/bin/macOSApp/Source/macOSApp.library.rules_xcodeproj.swift.compile.params";
 				TARGET_NAME = macOSApp;
+			};
+			name = AppStore;
+		};
+		4C31D7CE23BE1E320DDFF3E0 /* AppStore */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				ASAN_OTHER_CFLAGS__ = "$(ASAN_OTHER_CFLAGS__NO)";
+				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) -ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/c.compile.params";
+				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
+				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:lib_impl";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38/bin/CommandLine/CommandLineToolLib";
+				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:lib_impl macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
+				COMPILE_TARGET_NAME = lib_impl;
+				C_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38/bin/CommandLine/CommandLineToolLib/lib_impl.rules_xcodeproj.c.compile.params";
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				OTHER_CFLAGS = "$(ASAN_OTHER_CFLAGS__$(CLANG_ADDRESS_SANITIZER))";
+				PRODUCT_NAME = lib_impl;
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				TARGET_NAME = lib_impl;
 			};
 			name = AppStore;
 		};
@@ -13413,26 +13549,24 @@
 			};
 			name = Debug;
 		};
-		50D758CD825A271682A8CC6A /* Debug */ = {
+		526DB0D50803BE1C4EFAD3D0 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
-				ASAN_OTHER_CFLAGS__ = "$(ASAN_OTHER_CFLAGS__NO)";
-				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) -ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/c.compile.params";
-				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
-				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:lib_impl";
+				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:private_swift_lib";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/CommandLine/CommandLineToolLib";
-				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:lib_impl macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33";
+				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:private_swift_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33";
 				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
-				COMPILE_TARGET_NAME = lib_impl;
-				C_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/CommandLine/CommandLineToolLib/lib_impl.rules_xcodeproj.c.compile.params";
+				COMPILE_TARGET_NAME = private_swift_lib;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				OTHER_CFLAGS = "$(ASAN_OTHER_CFLAGS__$(CLANG_ADDRESS_SANITIZER))";
-				PRODUCT_NAME = lib_impl;
+				OTHER_SWIFT_FLAGS = "-Xcc -working-directory -Xcc $(PROJECT_DIR) -working-directory $(PROJECT_DIR) -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/swift.compile.params";
+				PRODUCT_MODULE_NAME = _SwiftLib;
+				PRODUCT_NAME = private_swift_lib;
 				SDKROOT = macosx;
 				SUPPORTED_PLATFORMS = macosx;
-				TARGET_NAME = lib_impl;
+				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/CommandLine/CommandLineToolLib/private_swift_lib.rules_xcodeproj.swift.compile.params";
+				TARGET_NAME = private_swift_lib;
 			};
 			name = Debug;
 		};
@@ -13569,29 +13703,6 @@
 				TVOS_DEPLOYMENT_TARGET = 15.0;
 			};
 			name = Debug;
-		};
-		540DA483A81C38DCEF978A66 /* AppStore */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = x86_64;
-				ASAN_OTHER_CFLAGS__ = "$(ASAN_OTHER_CFLAGS__NO)";
-				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) -ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/c.compile.params";
-				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
-				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:private_lib";
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36/bin/CommandLine/CommandLineToolLib";
-				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:private_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36";
-				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
-				COMPILE_TARGET_NAME = private_lib;
-				C_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36/bin/CommandLine/CommandLineToolLib/private_lib.rules_xcodeproj.c.compile.params";
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				OTHER_CFLAGS = "$(ASAN_OTHER_CFLAGS__$(CLANG_ADDRESS_SANITIZER))";
-				PRODUCT_NAME = private_lib;
-				SDKROOT = macosx;
-				SUPPORTED_PLATFORMS = macosx;
-				TARGET_NAME = private_lib;
-			};
-			name = AppStore;
 		};
 		5464E63AC3D4444D08433CA3 /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -14052,28 +14163,6 @@
 			};
 			name = AppStore;
 		};
-		670BF2EC610F52839CE05B88 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = x86_64;
-				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:lib_swift";
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/CommandLine/CommandLineToolLib";
-				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:lib_swift macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33";
-				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
-				COMPILE_TARGET_NAME = lib_swift;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				OTHER_SWIFT_FLAGS = "-Xcc -working-directory -Xcc $(PROJECT_DIR) -working-directory $(PROJECT_DIR) -Xcc -ivfsoverlay -Xcc $(OBJROOT)/bazel-out-overlay.yaml -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/swift.compile.params -I$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/CommandLine/CommandLineToolLib -F$(BAZEL_EXTERNAL)/examples_command_line_external";
-				PRODUCT_MODULE_NAME = LibSwift;
-				PRODUCT_NAME = lib_swift;
-				SDKROOT = macosx;
-				SUPPORTED_PLATFORMS = macosx;
-				SWIFT_OBJC_INTERFACE_HEADER_NAME = "private/LibSwift-Swift.h";
-				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/CommandLine/CommandLineToolLib/lib_swift.rules_xcodeproj.swift.compile.params";
-				TARGET_NAME = lib_swift;
-			};
-			name = Debug;
-		};
 		6A00F7C783BDE7426CFD2865 /* AppStore */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -14134,6 +14223,28 @@
 				"SWIFT_PARAMS_FILE[sdk=iphoneos*]" = "$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-10/bin/UI/UI.rules_xcodeproj.swift.compile.params";
 				TARGETED_DEVICE_FAMILY = 1;
 				TARGET_NAME = UIFramework.iOS;
+			};
+			name = AppStore;
+		};
+		6B731E0B2CC960052B9FC2DC /* AppStore */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:private_swift_lib";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36/bin/CommandLine/CommandLineToolLib";
+				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:private_swift_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
+				COMPILE_TARGET_NAME = private_swift_lib;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				OTHER_SWIFT_FLAGS = "-Xcc -working-directory -Xcc $(PROJECT_DIR) -working-directory $(PROJECT_DIR) -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/swift.compile.params";
+				PRODUCT_MODULE_NAME = _SwiftLib;
+				PRODUCT_NAME = private_swift_lib;
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36/bin/CommandLine/CommandLineToolLib/private_swift_lib.rules_xcodeproj.swift.compile.params";
+				TARGET_NAME = private_swift_lib;
 			};
 			name = AppStore;
 		};
@@ -14223,6 +14334,28 @@
 			};
 			name = Debug;
 		};
+		715E16DDD4A8A3B690069FF5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:lib_swift";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35/bin/CommandLine/CommandLineToolLib";
+				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:lib_swift macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
+				COMPILE_TARGET_NAME = lib_swift;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				OTHER_SWIFT_FLAGS = "-Xcc -working-directory -Xcc $(PROJECT_DIR) -working-directory $(PROJECT_DIR) -Xcc -ivfsoverlay -Xcc $(OBJROOT)/bazel-out-overlay.yaml -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/swift.compile.params -I$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35/bin/CommandLine/CommandLineToolLib -F$(BAZEL_EXTERNAL)/examples_command_line_external";
+				PRODUCT_MODULE_NAME = LibSwift;
+				PRODUCT_NAME = lib_swift;
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "private/LibSwift-Swift.h";
+				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35/bin/CommandLine/CommandLineToolLib/lib_swift.rules_xcodeproj.swift.compile.params";
+				TARGET_NAME = lib_swift;
+			};
+			name = Debug;
+		};
 		7187F36B9AF9EB73BA807EF7 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -14309,52 +14442,6 @@
 				SDKROOT = macosx;
 				SUPPORTED_PLATFORMS = macosx;
 				TARGET_NAME = UniversalCommandLineTool;
-			};
-			name = AppStore;
-		};
-		73B5C6F641D1243CC44AA1E1 /* AppStore */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = x86_64;
-				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:lib_swift";
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36/bin/CommandLine/CommandLineToolLib";
-				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:lib_swift macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36";
-				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
-				COMPILE_TARGET_NAME = lib_swift;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				OTHER_SWIFT_FLAGS = "-Xcc -working-directory -Xcc $(PROJECT_DIR) -working-directory $(PROJECT_DIR) -Xcc -ivfsoverlay -Xcc $(OBJROOT)/bazel-out-overlay.yaml -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/swift.compile.params -I$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36/bin/CommandLine/CommandLineToolLib -F$(BAZEL_EXTERNAL)/examples_command_line_external";
-				PRODUCT_MODULE_NAME = LibSwift;
-				PRODUCT_NAME = lib_swift;
-				SDKROOT = macosx;
-				SUPPORTED_PLATFORMS = macosx;
-				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_OBJC_INTERFACE_HEADER_NAME = "private/LibSwift-Swift.h";
-				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36/bin/CommandLine/CommandLineToolLib/lib_swift.rules_xcodeproj.swift.compile.params";
-				TARGET_NAME = lib_swift;
-			};
-			name = AppStore;
-		};
-		73FF9CF34A43918611470CBF /* AppStore */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = x86_64;
-				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:lib_swift";
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38/bin/CommandLine/CommandLineToolLib";
-				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:lib_swift macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38";
-				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
-				COMPILE_TARGET_NAME = lib_swift;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				OTHER_SWIFT_FLAGS = "-Xcc -working-directory -Xcc $(PROJECT_DIR) -working-directory $(PROJECT_DIR) -Xcc -ivfsoverlay -Xcc $(OBJROOT)/bazel-out-overlay.yaml -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/swift.compile.params -I$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38/bin/CommandLine/CommandLineToolLib -F$(BAZEL_EXTERNAL)/examples_command_line_external";
-				PRODUCT_MODULE_NAME = LibSwift;
-				PRODUCT_NAME = lib_swift;
-				SDKROOT = macosx;
-				SUPPORTED_PLATFORMS = macosx;
-				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_OBJC_INTERFACE_HEADER_NAME = "private/LibSwift-Swift.h";
-				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38/bin/CommandLine/CommandLineToolLib/lib_swift.rules_xcodeproj.swift.compile.params";
-				TARGET_NAME = lib_swift;
 			};
 			name = AppStore;
 		};
@@ -14465,47 +14552,49 @@
 			};
 			name = AppStore;
 		};
-		7E6CF010179BD2EDC643F644 /* Debug */ = {
+		773321D8B1E5E67162E27151 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
 				ASAN_OTHER_CFLAGS__ = "$(ASAN_OTHER_CFLAGS__NO)";
 				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) -ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/c.compile.params";
 				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
-				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:private_lib";
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35/bin/CommandLine/CommandLineToolLib";
-				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:private_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35";
+				BAZEL_LABEL = "@//CommandLine/swift_c_module:c_lib";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35/bin/CommandLine/swift_c_module";
+				BAZEL_TARGET_ID = "//CommandLine/swift_c_module:c_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35";
 				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
-				COMPILE_TARGET_NAME = private_lib;
-				C_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35/bin/CommandLine/CommandLineToolLib/private_lib.rules_xcodeproj.c.compile.params";
+				COMPILE_TARGET_NAME = c_lib;
+				C_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35/bin/CommandLine/swift_c_module/c_lib.rules_xcodeproj.c.compile.params";
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = "$(ASAN_OTHER_CFLAGS__$(CLANG_ADDRESS_SANITIZER))";
-				PRODUCT_NAME = private_lib;
+				PRODUCT_NAME = c_lib;
 				SDKROOT = macosx;
 				SUPPORTED_PLATFORMS = macosx;
-				TARGET_NAME = private_lib;
+				TARGET_NAME = c_lib;
 			};
 			name = Debug;
 		};
-		80C99545843058A6C2B0122E /* Debug */ = {
+		7CF3AF505E5B2E5AF25568A8 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
-				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:private_swift_lib";
+				ASAN_OTHER_CFLAGS__ = "$(ASAN_OTHER_CFLAGS__NO)";
+				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) -ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/c.compile.params";
+				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
+				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:lib_impl";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35/bin/CommandLine/CommandLineToolLib";
-				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:private_swift_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35";
+				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:lib_impl macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35";
 				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
-				COMPILE_TARGET_NAME = private_swift_lib;
+				COMPILE_TARGET_NAME = lib_impl;
+				C_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35/bin/CommandLine/CommandLineToolLib/lib_impl.rules_xcodeproj.c.compile.params";
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				OTHER_SWIFT_FLAGS = "-Xcc -working-directory -Xcc $(PROJECT_DIR) -working-directory $(PROJECT_DIR) -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/swift.compile.params";
-				PRODUCT_MODULE_NAME = _SwiftLib;
-				PRODUCT_NAME = private_swift_lib;
+				OTHER_CFLAGS = "$(ASAN_OTHER_CFLAGS__$(CLANG_ADDRESS_SANITIZER))";
+				PRODUCT_NAME = lib_impl;
 				SDKROOT = macosx;
 				SUPPORTED_PLATFORMS = macosx;
-				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35/bin/CommandLine/CommandLineToolLib/private_swift_lib.rules_xcodeproj.swift.compile.params";
-				TARGET_NAME = private_swift_lib;
+				TARGET_NAME = lib_impl;
 			};
 			name = Debug;
 		};
@@ -14700,29 +14789,6 @@
 			};
 			name = Debug;
 		};
-		963C76CE498CEEBFE3EE419F /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = x86_64;
-				ASAN_OTHER_CFLAGS__ = "$(ASAN_OTHER_CFLAGS__NO)";
-				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) -ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/c.compile.params";
-				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
-				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:private_lib";
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/CommandLine/CommandLineToolLib";
-				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:private_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33";
-				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
-				COMPILE_TARGET_NAME = private_lib;
-				C_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/CommandLine/CommandLineToolLib/private_lib.rules_xcodeproj.c.compile.params";
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				OTHER_CFLAGS = "$(ASAN_OTHER_CFLAGS__$(CLANG_ADDRESS_SANITIZER))";
-				PRODUCT_NAME = private_lib;
-				SDKROOT = macosx;
-				SUPPORTED_PLATFORMS = macosx;
-				TARGET_NAME = private_lib;
-			};
-			name = Debug;
-		};
 		987EE6E86973D20ECC842F60 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -14783,27 +14849,6 @@
 				TARGET_NAME = private_lib;
 			};
 			name = AppStore;
-		};
-		998DC3E78414BC5E06222F81 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = x86_64;
-				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:private_swift_lib";
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/CommandLine/CommandLineToolLib";
-				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:private_swift_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33";
-				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
-				COMPILE_TARGET_NAME = private_swift_lib;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				OTHER_SWIFT_FLAGS = "-Xcc -working-directory -Xcc $(PROJECT_DIR) -working-directory $(PROJECT_DIR) -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/swift.compile.params";
-				PRODUCT_MODULE_NAME = _SwiftLib;
-				PRODUCT_NAME = private_swift_lib;
-				SDKROOT = macosx;
-				SUPPORTED_PLATFORMS = macosx;
-				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/CommandLine/CommandLineToolLib/private_swift_lib.rules_xcodeproj.swift.compile.params";
-				TARGET_NAME = private_swift_lib;
-			};
-			name = Debug;
 		};
 		9B77CEE5F1C61532E473154B /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -14894,6 +14939,29 @@
 			};
 			name = Debug;
 		};
+		A53918A2D1EF4AD3254B2048 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				ASAN_OTHER_CFLAGS__ = "$(ASAN_OTHER_CFLAGS__NO)";
+				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) -ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/c.compile.params";
+				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
+				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:private_lib";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/CommandLine/CommandLineToolLib";
+				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:private_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
+				COMPILE_TARGET_NAME = private_lib;
+				C_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/CommandLine/CommandLineToolLib/private_lib.rules_xcodeproj.c.compile.params";
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				OTHER_CFLAGS = "$(ASAN_OTHER_CFLAGS__$(CLANG_ADDRESS_SANITIZER))";
+				PRODUCT_NAME = private_lib;
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				TARGET_NAME = private_lib;
+			};
+			name = Debug;
+		};
 		A56BEE637DA1B6A442624451 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -14918,29 +14986,6 @@
 				TARGET_NAME = Utils;
 			};
 			name = Debug;
-		};
-		A6EC9D6C1EA575B22E876BAB /* AppStore */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = x86_64;
-				ASAN_OTHER_CFLAGS__ = "$(ASAN_OTHER_CFLAGS__NO)";
-				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) -ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/c.compile.params";
-				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
-				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:lib_impl";
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36/bin/CommandLine/CommandLineToolLib";
-				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:lib_impl macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36";
-				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
-				COMPILE_TARGET_NAME = lib_impl;
-				C_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36/bin/CommandLine/CommandLineToolLib/lib_impl.rules_xcodeproj.c.compile.params";
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				OTHER_CFLAGS = "$(ASAN_OTHER_CFLAGS__$(CLANG_ADDRESS_SANITIZER))";
-				PRODUCT_NAME = lib_impl;
-				SDKROOT = macosx;
-				SUPPORTED_PLATFORMS = macosx;
-				TARGET_NAME = lib_impl;
-			};
-			name = AppStore;
 		};
 		A835DE82F2BF89343394515A /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -15088,6 +15133,28 @@
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36/bin/CommandLine/Tests/CommandLineLibSwiftTestsLib.rules_xcodeproj.swift.compile.params";
 				TARGET_NAME = CommandLineToolTests;
+			};
+			name = AppStore;
+		};
+		AF736851CF5B41F17D11E6C0 /* AppStore */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:private_swift_lib";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38/bin/CommandLine/CommandLineToolLib";
+				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:private_swift_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
+				COMPILE_TARGET_NAME = private_swift_lib;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				OTHER_SWIFT_FLAGS = "-Xcc -working-directory -Xcc $(PROJECT_DIR) -working-directory $(PROJECT_DIR) -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/swift.compile.params";
+				PRODUCT_MODULE_NAME = _SwiftLib;
+				PRODUCT_NAME = private_swift_lib;
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38/bin/CommandLine/CommandLineToolLib/private_swift_lib.rules_xcodeproj.swift.compile.params";
+				TARGET_NAME = private_swift_lib;
 			};
 			name = AppStore;
 		};
@@ -15585,6 +15652,29 @@
 			};
 			name = Debug;
 		};
+		CA92F7696D79401E0F3EF6A4 /* AppStore */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				ASAN_OTHER_CFLAGS__ = "$(ASAN_OTHER_CFLAGS__NO)";
+				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) -ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/c.compile.params";
+				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
+				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:private_lib";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36/bin/CommandLine/CommandLineToolLib";
+				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:private_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
+				COMPILE_TARGET_NAME = private_lib;
+				C_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36/bin/CommandLine/CommandLineToolLib/private_lib.rules_xcodeproj.c.compile.params";
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				OTHER_CFLAGS = "$(ASAN_OTHER_CFLAGS__$(CLANG_ADDRESS_SANITIZER))";
+				PRODUCT_NAME = private_lib;
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				TARGET_NAME = private_lib;
+			};
+			name = AppStore;
+		};
 		CAEFDA2B81F1174EB4ECF3DB /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -15622,29 +15712,6 @@
 				TARGET_NAME = tvOSAppUITests;
 				TEST_TARGET_NAME = tvOSApp;
 				TVOS_DEPLOYMENT_TARGET = 15.0;
-			};
-			name = Debug;
-		};
-		CBC21657B006FF420CA68F53 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = x86_64;
-				ASAN_OTHER_CFLAGS__ = "$(ASAN_OTHER_CFLAGS__NO)";
-				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) -ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/c.compile.params";
-				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
-				BAZEL_LABEL = "@//CommandLine/swift_c_module:c_lib";
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35/bin/CommandLine/swift_c_module";
-				BAZEL_TARGET_ID = "//CommandLine/swift_c_module:c_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35";
-				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
-				COMPILE_TARGET_NAME = c_lib;
-				C_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35/bin/CommandLine/swift_c_module/c_lib.rules_xcodeproj.c.compile.params";
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				OTHER_CFLAGS = "$(ASAN_OTHER_CFLAGS__$(CLANG_ADDRESS_SANITIZER))";
-				PRODUCT_NAME = c_lib;
-				SDKROOT = macosx;
-				SUPPORTED_PLATFORMS = macosx;
-				TARGET_NAME = c_lib;
 			};
 			name = Debug;
 		};
@@ -15706,48 +15773,26 @@
 			};
 			name = Debug;
 		};
-		D84DA1F842D4F39451E2C26B /* Debug */ = {
+		D0738A74708B078883C1AB92 /* AppStore */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
-				ASAN_OTHER_CFLAGS__ = "$(ASAN_OTHER_CFLAGS__NO)";
-				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) -ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/c.compile.params";
-				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
-				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:lib_impl";
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35/bin/CommandLine/CommandLineToolLib";
-				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:lib_impl macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35";
-				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
-				COMPILE_TARGET_NAME = lib_impl;
-				C_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35/bin/CommandLine/CommandLineToolLib/lib_impl.rules_xcodeproj.c.compile.params";
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				OTHER_CFLAGS = "$(ASAN_OTHER_CFLAGS__$(CLANG_ADDRESS_SANITIZER))";
-				PRODUCT_NAME = lib_impl;
-				SDKROOT = macosx;
-				SUPPORTED_PLATFORMS = macosx;
-				TARGET_NAME = lib_impl;
-			};
-			name = Debug;
-		};
-		DD223793FA3CCC36BAC5DEDD /* AppStore */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = x86_64;
-				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:private_swift_lib";
+				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:lib_swift";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36/bin/CommandLine/CommandLineToolLib";
-				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:private_swift_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36";
+				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:lib_swift macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36";
 				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
-				COMPILE_TARGET_NAME = private_swift_lib;
+				COMPILE_TARGET_NAME = lib_swift;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				OTHER_SWIFT_FLAGS = "-Xcc -working-directory -Xcc $(PROJECT_DIR) -working-directory $(PROJECT_DIR) -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/swift.compile.params";
-				PRODUCT_MODULE_NAME = _SwiftLib;
-				PRODUCT_NAME = private_swift_lib;
+				OTHER_SWIFT_FLAGS = "-Xcc -working-directory -Xcc $(PROJECT_DIR) -working-directory $(PROJECT_DIR) -Xcc -ivfsoverlay -Xcc $(OBJROOT)/bazel-out-overlay.yaml -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/swift.compile.params -I$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36/bin/CommandLine/CommandLineToolLib -F$(BAZEL_EXTERNAL)/examples_command_line_external";
+				PRODUCT_MODULE_NAME = LibSwift;
+				PRODUCT_NAME = lib_swift;
 				SDKROOT = macosx;
 				SUPPORTED_PLATFORMS = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36/bin/CommandLine/CommandLineToolLib/private_swift_lib.rules_xcodeproj.swift.compile.params";
-				TARGET_NAME = private_swift_lib;
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "private/LibSwift-Swift.h";
+				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36/bin/CommandLine/CommandLineToolLib/lib_swift.rules_xcodeproj.swift.compile.params";
+				TARGET_NAME = lib_swift;
 			};
 			name = AppStore;
 		};
@@ -15802,6 +15847,29 @@
 				TEST_HOST = "$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-opt-STABLE-15/bin/iOSApp/Source/iOSApp.app/iOSApp_ExecutableName";
 			};
 			name = AppStore;
+		};
+		E2F4CEEDF9233148704022F1 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				ASAN_OTHER_CFLAGS__ = "$(ASAN_OTHER_CFLAGS__NO)";
+				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) -ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/c.compile.params";
+				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
+				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:private_lib";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35/bin/CommandLine/CommandLineToolLib";
+				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:private_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
+				COMPILE_TARGET_NAME = private_lib;
+				C_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35/bin/CommandLine/CommandLineToolLib/private_lib.rules_xcodeproj.c.compile.params";
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				OTHER_CFLAGS = "$(ASAN_OTHER_CFLAGS__$(CLANG_ADDRESS_SANITIZER))";
+				PRODUCT_NAME = private_lib;
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				TARGET_NAME = private_lib;
+			};
+			name = Debug;
 		};
 		E958286B588C5287AD598A06 /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -15896,29 +15964,6 @@
 			};
 			name = Debug;
 		};
-		EBB911756C864835038AA69D /* AppStore */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = x86_64;
-				ASAN_OTHER_CFLAGS__ = "$(ASAN_OTHER_CFLAGS__NO)";
-				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) -ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/c.compile.params";
-				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
-				BAZEL_LABEL = "@//CommandLine/swift_c_module:c_lib";
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36/bin/CommandLine/swift_c_module";
-				BAZEL_TARGET_ID = "//CommandLine/swift_c_module:c_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36";
-				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
-				COMPILE_TARGET_NAME = c_lib;
-				C_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36/bin/CommandLine/swift_c_module/c_lib.rules_xcodeproj.c.compile.params";
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				OTHER_CFLAGS = "$(ASAN_OTHER_CFLAGS__$(CLANG_ADDRESS_SANITIZER))";
-				PRODUCT_NAME = c_lib;
-				SDKROOT = macosx;
-				SUPPORTED_PLATFORMS = macosx;
-				TARGET_NAME = c_lib;
-			};
-			name = AppStore;
-		};
 		ECB2C58ED351C1DF70FDAB75 /* AppStore */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -15947,26 +15992,26 @@
 			};
 			name = AppStore;
 		};
-		ECCFC8DEDF4E2E63648F9560 /* AppStore */ = {
+		EEA04B531253A44CF7FD6B51 /* AppStore */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
-				ASAN_OTHER_CFLAGS__ = "$(ASAN_OTHER_CFLAGS__NO)";
-				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) -ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/c.compile.params";
-				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
-				BAZEL_LABEL = "@//CommandLine/swift_c_module:c_lib";
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38/bin/CommandLine/swift_c_module";
-				BAZEL_TARGET_ID = "//CommandLine/swift_c_module:c_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38";
+				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:lib_swift";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38/bin/CommandLine/CommandLineToolLib";
+				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:lib_swift macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38";
 				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
-				COMPILE_TARGET_NAME = c_lib;
-				C_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38/bin/CommandLine/swift_c_module/c_lib.rules_xcodeproj.c.compile.params";
+				COMPILE_TARGET_NAME = lib_swift;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				OTHER_CFLAGS = "$(ASAN_OTHER_CFLAGS__$(CLANG_ADDRESS_SANITIZER))";
-				PRODUCT_NAME = c_lib;
+				OTHER_SWIFT_FLAGS = "-Xcc -working-directory -Xcc $(PROJECT_DIR) -working-directory $(PROJECT_DIR) -Xcc -ivfsoverlay -Xcc $(OBJROOT)/bazel-out-overlay.yaml -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/swift.compile.params -I$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38/bin/CommandLine/CommandLineToolLib -F$(BAZEL_EXTERNAL)/examples_command_line_external";
+				PRODUCT_MODULE_NAME = LibSwift;
+				PRODUCT_NAME = lib_swift;
 				SDKROOT = macosx;
 				SUPPORTED_PLATFORMS = macosx;
-				TARGET_NAME = c_lib;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "private/LibSwift-Swift.h";
+				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38/bin/CommandLine/CommandLineToolLib/lib_swift.rules_xcodeproj.swift.compile.params";
+				TARGET_NAME = lib_swift;
 			};
 			name = AppStore;
 		};
@@ -16058,28 +16103,6 @@
 			};
 			name = AppStore;
 		};
-		F6C9F5594C5C5CD961B64EA4 /* AppStore */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = x86_64;
-				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:private_swift_lib";
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38/bin/CommandLine/CommandLineToolLib";
-				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:private_swift_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38";
-				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
-				COMPILE_TARGET_NAME = private_swift_lib;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				OTHER_SWIFT_FLAGS = "-Xcc -working-directory -Xcc $(PROJECT_DIR) -working-directory $(PROJECT_DIR) -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/swift.compile.params";
-				PRODUCT_MODULE_NAME = _SwiftLib;
-				PRODUCT_NAME = private_swift_lib;
-				SDKROOT = macosx;
-				SUPPORTED_PLATFORMS = macosx;
-				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38/bin/CommandLine/CommandLineToolLib/private_swift_lib.rules_xcodeproj.swift.compile.params";
-				TARGET_NAME = private_swift_lib;
-			};
-			name = AppStore;
-		};
 		F8191A43ACD1E99D577E468C /* AppStore */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -16126,29 +16149,6 @@
 				TARGET_NAME = FrameworkCoreUtilsObjC;
 			};
 			name = AppStore;
-		};
-		FC8D30CE0BFC7CC2652E7E86 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = x86_64;
-				ASAN_OTHER_CFLAGS__ = "$(ASAN_OTHER_CFLAGS__NO)";
-				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) -ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/c.compile.params";
-				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
-				BAZEL_LABEL = "@//CommandLine/swift_c_module:c_lib";
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/CommandLine/swift_c_module";
-				BAZEL_TARGET_ID = "//CommandLine/swift_c_module:c_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33";
-				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
-				COMPILE_TARGET_NAME = c_lib;
-				C_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/CommandLine/swift_c_module/c_lib.rules_xcodeproj.c.compile.params";
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				OTHER_CFLAGS = "$(ASAN_OTHER_CFLAGS__$(CLANG_ADDRESS_SANITIZER))";
-				PRODUCT_NAME = c_lib;
-				SDKROOT = macosx;
-				SUPPORTED_PLATFORMS = macosx;
-				TARGET_NAME = c_lib;
-			};
-			name = Debug;
 		};
 		FCA794094F9910DF9DF3E40F /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -16205,6 +16205,15 @@
 			buildConfigurations = (
 				07B3EBE3BC279DD76178779A /* AppStore */,
 				30A3B21AB5EB106B2E608FA3 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		01912229FFC8DF4B36E1F925 /* Build configuration list for PBXNativeTarget "lib_swift (x86_64) (AppStore, Debug) (f321a)" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D0738A74708B078883C1AB92 /* AppStore */,
+				36BD0C03CA24148A7B8020BB /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
@@ -16290,6 +16299,15 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
+		4861D7D3DEF812E48C499E00 /* Build configuration list for PBXNativeTarget "private_lib (x86_64) (AppStore, Debug) (7d2e3)" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				2CD3B4F96957BFA9EB0E1275 /* AppStore */,
+				E2F4CEEDF9233148704022F1 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
 		4B01695F69D3879AFAE19DCF /* Build configuration list for PBXNativeTarget "MixedAnswerLib_Swift" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -16362,6 +16380,15 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
+		57C1FB17A5F60A33D2447364 /* Build configuration list for PBXNativeTarget "lib_swift (x86_64) (AppStore, Debug) (7d2e3)" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				EEA04B531253A44CF7FD6B51 /* AppStore */,
+				715E16DDD4A8A3B690069FF5 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
 		595CCB3FBDC8E111D731DA95 /* Build configuration list for PBXNativeTarget "private_swift_lib (arm64)" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -16376,15 +16403,6 @@
 			buildConfigurations = (
 				74B7945D7BEECE1A89E02A3D /* AppStore */,
 				90605288FFBEAD0A44F502BB /* Debug */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Debug;
-		};
-		64283CA4B08CF9184F238626 /* Build configuration list for PBXNativeTarget "c_lib (f321a)" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				EBB911756C864835038AA69D /* AppStore */,
-				FC8D30CE0BFC7CC2652E7E86 /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
@@ -16407,15 +16425,6 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
-		695A147C26D0BBB8656AA480 /* Build configuration list for PBXNativeTarget "lib_impl (7d2e3)" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				486DCB7BFCA19245D09582D3 /* AppStore */,
-				D84DA1F842D4F39451E2C26B /* Debug */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Debug;
-		};
 		713ABD0E52D124C774A5D1B5 /* Build configuration list for PBXNativeTarget "BasicTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -16434,11 +16443,20 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
-		7732DBB228206F99D22CD4B3 /* Build configuration list for PBXNativeTarget "private_swift_lib (f321a)" */ = {
+		76F21EAF8FFDB9E0CC388C27 /* Build configuration list for PBXNativeTarget "c_lib (x86_64) (AppStore, Debug) (7d2e3)" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				DD223793FA3CCC36BAC5DEDD /* AppStore */,
-				998DC3E78414BC5E06222F81 /* Debug */,
+				028C6B01F864D3D6DE8C830E /* AppStore */,
+				773321D8B1E5E67162E27151 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		7F64EDB10B3995D384B30E39 /* Build configuration list for PBXNativeTarget "lib_impl (x86_64) (AppStore, Debug) (7d2e3)" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4C31D7CE23BE1E320DDFF3E0 /* AppStore */,
+				7CF3AF505E5B2E5AF25568A8 /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
@@ -16488,15 +16506,6 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
-		8C9DF43C4A8A9357E49AA789 /* Build configuration list for PBXNativeTarget "private_lib (f321a)" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				540DA483A81C38DCEF978A66 /* AppStore */,
-				963C76CE498CEEBFE3EE419F /* Debug */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Debug;
-		};
 		8D0A215926F86AD18BB722CD /* Build configuration list for PBXNativeTarget "tvOSAppUnitTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -16542,15 +16551,6 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
-		9E6E9AF105F3B379699434F2 /* Build configuration list for PBXNativeTarget "c_lib (7d2e3)" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				ECCFC8DEDF4E2E63648F9560 /* AppStore */,
-				CBC21657B006FF420CA68F53 /* Debug */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Debug;
-		};
 		A130411CB8C0BE310F03989B /* Build configuration list for PBXNativeTarget "FXPageControl" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -16569,11 +16569,11 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
-		A60859ACA1047EC1FD9A1E0A /* Build configuration list for PBXNativeTarget "private_lib (7d2e3)" */ = {
+		A36C362F4C75B0BAB71FA1D6 /* Build configuration list for PBXNativeTarget "private_swift_lib (x86_64) (AppStore, Debug) (f321a)" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				491089F252D7FA8E5CD46925 /* AppStore */,
-				7E6CF010179BD2EDC643F644 /* Debug */,
+				6B731E0B2CC960052B9FC2DC /* AppStore */,
+				526DB0D50803BE1C4EFAD3D0 /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
@@ -16583,6 +16583,15 @@
 			buildConfigurations = (
 				395552AF763821AA24020045 /* AppStore */,
 				281468B9DE11BDF7386534BD /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		AF297CF0F0D2BF6560D7BFC4 /* Build configuration list for PBXNativeTarget "private_swift_lib (x86_64) (AppStore, Debug) (7d2e3)" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AF736851CF5B41F17D11E6C0 /* AppStore */,
+				478C7B8A91269BF13AF95DE4 /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
@@ -16614,29 +16623,11 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
-		C2B1537C85417BBA01E113F7 /* Build configuration list for PBXNativeTarget "lib_swift (f321a)" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				73B5C6F641D1243CC44AA1E1 /* AppStore */,
-				670BF2EC610F52839CE05B88 /* Debug */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Debug;
-		};
 		C986B7E84520EFD0454FA9C4 /* Build configuration list for PBXNativeTarget "UIFramework.tvOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				F5DC4ADE63E219345F71147D /* AppStore */,
 				21F9AE5BE9AB2E63D8B9E20F /* Debug */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Debug;
-		};
-		CD1746947AC8A564C2527D1A /* Build configuration list for PBXNativeTarget "lib_swift (7d2e3)" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				73FF9CF34A43918611470CBF /* AppStore */,
-				0174EB2E3EF79496ECE60688 /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
@@ -16650,11 +16641,11 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
-		DAA656300AFF26A087CECD4F /* Build configuration list for PBXNativeTarget "private_swift_lib (7d2e3)" */ = {
+		D90C3C6C901499086E329E75 /* Build configuration list for PBXNativeTarget "private_lib (x86_64) (AppStore, Debug) (f321a)" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				F6C9F5594C5C5CD961B64EA4 /* AppStore */,
-				80C99545843058A6C2B0122E /* Debug */,
+				CA92F7696D79401E0F3EF6A4 /* AppStore */,
+				A53918A2D1EF4AD3254B2048 /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
@@ -16686,6 +16677,15 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
+		EAB016539A35B9B425C38865 /* Build configuration list for PBXNativeTarget "c_lib (x86_64) (AppStore, Debug) (f321a)" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				206A2C6CF6BBDFE4B54218B4 /* AppStore */,
+				0A1FF83C1814537445CDCE99 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
 		EFD92156A876B6D6FFBB6CA8 /* Build configuration list for PBXNativeTarget "Lib (watchOS)" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -16704,11 +16704,11 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
-		F4BBD4A2DBB7AC84FB67D4C0 /* Build configuration list for PBXNativeTarget "lib_impl (f321a)" */ = {
+		F8787A42308EA0E966AD1C92 /* Build configuration list for PBXNativeTarget "lib_impl (x86_64) (AppStore, Debug) (f321a)" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				A6EC9D6C1EA575B22E876BAB /* AppStore */,
-				50D758CD825A271682A8CC6A /* Debug */,
+				1BAC8A32FA5F4F54029BE31B /* AppStore */,
+				3B5081F64B422DC060EBE720 /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/c_lib (x86_64) (AppStore, Debug) (7d2e3).xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/c_lib (x86_64) (AppStore, Debug) (7d2e3).xcscheme
@@ -14,10 +14,10 @@
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
-                     BlueprintIdentifier = "E1AC9F0E8F6592B37546029E"
-                     BuildableName = "c_lib (7d2e3)"
-                     BlueprintName = "c_lib (7d2e3)"
-                     ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
+                     BlueprintIdentifier = "28F896144BD31E78D7D9AF3A"
+                     BuildableName = "c_lib (x86_64) (AppStore, Debug) (7d2e3)"
+                     BlueprintName = "c_lib (x86_64) (AppStore, Debug) (7d2e3)"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
                   </BuildableReference>
                </EnvironmentBuildable>
             </ActionContent>
@@ -25,15 +25,15 @@
          <ExecutionAction
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
-               title = "Set Bazel Build Output Groups for c_lib (7d2e3)"
+               title = "Set Bazel Build Output Groups for c_lib (x86_64) (AppStore, Debug) (7d2e3)"
                scriptText = "echo &quot;$BAZEL_LABEL,$BAZEL_TARGET_ID&quot; &gt;&gt; &quot;$SCHEME_TARGET_IDS_FILE&quot;&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
-                     BlueprintIdentifier = "E1AC9F0E8F6592B37546029E"
-                     BuildableName = "c_lib (7d2e3)"
-                     BlueprintName = "c_lib (7d2e3)"
-                     ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
+                     BlueprintIdentifier = "28F896144BD31E78D7D9AF3A"
+                     BuildableName = "c_lib (x86_64) (AppStore, Debug) (7d2e3)"
+                     BlueprintName = "c_lib (x86_64) (AppStore, Debug) (7d2e3)"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
                   </BuildableReference>
                </EnvironmentBuildable>
             </ActionContent>
@@ -48,10 +48,10 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "E1AC9F0E8F6592B37546029E"
-               BuildableName = "c_lib (7d2e3)"
-               BlueprintName = "c_lib (7d2e3)"
-               ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
+               BlueprintIdentifier = "28F896144BD31E78D7D9AF3A"
+               BuildableName = "c_lib (x86_64) (AppStore, Debug) (7d2e3)"
+               BlueprintName = "c_lib (x86_64) (AppStore, Debug) (7d2e3)"
+               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/c_lib (x86_64) (AppStore, Debug) (f321a).xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/c_lib (x86_64) (AppStore, Debug) (f321a).xcscheme
@@ -14,9 +14,9 @@
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
-                     BlueprintIdentifier = "219FC92FC257657B7BEA0B7B"
-                     BuildableName = "lib_swift (7d2e3)"
-                     BlueprintName = "lib_swift (7d2e3)"
+                     BlueprintIdentifier = "A5885841514C75A20817CE98"
+                     BuildableName = "c_lib (x86_64) (AppStore, Debug) (f321a)"
+                     BlueprintName = "c_lib (x86_64) (AppStore, Debug) (f321a)"
                      ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
                   </BuildableReference>
                </EnvironmentBuildable>
@@ -25,14 +25,14 @@
          <ExecutionAction
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
-               title = "Set Bazel Build Output Groups for lib_swift (7d2e3)"
+               title = "Set Bazel Build Output Groups for c_lib (x86_64) (AppStore, Debug) (f321a)"
                scriptText = "echo &quot;$BAZEL_LABEL,$BAZEL_TARGET_ID&quot; &gt;&gt; &quot;$SCHEME_TARGET_IDS_FILE&quot;&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
-                     BlueprintIdentifier = "219FC92FC257657B7BEA0B7B"
-                     BuildableName = "lib_swift (7d2e3)"
-                     BlueprintName = "lib_swift (7d2e3)"
+                     BlueprintIdentifier = "A5885841514C75A20817CE98"
+                     BuildableName = "c_lib (x86_64) (AppStore, Debug) (f321a)"
+                     BlueprintName = "c_lib (x86_64) (AppStore, Debug) (f321a)"
                      ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
                   </BuildableReference>
                </EnvironmentBuildable>
@@ -48,9 +48,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "219FC92FC257657B7BEA0B7B"
-               BuildableName = "lib_swift (7d2e3)"
-               BlueprintName = "lib_swift (7d2e3)"
+               BlueprintIdentifier = "A5885841514C75A20817CE98"
+               BuildableName = "c_lib (x86_64) (AppStore, Debug) (f321a)"
+               BlueprintName = "c_lib (x86_64) (AppStore, Debug) (f321a)"
                ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/lib_impl (x86_64) (AppStore, Debug) (7d2e3).xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/lib_impl (x86_64) (AppStore, Debug) (7d2e3).xcscheme
@@ -14,10 +14,10 @@
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
-                     BlueprintIdentifier = "D846E676B1F48432762135EA"
-                     BuildableName = "private_swift_lib (7d2e3)"
-                     BlueprintName = "private_swift_lib (7d2e3)"
-                     ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
+                     BlueprintIdentifier = "1732C9B70F9B5BDB60B7FC26"
+                     BuildableName = "lib_impl (x86_64) (AppStore, Debug) (7d2e3)"
+                     BlueprintName = "lib_impl (x86_64) (AppStore, Debug) (7d2e3)"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
                   </BuildableReference>
                </EnvironmentBuildable>
             </ActionContent>
@@ -25,15 +25,15 @@
          <ExecutionAction
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
-               title = "Set Bazel Build Output Groups for private_swift_lib (7d2e3)"
+               title = "Set Bazel Build Output Groups for lib_impl (x86_64) (AppStore, Debug) (7d2e3)"
                scriptText = "echo &quot;$BAZEL_LABEL,$BAZEL_TARGET_ID&quot; &gt;&gt; &quot;$SCHEME_TARGET_IDS_FILE&quot;&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
-                     BlueprintIdentifier = "D846E676B1F48432762135EA"
-                     BuildableName = "private_swift_lib (7d2e3)"
-                     BlueprintName = "private_swift_lib (7d2e3)"
-                     ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
+                     BlueprintIdentifier = "1732C9B70F9B5BDB60B7FC26"
+                     BuildableName = "lib_impl (x86_64) (AppStore, Debug) (7d2e3)"
+                     BlueprintName = "lib_impl (x86_64) (AppStore, Debug) (7d2e3)"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
                   </BuildableReference>
                </EnvironmentBuildable>
             </ActionContent>
@@ -48,10 +48,10 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "D846E676B1F48432762135EA"
-               BuildableName = "private_swift_lib (7d2e3)"
-               BlueprintName = "private_swift_lib (7d2e3)"
-               ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
+               BlueprintIdentifier = "1732C9B70F9B5BDB60B7FC26"
+               BuildableName = "lib_impl (x86_64) (AppStore, Debug) (7d2e3)"
+               BlueprintName = "lib_impl (x86_64) (AppStore, Debug) (7d2e3)"
+               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/lib_impl (x86_64) (AppStore, Debug) (f321a).xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/lib_impl (x86_64) (AppStore, Debug) (f321a).xcscheme
@@ -14,10 +14,10 @@
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
-                     BlueprintIdentifier = "611D8A1C90B39DBF5A8073AE"
-                     BuildableName = "private_lib (7d2e3)"
-                     BlueprintName = "private_lib (7d2e3)"
-                     ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
+                     BlueprintIdentifier = "A7138F8D1198A6F3EFCB7D9F"
+                     BuildableName = "lib_impl (x86_64) (AppStore, Debug) (f321a)"
+                     BlueprintName = "lib_impl (x86_64) (AppStore, Debug) (f321a)"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
                   </BuildableReference>
                </EnvironmentBuildable>
             </ActionContent>
@@ -25,15 +25,15 @@
          <ExecutionAction
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
-               title = "Set Bazel Build Output Groups for private_lib (7d2e3)"
+               title = "Set Bazel Build Output Groups for lib_impl (x86_64) (AppStore, Debug) (f321a)"
                scriptText = "echo &quot;$BAZEL_LABEL,$BAZEL_TARGET_ID&quot; &gt;&gt; &quot;$SCHEME_TARGET_IDS_FILE&quot;&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
-                     BlueprintIdentifier = "611D8A1C90B39DBF5A8073AE"
-                     BuildableName = "private_lib (7d2e3)"
-                     BlueprintName = "private_lib (7d2e3)"
-                     ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
+                     BlueprintIdentifier = "A7138F8D1198A6F3EFCB7D9F"
+                     BuildableName = "lib_impl (x86_64) (AppStore, Debug) (f321a)"
+                     BlueprintName = "lib_impl (x86_64) (AppStore, Debug) (f321a)"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
                   </BuildableReference>
                </EnvironmentBuildable>
             </ActionContent>
@@ -48,10 +48,10 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "611D8A1C90B39DBF5A8073AE"
-               BuildableName = "private_lib (7d2e3)"
-               BlueprintName = "private_lib (7d2e3)"
-               ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
+               BlueprintIdentifier = "A7138F8D1198A6F3EFCB7D9F"
+               BuildableName = "lib_impl (x86_64) (AppStore, Debug) (f321a)"
+               BlueprintName = "lib_impl (x86_64) (AppStore, Debug) (f321a)"
+               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/lib_swift (x86_64) (AppStore, Debug) (7d2e3).xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/lib_swift (x86_64) (AppStore, Debug) (7d2e3).xcscheme
@@ -14,10 +14,10 @@
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
-                     BlueprintIdentifier = "4851285CEF582BBA2236C63B"
-                     BuildableName = "private_swift_lib (f321a)"
-                     BlueprintName = "private_swift_lib (f321a)"
-                     ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
+                     BlueprintIdentifier = "A5E9FDD0476FFCEE458F4679"
+                     BuildableName = "lib_swift (x86_64) (AppStore, Debug) (7d2e3)"
+                     BlueprintName = "lib_swift (x86_64) (AppStore, Debug) (7d2e3)"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
                   </BuildableReference>
                </EnvironmentBuildable>
             </ActionContent>
@@ -25,15 +25,15 @@
          <ExecutionAction
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
-               title = "Set Bazel Build Output Groups for private_swift_lib (f321a)"
+               title = "Set Bazel Build Output Groups for lib_swift (x86_64) (AppStore, Debug) (7d2e3)"
                scriptText = "echo &quot;$BAZEL_LABEL,$BAZEL_TARGET_ID&quot; &gt;&gt; &quot;$SCHEME_TARGET_IDS_FILE&quot;&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
-                     BlueprintIdentifier = "4851285CEF582BBA2236C63B"
-                     BuildableName = "private_swift_lib (f321a)"
-                     BlueprintName = "private_swift_lib (f321a)"
-                     ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
+                     BlueprintIdentifier = "A5E9FDD0476FFCEE458F4679"
+                     BuildableName = "lib_swift (x86_64) (AppStore, Debug) (7d2e3)"
+                     BlueprintName = "lib_swift (x86_64) (AppStore, Debug) (7d2e3)"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
                   </BuildableReference>
                </EnvironmentBuildable>
             </ActionContent>
@@ -48,10 +48,10 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "4851285CEF582BBA2236C63B"
-               BuildableName = "private_swift_lib (f321a)"
-               BlueprintName = "private_swift_lib (f321a)"
-               ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
+               BlueprintIdentifier = "A5E9FDD0476FFCEE458F4679"
+               BuildableName = "lib_swift (x86_64) (AppStore, Debug) (7d2e3)"
+               BlueprintName = "lib_swift (x86_64) (AppStore, Debug) (7d2e3)"
+               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/lib_swift (x86_64) (AppStore, Debug) (f321a).xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/lib_swift (x86_64) (AppStore, Debug) (f321a).xcscheme
@@ -14,10 +14,10 @@
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
-                     BlueprintIdentifier = "8558C22680359C7F2E153FBB"
-                     BuildableName = "private_lib (f321a)"
-                     BlueprintName = "private_lib (f321a)"
-                     ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
+                     BlueprintIdentifier = "2EAE603EA49BECFF614EDC09"
+                     BuildableName = "lib_swift (x86_64) (AppStore, Debug) (f321a)"
+                     BlueprintName = "lib_swift (x86_64) (AppStore, Debug) (f321a)"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
                   </BuildableReference>
                </EnvironmentBuildable>
             </ActionContent>
@@ -25,15 +25,15 @@
          <ExecutionAction
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
-               title = "Set Bazel Build Output Groups for private_lib (f321a)"
+               title = "Set Bazel Build Output Groups for lib_swift (x86_64) (AppStore, Debug) (f321a)"
                scriptText = "echo &quot;$BAZEL_LABEL,$BAZEL_TARGET_ID&quot; &gt;&gt; &quot;$SCHEME_TARGET_IDS_FILE&quot;&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
-                     BlueprintIdentifier = "8558C22680359C7F2E153FBB"
-                     BuildableName = "private_lib (f321a)"
-                     BlueprintName = "private_lib (f321a)"
-                     ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
+                     BlueprintIdentifier = "2EAE603EA49BECFF614EDC09"
+                     BuildableName = "lib_swift (x86_64) (AppStore, Debug) (f321a)"
+                     BlueprintName = "lib_swift (x86_64) (AppStore, Debug) (f321a)"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
                   </BuildableReference>
                </EnvironmentBuildable>
             </ActionContent>
@@ -48,10 +48,10 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "8558C22680359C7F2E153FBB"
-               BuildableName = "private_lib (f321a)"
-               BlueprintName = "private_lib (f321a)"
-               ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
+               BlueprintIdentifier = "2EAE603EA49BECFF614EDC09"
+               BuildableName = "lib_swift (x86_64) (AppStore, Debug) (f321a)"
+               BlueprintName = "lib_swift (x86_64) (AppStore, Debug) (f321a)"
+               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/private_lib (x86_64) (AppStore, Debug) (7d2e3).xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/private_lib (x86_64) (AppStore, Debug) (7d2e3).xcscheme
@@ -14,10 +14,10 @@
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
-                     BlueprintIdentifier = "7527C82F4364411F5744B4D8"
-                     BuildableName = "lib_swift (f321a)"
-                     BlueprintName = "lib_swift (f321a)"
-                     ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
+                     BlueprintIdentifier = "21F5BEC07AF0B26EF4B4B151"
+                     BuildableName = "private_lib (x86_64) (AppStore, Debug) (7d2e3)"
+                     BlueprintName = "private_lib (x86_64) (AppStore, Debug) (7d2e3)"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
                   </BuildableReference>
                </EnvironmentBuildable>
             </ActionContent>
@@ -25,15 +25,15 @@
          <ExecutionAction
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
-               title = "Set Bazel Build Output Groups for lib_swift (f321a)"
+               title = "Set Bazel Build Output Groups for private_lib (x86_64) (AppStore, Debug) (7d2e3)"
                scriptText = "echo &quot;$BAZEL_LABEL,$BAZEL_TARGET_ID&quot; &gt;&gt; &quot;$SCHEME_TARGET_IDS_FILE&quot;&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
-                     BlueprintIdentifier = "7527C82F4364411F5744B4D8"
-                     BuildableName = "lib_swift (f321a)"
-                     BlueprintName = "lib_swift (f321a)"
-                     ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
+                     BlueprintIdentifier = "21F5BEC07AF0B26EF4B4B151"
+                     BuildableName = "private_lib (x86_64) (AppStore, Debug) (7d2e3)"
+                     BlueprintName = "private_lib (x86_64) (AppStore, Debug) (7d2e3)"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
                   </BuildableReference>
                </EnvironmentBuildable>
             </ActionContent>
@@ -48,10 +48,10 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "7527C82F4364411F5744B4D8"
-               BuildableName = "lib_swift (f321a)"
-               BlueprintName = "lib_swift (f321a)"
-               ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
+               BlueprintIdentifier = "21F5BEC07AF0B26EF4B4B151"
+               BuildableName = "private_lib (x86_64) (AppStore, Debug) (7d2e3)"
+               BlueprintName = "private_lib (x86_64) (AppStore, Debug) (7d2e3)"
+               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/private_lib (x86_64) (AppStore, Debug) (f321a).xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/private_lib (x86_64) (AppStore, Debug) (f321a).xcscheme
@@ -14,9 +14,9 @@
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
-                     BlueprintIdentifier = "7E8B099583E4DC09BD4F352E"
-                     BuildableName = "lib_impl (f321a)"
-                     BlueprintName = "lib_impl (f321a)"
+                     BlueprintIdentifier = "D4FE36D30F79C14A49159CAD"
+                     BuildableName = "private_lib (x86_64) (AppStore, Debug) (f321a)"
+                     BlueprintName = "private_lib (x86_64) (AppStore, Debug) (f321a)"
                      ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
                   </BuildableReference>
                </EnvironmentBuildable>
@@ -25,14 +25,14 @@
          <ExecutionAction
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
-               title = "Set Bazel Build Output Groups for lib_impl (f321a)"
+               title = "Set Bazel Build Output Groups for private_lib (x86_64) (AppStore, Debug) (f321a)"
                scriptText = "echo &quot;$BAZEL_LABEL,$BAZEL_TARGET_ID&quot; &gt;&gt; &quot;$SCHEME_TARGET_IDS_FILE&quot;&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
-                     BlueprintIdentifier = "7E8B099583E4DC09BD4F352E"
-                     BuildableName = "lib_impl (f321a)"
-                     BlueprintName = "lib_impl (f321a)"
+                     BlueprintIdentifier = "D4FE36D30F79C14A49159CAD"
+                     BuildableName = "private_lib (x86_64) (AppStore, Debug) (f321a)"
+                     BlueprintName = "private_lib (x86_64) (AppStore, Debug) (f321a)"
                      ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
                   </BuildableReference>
                </EnvironmentBuildable>
@@ -48,9 +48,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "7E8B099583E4DC09BD4F352E"
-               BuildableName = "lib_impl (f321a)"
-               BlueprintName = "lib_impl (f321a)"
+               BlueprintIdentifier = "D4FE36D30F79C14A49159CAD"
+               BuildableName = "private_lib (x86_64) (AppStore, Debug) (f321a)"
+               BlueprintName = "private_lib (x86_64) (AppStore, Debug) (f321a)"
                ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/private_swift_lib (x86_64) (AppStore, Debug) (7d2e3).xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/private_swift_lib (x86_64) (AppStore, Debug) (7d2e3).xcscheme
@@ -14,10 +14,10 @@
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
-                     BlueprintIdentifier = "2734834A28FFEBBA6357B35B"
-                     BuildableName = "c_lib (f321a)"
-                     BlueprintName = "c_lib (f321a)"
-                     ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
+                     BlueprintIdentifier = "63CEFAD4966431863BF44E2E"
+                     BuildableName = "private_swift_lib (x86_64) (AppStore, Debug) (7d2e3)"
+                     BlueprintName = "private_swift_lib (x86_64) (AppStore, Debug) (7d2e3)"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
                   </BuildableReference>
                </EnvironmentBuildable>
             </ActionContent>
@@ -25,15 +25,15 @@
          <ExecutionAction
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
-               title = "Set Bazel Build Output Groups for c_lib (f321a)"
+               title = "Set Bazel Build Output Groups for private_swift_lib (x86_64) (AppStore, Debug) (7d2e3)"
                scriptText = "echo &quot;$BAZEL_LABEL,$BAZEL_TARGET_ID&quot; &gt;&gt; &quot;$SCHEME_TARGET_IDS_FILE&quot;&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
-                     BlueprintIdentifier = "2734834A28FFEBBA6357B35B"
-                     BuildableName = "c_lib (f321a)"
-                     BlueprintName = "c_lib (f321a)"
-                     ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
+                     BlueprintIdentifier = "63CEFAD4966431863BF44E2E"
+                     BuildableName = "private_swift_lib (x86_64) (AppStore, Debug) (7d2e3)"
+                     BlueprintName = "private_swift_lib (x86_64) (AppStore, Debug) (7d2e3)"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
                   </BuildableReference>
                </EnvironmentBuildable>
             </ActionContent>
@@ -48,10 +48,10 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "2734834A28FFEBBA6357B35B"
-               BuildableName = "c_lib (f321a)"
-               BlueprintName = "c_lib (f321a)"
-               ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
+               BlueprintIdentifier = "63CEFAD4966431863BF44E2E"
+               BuildableName = "private_swift_lib (x86_64) (AppStore, Debug) (7d2e3)"
+               BlueprintName = "private_swift_lib (x86_64) (AppStore, Debug) (7d2e3)"
+               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/private_swift_lib (x86_64) (AppStore, Debug) (f321a).xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/private_swift_lib (x86_64) (AppStore, Debug) (f321a).xcscheme
@@ -14,10 +14,10 @@
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
-                     BlueprintIdentifier = "9C71DD492D8A65449E4BC123"
-                     BuildableName = "lib_impl (7d2e3)"
-                     BlueprintName = "lib_impl (7d2e3)"
-                     ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
+                     BlueprintIdentifier = "7C0C9AEF7453D9B751FA7B88"
+                     BuildableName = "private_swift_lib (x86_64) (AppStore, Debug) (f321a)"
+                     BlueprintName = "private_swift_lib (x86_64) (AppStore, Debug) (f321a)"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
                   </BuildableReference>
                </EnvironmentBuildable>
             </ActionContent>
@@ -25,15 +25,15 @@
          <ExecutionAction
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
-               title = "Set Bazel Build Output Groups for lib_impl (7d2e3)"
+               title = "Set Bazel Build Output Groups for private_swift_lib (x86_64) (AppStore, Debug) (f321a)"
                scriptText = "echo &quot;$BAZEL_LABEL,$BAZEL_TARGET_ID&quot; &gt;&gt; &quot;$SCHEME_TARGET_IDS_FILE&quot;&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
-                     BlueprintIdentifier = "9C71DD492D8A65449E4BC123"
-                     BuildableName = "lib_impl (7d2e3)"
-                     BlueprintName = "lib_impl (7d2e3)"
-                     ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
+                     BlueprintIdentifier = "7C0C9AEF7453D9B751FA7B88"
+                     BuildableName = "private_swift_lib (x86_64) (AppStore, Debug) (f321a)"
+                     BlueprintName = "private_swift_lib (x86_64) (AppStore, Debug) (f321a)"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
                   </BuildableReference>
                </EnvironmentBuildable>
             </ActionContent>
@@ -48,10 +48,10 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "9C71DD492D8A65449E4BC123"
-               BuildableName = "lib_impl (7d2e3)"
-               BlueprintName = "lib_impl (7d2e3)"
-               ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
+               BlueprintIdentifier = "7C0C9AEF7453D9B751FA7B88"
+               BuildableName = "private_swift_lib (x86_64) (AppStore, Debug) (f321a)"
+               BlueprintName = "private_swift_lib (x86_64) (AppStore, Debug) (f321a)"
+               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>

--- a/examples/integration/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -30,10 +30,10 @@
 		0FB9257F29B5174C12CA4769 /* UIFramework.iOS.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D5BBE2ECC921BED8A450ADA7 /* UIFramework.iOS.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		0FF9D4A8602D2544D978E425 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 760F6E68BCA2F8BFE08A3488 /* Assets.xcassets */; };
 		1086EEDE6F79A6219D045DAD /* _CompileStub_.m in Sources */ = {isa = PBXBuildFile; fileRef = 0BD403D59FD279723BD9B059 /* _CompileStub_.m */; };
+		12F3422E8AAA3C2EE8A402C1 /* c_lib.c in Sources */ = {isa = PBXBuildFile; fileRef = 4F21B55C0FF592EB8A6B490E /* c_lib.c */; };
 		130B4EF21F478D0D76C741D0 /* bucket in Resources */ = {isa = PBXBuildFile; fileRef = F6E95C35BFA11ADEFB303262 /* bucket */; };
 		1422B6CB70DF04075ED1840D /* MessagesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB0BFC82E23A0F0BB9D548D4 /* MessagesViewController.swift */; };
 		165C09AD57F00537B44DB24C /* Utils.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 4A76FF6AB0958AAB140741FB /* Utils.bundle */; };
-		1686E3240AD255E446558168 /* lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78D06BF3F4D379602F04C828 /* lib.swift */; };
 		184D98C3D76374B2F6DF2D72 /* LibFramework.iOS.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 1EBCB856193A610747419205 /* LibFramework.iOS.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		18A2579229849145144A051C /* Resources.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1FC7CD938D96895389A09A5 /* Resources.swift */; };
 		191F1E18831DA860A87627D0 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 015E6004A77E27E5BDBF92F8 /* Assets.xcassets */; };
@@ -58,8 +58,6 @@
 		31FB3493B0CBCAB455AFA25D /* GoogleMaps.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 6A49AEE1769DFD7A488B23CB /* GoogleMaps.bundle */; };
 		33C9107F190D8AE3E20C39F2 /* WatchOSAppUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7B005556CA96365E4CD9D39 /* WatchOSAppUITestsLaunchTests.swift */; };
 		34779941BB78F538351B0C0B /* CoreUtilsObjC.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DB1707851007E63305C749E4 /* CoreUtilsObjC.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		35AB4DBFC7AE50D0AF6E36FA /* private_lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F5B724BDC1069B03FE231A1 /* private_lib.swift */; };
-		366945DE1E90608F47744C19 /* private_lib.c in Sources */ = {isa = PBXBuildFile; fileRef = 8782496D7D7A013102474DAC /* private_lib.c */; };
 		369BE4C45C89E24BF5B89491 /* WidgetExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = ACCBAFFBB5927FE7677AD3A7 /* WidgetExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		379ABDCAB2000606A34286D7 /* CoreUtilsObjC.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DB1707851007E63305C749E4 /* CoreUtilsObjC.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		38F12306199D69FD72436245 /* CryptoSwift.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 557A12C749D0A23CF53C12B1 /* CryptoSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -73,9 +71,11 @@
 		45A3BBF20DA02E90B721F5FD /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 015E6004A77E27E5BDBF92F8 /* Assets.xcassets */; };
 		4A23E48D941F964E102BC08B /* WatchOSAppUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0EF429C363C7A90D155EF12 /* WatchOSAppUITests.swift */; };
 		4BAA64EC25430110196B80F8 /* dir in Resources */ = {isa = PBXBuildFile; fileRef = C6ACA6BBC268EAC0509D95BE /* dir */; };
+		4E0EA33B18DD0B68FF60F8EF /* lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78D06BF3F4D379602F04C828 /* lib.swift */; };
 		527F03BE92A466819AB47CBD /* lib.m in Sources */ = {isa = PBXBuildFile; fileRef = A05675A4B440A99E53CDBBA4 /* lib.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		53212E3B2F5BB5FD4ABDFCF8 /* CoreUtilsObjC.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DB1707851007E63305C749E4 /* CoreUtilsObjC.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		5611B7D7DC675A90F3B5EC70 /* Utils.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 4A76FF6AB0958AAB140741FB /* Utils.bundle */; };
+		56842EB50C9C78B710DF2B4E /* lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78D06BF3F4D379602F04C828 /* lib.swift */; };
 		572FAFBEE3430463CCAE4F92 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 015E6004A77E27E5BDBF92F8 /* Assets.xcassets */; };
 		5748C8D48BA08EF8C2F33D56 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FB7044ABA509755C2214F8C0 /* Assets.xcassets */; };
 		57B6669C9AE0F887A3D54BDA /* bucket in Resources */ = {isa = PBXBuildFile; fileRef = 43619E6CF5072EF7FDF3C805 /* bucket */; };
@@ -86,8 +86,7 @@
 		5FD6470DB8CC16471082F3B8 /* LibFramework.watchOS.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 90FC1B8C28EBA9669CB888E0 /* LibFramework.watchOS.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		6001B6EC0F795355FD2D4F19 /* Lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78BFA40ADE9EA85AE0DC7264 /* Lib.swift */; };
 		601DB89F17A2C44AE12A9568 /* iOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 287845DB347C55799A465CCB /* iOSApp.swift */; };
-		60C1DCD7BB4EEE88887C9F87 /* c_lib.c in Sources */ = {isa = PBXBuildFile; fileRef = 4F21B55C0FF592EB8A6B490E /* c_lib.c */; };
-		61FB9BC55A5B5F5EFF2F003D /* private_lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F5B724BDC1069B03FE231A1 /* private_lib.swift */; };
+		605987F9967F3D135903E41B /* private_lib.c in Sources */ = {isa = PBXBuildFile; fileRef = 8782496D7D7A013102474DAC /* private_lib.c */; };
 		629D119D9C3B718A3D8EDFF3 /* unprocessed.json in Resources */ = {isa = PBXBuildFile; fileRef = 6BCA12DCF9A0AC70B5DCBC92 /* unprocessed.json */; };
 		62AAECE2E8AA2533F74E5353 /* TestingUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65724FAA8D54DC9DF3650B98 /* TestingUtils.swift */; };
 		63D45DB646A4C1D2D62C7FF8 /* CryptoSwift.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 31EBAA302BF21712CB52AF4A /* CryptoSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -95,10 +94,10 @@
 		63EB6D30C8ACFED51DD74BD2 /* Lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE234023678C509630A519F /* Lib.swift */; };
 		64B7F1959F949668483B260D /* UIFramework.iOS.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D5BBE2ECC921BED8A450ADA7 /* UIFramework.iOS.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		68DDC334D043370EF3C687CB /* nested in Resources */ = {isa = PBXBuildFile; fileRef = 54F2EEEABB35B30C136E1BFE /* nested */; };
-		69CC32FA87F2EF045D96EF5E /* c_lib.c in Sources */ = {isa = PBXBuildFile; fileRef = 4F21B55C0FF592EB8A6B490E /* c_lib.c */; };
 		6B002EC26AA40F4B4705B73F /* _CompileStub_.m in Sources */ = {isa = PBXBuildFile; fileRef = 0BD403D59FD279723BD9B059 /* _CompileStub_.m */; };
 		6D4F103FDD49B55D34204338 /* Lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF2D6765F21A095C39F95C71 /* Lib.swift */; };
 		6DA1C52EF70B0509B870CEBC /* CoreUtilsObjC.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DB1707851007E63305C749E4 /* CoreUtilsObjC.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		6DCE495DCB4C76361B42F90B /* private_lib.c in Sources */ = {isa = PBXBuildFile; fileRef = 8782496D7D7A013102474DAC /* private_lib.c */; };
 		6DFABA720515679A57B21E9A /* tvOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A8819411CDBE6FBDD4DC5D /* tvOSApp.swift */; };
 		6F76C21A32D2CDD9C895EE43 /* CryptoSwift.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 7B83FA3D9C641551A4E408D2 /* CryptoSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		71B26B7CE70D8AF56D2FFC4E /* private_lib.c in Sources */ = {isa = PBXBuildFile; fileRef = 8782496D7D7A013102474DAC /* private_lib.c */; };
@@ -111,6 +110,7 @@
 		7B6CF17F34BAF9FE09B8721A /* CryptoSwift.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 377BB3CE77D26BF4FC27696B /* CryptoSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7B95FB51C2726ADB3DE139C5 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD9B5C446AD8743E2EC5284C /* ContentView.swift */; };
 		7C5010C0A096F0389262CC35 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DF4802D8580A4DE0B18BE23D /* Assets.xcassets */; };
+		7CBBDEAD3005532EE7C9C151 /* lib.m in Sources */ = {isa = PBXBuildFile; fileRef = A05675A4B440A99E53CDBBA4 /* lib.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		7D4B251FF37D9767A89014AB /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B72CB4B5F7896B3C3EB681E3 /* Assets.xcassets */; };
 		7E46D7B03B74741284C3EACB /* UIFramework.tvOS.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 7E16D0C3B1A292BBEE1E86A9 /* UIFramework.tvOS.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7E8E039A17C3B37272030C11 /* WatchOSAppExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30752600FA7DB86C634859D3 /* WatchOSAppExtensionTests.swift */; };
@@ -125,7 +125,6 @@
 		868A1DC835387DF8B2925C81 /* GoogleMaps.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 655FBBBF8B98FCCFD4A638C4 /* GoogleMaps.bundle */; };
 		86D5122F9B021A7C910EC0F5 /* SwiftUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99E2337032E558F62FD5C809 /* SwiftUnitTests.swift */; };
 		87E3E4E8C9851CE4B951252E /* ObjCUnitTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 157663D9790842ADFB5AA1B5 /* ObjCUnitTests.m */; };
-		8A50B36E3DD12CF3DA507190 /* lib.m in Sources */ = {isa = PBXBuildFile; fileRef = A05675A4B440A99E53CDBBA4 /* lib.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		8CAA9BD47B1C914E70346072 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 015E6004A77E27E5BDBF92F8 /* Assets.xcassets */; };
 		8CE4EDB7AE3A359A8F64B8D8 /* UITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D1C3274E698C0F339AC7EE1 /* UITestsLaunchTests.swift */; };
 		8F4F421F3DB0F7940C9A9F45 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D8F73CFFD89120501DB312CD /* Assets.xcassets */; };
@@ -133,11 +132,11 @@
 		90B2CD75E58ABE23A2B61169 /* CryptoSwift.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 31EBAA302BF21712CB52AF4A /* CryptoSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9190E0BA24E8CA315E23A7B1 /* UIFramework.iOS.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D5BBE2ECC921BED8A450ADA7 /* UIFramework.iOS.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		93B976C2A65BE389D190692F /* Nested in Resources */ = {isa = PBXBuildFile; fileRef = CB4A0FB26B6A160C6B667828 /* Nested */; };
-		94C8FC305B5B45AC1AB5A315 /* lib.m in Sources */ = {isa = PBXBuildFile; fileRef = A05675A4B440A99E53CDBBA4 /* lib.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		96536BFC80D7064031732BC1 /* bucket in Resources */ = {isa = PBXBuildFile; fileRef = 18DA86E29627EB74DD2B794C /* bucket */; };
 		9662270A130DFD557C8BEBA5 /* ExampleResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 0F4BE0C4D3926E5116BC3EF3 /* ExampleResources.bundle */; };
 		968E45E3BD7D19EC94CDF701 /* Intents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99004F8C800E22E644A03FCA /* Intents.swift */; };
 		998F6ABEDFC3F5E18C6F88E1 /* AppClip.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5C7FA633009F456D7C4262 /* AppClip.swift */; };
+		99A63DA891F5FCA7972D7F2D /* lib.m in Sources */ = {isa = PBXBuildFile; fileRef = A05675A4B440A99E53CDBBA4 /* lib.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		9C999017A9F3CD2A43CC4D94 /* Lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CFE89B771BC3C4419F6AB3A /* Lib.swift */; };
 		9E8914B49E2E9F1BFFA0C46D /* LibFramework.iOS.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 1EBCB856193A610747419205 /* LibFramework.iOS.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9E8F04218CC0D3FC3B437FE8 /* LibFramework.tvOS.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F7B18D45E415DC9708319FCC /* LibFramework.tvOS.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -166,7 +165,6 @@
 		B30DE2FDC88B4ECCB2D62FA6 /* CryptoSwift.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 31EBAA302BF21712CB52AF4A /* CryptoSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		B5B2DEF7E38E09E7CD67C7EB /* Utils.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 4A76FF6AB0958AAB140741FB /* Utils.bundle */; };
 		B63CB2DBCB9DFF55C70E6632 /* Lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 622FAD72A152FFD7C047CA44 /* Lib.swift */; };
-		B6A87B09B2A8DA464B4011A4 /* lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78D06BF3F4D379602F04C828 /* lib.swift */; };
 		B73CBF460483486ED2CABE06 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 015E6004A77E27E5BDBF92F8 /* Assets.xcassets */; };
 		B7E9EF7E594CF579430DBCB9 /* UIFramework.iOS.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D5BBE2ECC921BED8A450ADA7 /* UIFramework.iOS.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		B901C52A097EE125016A28B6 /* Intents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74A44B8C4E72BE05EA2D10D6 /* Intents.swift */; };
@@ -176,7 +174,6 @@
 		BF4099D647CD5EEF95F87490 /* watchOSApp.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = 875CA26FB8119C039F89E8E6 /* watchOSApp.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		BF4A220123BB08F8CD1468B0 /* Intents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0803A9144DAAFE13532DD4B3 /* Intents.swift */; };
 		C395444B905557CE7D8DBE5C /* WidgetExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CD2681FF92A3EF76D38D118 /* WidgetExtension.swift */; };
-		C3C07B69C4924DF9F07479EB /* private_lib.c in Sources */ = {isa = PBXBuildFile; fileRef = 8782496D7D7A013102474DAC /* private_lib.c */; };
 		C4E3A4A66F521CA76B65F654 /* Lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = C80082623DF393D6ABC4F9E0 /* Lib.swift */; };
 		C52713F177F42B0488A82FA1 /* launch_images_ios.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0701D4FA5A690C1643D35B00 /* launch_images_ios.xcassets */; };
 		C55FE0873A7924AC2C3EA5E4 /* UITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F43CF7476674E5FCD5C5FBB /* UITests.swift */; };
@@ -187,6 +184,7 @@
 		CB228941B7F5AD23A9A13FE8 /* UnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2124C0E94F14B8B0F71C8AB9 /* UnitTests.swift */; };
 		CB2B50DE11932E4ACB8FC7D3 /* c_lib.c in Sources */ = {isa = PBXBuildFile; fileRef = 4F21B55C0FF592EB8A6B490E /* c_lib.c */; };
 		CD5745F164568030B2814D06 /* Utils.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 4A76FF6AB0958AAB140741FB /* Utils.bundle */; };
+		D050C0109A3CA375ABA53F59 /* private_lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F5B724BDC1069B03FE231A1 /* private_lib.swift */; };
 		D0FDA6922FDA4876D6697366 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 65689CDD728D49E33DAAAFCB /* main.m */; };
 		D28B5A6CC2E73F8BACCE1CF1 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 754CEA6FEB88C4D8BEAEEDFC /* ContentView.swift */; };
 		D4571AB9AF2673144354092D /* Utils.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 4A76FF6AB0958AAB140741FB /* Utils.bundle */; };
@@ -197,6 +195,7 @@
 		DE0B554FBC1DFE58D25B34F9 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 015E6004A77E27E5BDBF92F8 /* Assets.xcassets */; };
 		E0D73FF1F00791FC2DF06E7E /* CryptoSwift.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 31EBAA302BF21712CB52AF4A /* CryptoSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		E0E4271A8675CF758AA32A59 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 754CEA6FEB88C4D8BEAEEDFC /* ContentView.swift */; };
+		E24B13704F7B2585A99E345F /* private_lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F5B724BDC1069B03FE231A1 /* private_lib.swift */; };
 		E278F1DD818736A085E8EF07 /* ExampleNestedResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = BEABA3215EF0ADFD43509CBC /* ExampleNestedResources.bundle */; };
 		E2E1FA252D363BCBAAE2436C /* UIFramework.iOS.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D5BBE2ECC921BED8A450ADA7 /* UIFramework.iOS.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		E372FF2EEEDA50F8041AD197 /* Launch.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AC2F05074197F1DF4452D1AD /* Launch.storyboard */; };
@@ -214,6 +213,7 @@
 		F75625602CA2330C13D16FC1 /* UIFramework.tvOS.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 7E16D0C3B1A292BBEE1E86A9 /* UIFramework.tvOS.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		F9A1CDD0C7F69D98D0FD6E1F /* _CompileStub_.m in Sources */ = {isa = PBXBuildFile; fileRef = 0BD403D59FD279723BD9B059 /* _CompileStub_.m */; };
 		FCAE3377AF6DDF6D1ACFBC78 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A9B9689D76A550CCCEB0600 /* ContentView.swift */; };
+		FD8FE7C2A812138C994CBB43 /* c_lib.c in Sources */ = {isa = PBXBuildFile; fileRef = 4F21B55C0FF592EB8A6B490E /* c_lib.c */; };
 		FE529D1AAD764E573E7F205F /* CryptoSwift.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8E55FC029DC30135EE7BE77F /* CryptoSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
@@ -239,26 +239,12 @@
 			remoteGlobalIDString = FE59281FE487F27A37DC2EE7;
 			remoteInfo = BazelDependencies;
 		};
-		04CC3C9CC35E10E946082E12 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = FE59281FE487F27A37DC2EE7;
-			remoteInfo = BazelDependencies;
-		};
 		05C68ABC4F91593EA8B316F7 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 5CFDBC4E4DBF6C4D68352F7F;
 			remoteInfo = watchOSAppExtension;
-		};
-		067F28CE3926FD219498A734 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 542253A7A8F5937E85688AC7;
-			remoteInfo = "lib_impl (f321a)";
 		};
 		081E2FB24812936174E4E220 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -274,19 +260,19 @@
 			remoteGlobalIDString = EDF8F127D3EA3E7481E6D3D5;
 			remoteInfo = WidgetExtension;
 		};
-		0CB004D72351A1E2D7BB9481 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = FE59281FE487F27A37DC2EE7;
-			remoteInfo = BazelDependencies;
-		};
 		0CC9114A9DE54DD04FDAF560 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 801E2436A69733A307109C9A;
 			remoteInfo = "Lib (iOS, tvOS)";
+		};
+		158DE6C869C2C2D92CAC3633 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = FE59281FE487F27A37DC2EE7;
+			remoteInfo = BazelDependencies;
 		};
 		1886FFEB2BFFAC4EA2CDB93F /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -295,12 +281,12 @@
 			remoteGlobalIDString = FE59281FE487F27A37DC2EE7;
 			remoteInfo = BazelDependencies;
 		};
-		18D15B77DBCA53EBF9C29BE4 /* PBXContainerItemProxy */ = {
+		1C5009EF4D70E3695A0AF216 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = D846E676B1F48432762135EA;
-			remoteInfo = "private_swift_lib (7d2e3)";
+			remoteGlobalIDString = FE59281FE487F27A37DC2EE7;
+			remoteInfo = BazelDependencies;
 		};
 		1D099386CE23C8C50ADAD388 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -308,6 +294,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 801E2436A69733A307109C9A;
 			remoteInfo = "Lib (iOS, tvOS)";
+		};
+		207A806061A813CB7A2DE8AB /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = FE59281FE487F27A37DC2EE7;
+			remoteInfo = BazelDependencies;
 		};
 		219C7173818C041CFDBB63C0 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -386,6 +379,13 @@
 			remoteGlobalIDString = FE59281FE487F27A37DC2EE7;
 			remoteInfo = BazelDependencies;
 		};
+		2DF0EB97585668B432F62605 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = FE59281FE487F27A37DC2EE7;
+			remoteInfo = BazelDependencies;
+		};
 		2E154B3EF64F4E026460D719 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
@@ -420,6 +420,20 @@
 			proxyType = 1;
 			remoteGlobalIDString = FE59281FE487F27A37DC2EE7;
 			remoteInfo = BazelDependencies;
+		};
+		338CBDE4515EA6B8612D848A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1A9C34161E849CD15FAB705B;
+			remoteInfo = "private_lib (x86_64) (AppStore, Debug) (f321a)";
+		};
+		340D17F35CF5FC4A68D9955B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 45DECB1A5D5381A0B8C369B5;
+			remoteInfo = "c_lib (x86_64) (AppStore, Debug) (f321a)";
 		};
 		35F48547FB036B1BB554CB9B /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -470,19 +484,12 @@
 			remoteGlobalIDString = FE59281FE487F27A37DC2EE7;
 			remoteInfo = BazelDependencies;
 		};
-		3F461885C7BC8FEB3E57F57E /* PBXContainerItemProxy */ = {
+		411FEE099F6977264A460603 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = FE59281FE487F27A37DC2EE7;
-			remoteInfo = BazelDependencies;
-		};
-		41FBEED137EE585B3CF723D0 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 2734834A28FFEBBA6357B35B;
-			remoteInfo = "c_lib (f321a)";
+			remoteGlobalIDString = 57840EFFCCDD851E8DCF053C;
+			remoteInfo = "private_swift_lib (x86_64) (AppStore, Debug) (f321a)";
 		};
 		43436D7A65E128E2EE4EBFC0 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -499,6 +506,13 @@
 			remoteInfo = FXPageControl;
 		};
 		4CCF9F788AC4A1B84D4C9BB3 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = FE59281FE487F27A37DC2EE7;
+			remoteInfo = BazelDependencies;
+		};
+		4E725F1A78BC7C54B37FE3B9 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
 			proxyType = 1;
@@ -533,6 +547,13 @@
 			remoteGlobalIDString = FE59281FE487F27A37DC2EE7;
 			remoteInfo = BazelDependencies;
 		};
+		50AF74207A0F8E636616EBD2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C7E68ADCEEDA842BAB2871EB;
+			remoteInfo = "private_lib (x86_64) (AppStore, Debug) (7d2e3)";
+		};
 		51D52A56D93791FCECA02FCC /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
@@ -561,6 +582,13 @@
 			remoteGlobalIDString = 801E2436A69733A307109C9A;
 			remoteInfo = "Lib (iOS, tvOS)";
 		};
+		59733E98E3820E833A9B4336 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 18EBFDB7226F943F66D75280;
+			remoteInfo = "lib_swift (x86_64) (AppStore, Debug) (f321a)";
+		};
 		59AB901F8840A59BA8293207 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
@@ -575,26 +603,26 @@
 			remoteGlobalIDString = FE59281FE487F27A37DC2EE7;
 			remoteInfo = BazelDependencies;
 		};
-		5C5372AF692B38ED5AD1E064 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 7527C82F4364411F5744B4D8;
-			remoteInfo = "lib_swift (f321a)";
-		};
-		5CCFFE8D15F166CAE25116AD /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = FE59281FE487F27A37DC2EE7;
-			remoteInfo = BazelDependencies;
-		};
 		60535305E19F4FB77E265FA4 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = FE59281FE487F27A37DC2EE7;
 			remoteInfo = BazelDependencies;
+		};
+		6253DFCB68B0F35C5605034C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = FE59281FE487F27A37DC2EE7;
+			remoteInfo = BazelDependencies;
+		};
+		65BB234C15DD73F481823927 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 88C064658F18E2860B4D1308;
+			remoteInfo = "lib_impl (x86_64) (AppStore, Debug) (f321a)";
 		};
 		69917F7A7264716F8B632D9A /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -604,13 +632,6 @@
 			remoteInfo = FrameworkCoreUtilsObjC;
 		};
 		69FACF3FCAE1B6A644FAE204 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = FE59281FE487F27A37DC2EE7;
-			remoteInfo = BazelDependencies;
-		};
-		6A68A4C5BB55E3D9D543AD2B /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
 			proxyType = 1;
@@ -638,12 +659,12 @@
 			remoteGlobalIDString = A6969986F4330BE56701A5EC;
 			remoteInfo = iOSApp;
 		};
-		71F80AE4B0931FA69EA90908 /* PBXContainerItemProxy */ = {
+		72EF2FE1CAA89FC61EE1BD3F /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 7527C82F4364411F5744B4D8;
-			remoteInfo = "lib_swift (f321a)";
+			remoteGlobalIDString = 18EBFDB7226F943F66D75280;
+			remoteInfo = "lib_swift (x86_64) (AppStore, Debug) (f321a)";
 		};
 		74B37375F37636668668D9F8 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -652,21 +673,7 @@
 			remoteGlobalIDString = FE59281FE487F27A37DC2EE7;
 			remoteInfo = BazelDependencies;
 		};
-		74F3FF7C3BEADDD0578DECB0 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = E1AC9F0E8F6592B37546029E;
-			remoteInfo = "c_lib (7d2e3)";
-		};
 		7670463AC6A280936CFCC92A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = FE59281FE487F27A37DC2EE7;
-			remoteInfo = BazelDependencies;
-		};
-		772D430D1DF09A26D18B636A /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
 			proxyType = 1;
@@ -708,13 +715,6 @@
 			remoteGlobalIDString = FE59281FE487F27A37DC2EE7;
 			remoteInfo = BazelDependencies;
 		};
-		819FE9CCADFF8E34D4D3A684 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = FE59281FE487F27A37DC2EE7;
-			remoteInfo = BazelDependencies;
-		};
 		840B5F1DA31B9CB21C0D15B4 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
@@ -728,13 +728,6 @@
 			proxyType = 1;
 			remoteGlobalIDString = 801E2436A69733A307109C9A;
 			remoteInfo = "Lib (iOS, tvOS)";
-		};
-		8D100BAFDA353E2ADEB015D8 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 4851285CEF582BBA2236C63B;
-			remoteInfo = "private_swift_lib (f321a)";
 		};
 		8D35E9630EB5441476C1BB79 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -785,19 +778,12 @@
 			remoteGlobalIDString = FE59281FE487F27A37DC2EE7;
 			remoteInfo = BazelDependencies;
 		};
-		9817730F50DC4F11FD4F3FD7 /* PBXContainerItemProxy */ = {
+		96323FF766777D21AC534434 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 611D8A1C90B39DBF5A8073AE;
-			remoteInfo = "private_lib (7d2e3)";
-		};
-		9959E5C98A48E1A82AFF1C9D /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 8558C22680359C7F2E153FBB;
-			remoteInfo = "private_lib (f321a)";
+			remoteGlobalIDString = FE59281FE487F27A37DC2EE7;
+			remoteInfo = BazelDependencies;
 		};
 		998A100407F45D339BD86A63 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -806,6 +792,13 @@
 			remoteGlobalIDString = 9A63A40F4548616B6FC99E1D;
 			remoteInfo = LibFramework.iOS;
 		};
+		9B27CBCDD047AC7667DA1E3C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = FE59281FE487F27A37DC2EE7;
+			remoteInfo = BazelDependencies;
+		};
 		9C6A67C7CAD218F6D033CCD0 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
@@ -813,12 +806,12 @@
 			remoteGlobalIDString = FE59281FE487F27A37DC2EE7;
 			remoteInfo = BazelDependencies;
 		};
-		A19D496B49248A77F54CC291 /* PBXContainerItemProxy */ = {
+		9CC815054A7EE29518CFC1E8 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = FE59281FE487F27A37DC2EE7;
-			remoteInfo = BazelDependencies;
+			remoteGlobalIDString = 2A467471C6406DBFAF8A6490;
+			remoteInfo = "private_swift_lib (x86_64) (AppStore, Debug) (7d2e3)";
 		};
 		A4014EA633D959E595B52DB5 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -834,12 +827,12 @@
 			remoteGlobalIDString = FE59281FE487F27A37DC2EE7;
 			remoteInfo = BazelDependencies;
 		};
-		A6C59C94D5471083E096D5DD /* PBXContainerItemProxy */ = {
+		A78F86DAA5F14E4BBD7EF010 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 9C71DD492D8A65449E4BC123;
-			remoteInfo = "lib_impl (7d2e3)";
+			remoteGlobalIDString = B500D7461E49E54B4ABF62AD;
+			remoteInfo = "lib_swift (x86_64) (AppStore, Debug) (7d2e3)";
 		};
 		A8252B98C6EB8140BC626B35 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -869,6 +862,13 @@
 			remoteGlobalIDString = F3451D8089613E01522F3373;
 			remoteInfo = tvOSApp;
 		};
+		AC03B0F7B49B73697952B491 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DF7734F9DE4017910A9F923A;
+			remoteInfo = "c_lib (x86_64) (AppStore, Debug) (7d2e3)";
+		};
 		AF7D3C9269E3B0ECEC1ADBEB /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
@@ -889,13 +889,6 @@
 			proxyType = 1;
 			remoteGlobalIDString = FE59281FE487F27A37DC2EE7;
 			remoteInfo = BazelDependencies;
-		};
-		B7AAECD762BC05500F1CE48E /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 91F80CE88A7520813ACCC369;
-			remoteInfo = "lib_swift (7d2e3)";
 		};
 		B7BF2C5657C0BE354B8C4205 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -925,7 +918,7 @@
 			remoteGlobalIDString = FE59281FE487F27A37DC2EE7;
 			remoteInfo = BazelDependencies;
 		};
-		BF28CF27A4DAB78914F9F93D /* PBXContainerItemProxy */ = {
+		BF1897C32881F371D69A141B /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
 			proxyType = 1;
@@ -945,6 +938,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = FE59281FE487F27A37DC2EE7;
 			remoteInfo = BazelDependencies;
+		};
+		CC5757B817F8DBE2D1A5DA42 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 8B80C81E05DBE296D69AC29B;
+			remoteInfo = "lib_impl (x86_64) (AppStore, Debug) (7d2e3)";
 		};
 		CCF5F999C38B7E9F08FF3C7F /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -1008,13 +1008,6 @@
 			proxyType = 1;
 			remoteGlobalIDString = 1FE2666583AC1B0FDD36DE7F;
 			remoteInfo = "c_lib (arm64)";
-		};
-		DC73EE843C874A3456BEB5EE /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = FE59281FE487F27A37DC2EE7;
-			remoteInfo = BazelDependencies;
 		};
 		E4573A6FD29D46BCB02A7464 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -1092,6 +1085,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 42E984F26D5B4ECBE0F0F076;
 			remoteInfo = Utils;
+		};
+		F350A9413E8754DB052FAC46 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = FE59281FE487F27A37DC2EE7;
+			remoteInfo = BazelDependencies;
 		};
 		F42CD9468A9C7900AB998DA9 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -7985,6 +7985,27 @@
 			productReference = 875CA26FB8119C039F89E8E6 /* watchOSApp.app */;
 			productType = "com.apple.product-type.application.watchapp2";
 		};
+		18EBFDB7226F943F66D75280 /* lib_swift (x86_64) (AppStore, Debug) (f321a) */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = BF8BBCA83CD8BF317DB0F35B /* Build configuration list for PBXNativeTarget "lib_swift (x86_64) (AppStore, Debug) (f321a)" */;
+			buildPhases = (
+				6B7190B74B0F911B8B8A7703 /* Create Compile Dependencies */,
+				A4C7AB9EEF71C4C135E51469 /* Sources */,
+				419DDBDB245D93A06EB593E2 /* Copy Swift Generated Header */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				490BE75254CF14DBFD3967A9 /* PBXTargetDependency */,
+				FD44F577181C4EA4B1686B10 /* PBXTargetDependency */,
+				9C6A21C6D9A3B9501FA53A3E /* PBXTargetDependency */,
+				C5F64742812AB9D21735AEEF /* PBXTargetDependency */,
+				E15911C0BCA9605B3E309E92 /* PBXTargetDependency */,
+			);
+			name = "lib_swift (x86_64) (AppStore, Debug) (f321a)";
+			productName = lib_swift;
+			productType = "com.apple.product-type.library.static";
+		};
 		195D1619C173ADE9E5CEE20A /* tvOS */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = CE8EC23F8BA0F8067187BFCC /* Build configuration list for PBXNativeTarget "tvOS" */;
@@ -8024,6 +8045,22 @@
 			productReference = 7E16D0C3B1A292BBEE1E86A9 /* UIFramework.tvOS.framework */;
 			productType = "com.apple.product-type.framework";
 		};
+		1A9C34161E849CD15FAB705B /* private_lib (x86_64) (AppStore, Debug) (f321a) */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4E70667A9C7709E9114CE9E7 /* Build configuration list for PBXNativeTarget "private_lib (x86_64) (AppStore, Debug) (f321a)" */;
+			buildPhases = (
+				A8FD19CB22AC63A8C473CE34 /* Create Compile Dependencies */,
+				8E5F126980F0EA99F719A38B /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				7645DA46167EA76B76D24DCA /* PBXTargetDependency */,
+			);
+			name = "private_lib (x86_64) (AppStore, Debug) (f321a)";
+			productName = private_lib;
+			productType = "com.apple.product-type.library.static";
+		};
 		1FE2666583AC1B0FDD36DE7F /* c_lib (arm64) */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = D9AA4D79563CF098065FCC38 /* Build configuration list for PBXNativeTarget "c_lib (arm64)" */;
@@ -8057,20 +8094,20 @@
 			productReference = 0F4BE0C4D3926E5116BC3EF3 /* ExampleResources.bundle */;
 			productType = "com.apple.product-type.bundle";
 		};
-		2734834A28FFEBBA6357B35B /* c_lib (f321a) */ = {
+		2A467471C6406DBFAF8A6490 /* private_swift_lib (x86_64) (AppStore, Debug) (7d2e3) */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = B963F55C245117E81DB6E0E1 /* Build configuration list for PBXNativeTarget "c_lib (f321a)" */;
+			buildConfigurationList = 1EC13BFED89B1AC6B5C81EA2 /* Build configuration list for PBXNativeTarget "private_swift_lib (x86_64) (AppStore, Debug) (7d2e3)" */;
 			buildPhases = (
-				91F3D5ABC835E831B75DAEDD /* Create Compile Dependencies */,
-				EB34A1E53D56AFEE0D0219C6 /* Sources */,
+				0812806A7C69C3FE429B89BF /* Create Compile Dependencies */,
+				1E3A54FBAF4ED761EB2D0ED7 /* Sources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				F06D93E7BB82298144297B31 /* PBXTargetDependency */,
+				6A78C744F6EF05B5DF6A086A /* PBXTargetDependency */,
 			);
-			name = "c_lib (f321a)";
-			productName = c_lib;
+			name = "private_swift_lib (x86_64) (AppStore, Debug) (7d2e3)";
+			productName = private_swift_lib;
 			productType = "com.apple.product-type.library.static";
 		};
 		2B369B164AB3542A258E8E5F /* AppClip */ = {
@@ -8215,6 +8252,22 @@
 			productName = Utils;
 			productType = "com.apple.product-type.library.static";
 		};
+		45DECB1A5D5381A0B8C369B5 /* c_lib (x86_64) (AppStore, Debug) (f321a) */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CD26F273670416B5D6C5FCDC /* Build configuration list for PBXNativeTarget "c_lib (x86_64) (AppStore, Debug) (f321a)" */;
+			buildPhases = (
+				8AD42718481CD96E91DF1C54 /* Create Compile Dependencies */,
+				C3E6AAB46388D0B61EE36EE7 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				FBD0D605B2E46735AB9C0662 /* PBXTargetDependency */,
+			);
+			name = "c_lib (x86_64) (AppStore, Debug) (f321a)";
+			productName = c_lib;
+			productType = "com.apple.product-type.library.static";
+		};
 		467E28CECC74A90D0BF1F0D5 /* watchOSAppUITests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = A982990F8A8FCABCC0A40AA5 /* Build configuration list for PBXNativeTarget "watchOSAppUITests" */;
@@ -8233,22 +8286,6 @@
 			productName = watchOSAppUITests;
 			productReference = 68113755D035683C8D9BF0A7 /* watchOSAppUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
-		};
-		4851285CEF582BBA2236C63B /* private_swift_lib (f321a) */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 09155DEE008B6A1F2281FDA3 /* Build configuration list for PBXNativeTarget "private_swift_lib (f321a)" */;
-			buildPhases = (
-				5B074C7D26426A511379C4AB /* Create Compile Dependencies */,
-				FC2D1EBD6441F6AB77E71466 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				5F548667511F21793E364B60 /* PBXTargetDependency */,
-			);
-			name = "private_swift_lib (f321a)";
-			productName = private_swift_lib;
-			productType = "com.apple.product-type.library.static";
 		};
 		4A81F3A0DADC86D2FCF01DB1 /* iMessageApp */ = {
 			isa = PBXNativeTarget;
@@ -8289,22 +8326,6 @@
 			productName = lib_swift;
 			productType = "com.apple.product-type.library.static";
 		};
-		542253A7A8F5937E85688AC7 /* lib_impl (f321a) */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 1095547928A5213280187B21 /* Build configuration list for PBXNativeTarget "lib_impl (f321a)" */;
-			buildPhases = (
-				5ABCA7A4156595FF718E4304 /* Create Compile Dependencies */,
-				95D5218E2836A7CCDD63EDFA /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				3FB9ECBFFB302E9C34244EE9 /* PBXTargetDependency */,
-			);
-			name = "lib_impl (f321a)";
-			productName = lib_impl;
-			productType = "com.apple.product-type.library.static";
-		};
 		54498588592BF5753EB929CC /* private_swift_lib (arm64) */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 5C2809BDC9E86ED82DEC3B06 /* Build configuration list for PBXNativeTarget "private_swift_lib (arm64)" */;
@@ -8318,6 +8339,22 @@
 				FC24B99A330052D21AE04299 /* PBXTargetDependency */,
 			);
 			name = "private_swift_lib (arm64)";
+			productName = private_swift_lib;
+			productType = "com.apple.product-type.library.static";
+		};
+		57840EFFCCDD851E8DCF053C /* private_swift_lib (x86_64) (AppStore, Debug) (f321a) */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 23F0C19595B9825F67644351 /* Build configuration list for PBXNativeTarget "private_swift_lib (x86_64) (AppStore, Debug) (f321a)" */;
+			buildPhases = (
+				2B7FD8BEBE4854259D135999 /* Create Compile Dependencies */,
+				3CDFA93F6AF890AC33E34A77 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				248A0DAF6D48F5B24A42D29D /* PBXTargetDependency */,
+			);
+			name = "private_swift_lib (x86_64) (AppStore, Debug) (f321a)";
 			productName = private_swift_lib;
 			productType = "com.apple.product-type.library.static";
 		};
@@ -8379,22 +8416,6 @@
 			productName = MixedAnswer;
 			productType = "com.apple.product-type.library.static";
 		};
-		611D8A1C90B39DBF5A8073AE /* private_lib (7d2e3) */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 0C75F94110BF70FFE03C758F /* Build configuration list for PBXNativeTarget "private_lib (7d2e3)" */;
-			buildPhases = (
-				A9A78F0B9D7C0BD1C3C18F17 /* Create Compile Dependencies */,
-				E0988D9559BEA3812296EEF2 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				FA1292EB5770848F064B2E72 /* PBXTargetDependency */,
-			);
-			name = "private_lib (7d2e3)";
-			productName = private_lib;
-			productType = "com.apple.product-type.library.static";
-		};
 		63A26735968A55ECFF1DB504 /* OnlyStructuredResources */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 311205EEAE7948C675361FD3 /* Build configuration list for PBXNativeTarget "OnlyStructuredResources" */;
@@ -8410,27 +8431,6 @@
 			productName = OnlyStructuredResources;
 			productReference = DF443AB455A2BDD3CD13671D /* OnlyStructuredResources.bundle */;
 			productType = "com.apple.product-type.bundle";
-		};
-		7527C82F4364411F5744B4D8 /* lib_swift (f321a) */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 8326DD2A212C1AE4B1977C4E /* Build configuration list for PBXNativeTarget "lib_swift (f321a)" */;
-			buildPhases = (
-				3980CAE3BC22FBEBDBA516E2 /* Create Compile Dependencies */,
-				C6F97A8F1A2EA0F7A3F260D7 /* Sources */,
-				FA1DAC62B62F973746A5DE4C /* Copy Swift Generated Header */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				CDD27EFC7FD934C6E54D9B63 /* PBXTargetDependency */,
-				DB0E09D20576B42DE2C48628 /* PBXTargetDependency */,
-				8E212110C1EE678F0F796DCE /* PBXTargetDependency */,
-				CECEE269FD5823A1AECB5DC6 /* PBXTargetDependency */,
-				853B16082C4B9D5701BA4140 /* PBXTargetDependency */,
-			);
-			name = "lib_swift (f321a)";
-			productName = lib_swift;
-			productType = "com.apple.product-type.library.static";
 		};
 		7856014E22F3CF45191565D8 /* iOSAppSwiftUnitTestSuite */ = {
 			isa = PBXNativeTarget;
@@ -8487,22 +8487,6 @@
 			productName = Lib;
 			productType = "com.apple.product-type.library.static";
 		};
-		8558C22680359C7F2E153FBB /* private_lib (f321a) */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 41486CA13CC9C13F8E072C5A /* Build configuration list for PBXNativeTarget "private_lib (f321a)" */;
-			buildPhases = (
-				A7D86610F30A0702134FB2E0 /* Create Compile Dependencies */,
-				3FE7B4E3298797B49F97BD63 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				F11F1E3E0D3BE2856787CF03 /* PBXTargetDependency */,
-			);
-			name = "private_lib (f321a)";
-			productName = private_lib;
-			productType = "com.apple.product-type.library.static";
-		};
 		8623E585005AABB68B7E9EA9 /* watchOS */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = DE753F1584BAEEE9E9B3D961 /* Build configuration list for PBXNativeTarget "watchOS" */;
@@ -8522,6 +8506,38 @@
 			productReference = 38D51FF469C531901A0E5BFF /* Lib.framework */;
 			productType = "com.apple.product-type.framework";
 		};
+		88C064658F18E2860B4D1308 /* lib_impl (x86_64) (AppStore, Debug) (f321a) */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F37E2A4E58E880A623B46859 /* Build configuration list for PBXNativeTarget "lib_impl (x86_64) (AppStore, Debug) (f321a)" */;
+			buildPhases = (
+				87B90DB893F637375CAA71A4 /* Create Compile Dependencies */,
+				69571B50DAE941E73E530C47 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				32BEBE775260B86528982694 /* PBXTargetDependency */,
+			);
+			name = "lib_impl (x86_64) (AppStore, Debug) (f321a)";
+			productName = lib_impl;
+			productType = "com.apple.product-type.library.static";
+		};
+		8B80C81E05DBE296D69AC29B /* lib_impl (x86_64) (AppStore, Debug) (7d2e3) */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = BFDE7EAE4E4C4CC64C96FAC7 /* Build configuration list for PBXNativeTarget "lib_impl (x86_64) (AppStore, Debug) (7d2e3)" */;
+			buildPhases = (
+				63E8B7B8CC200FDFA48C3B6A /* Create Compile Dependencies */,
+				3D742D78BA9CCF908638191D /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				C94E60053FE49F1B5D71ADAD /* PBXTargetDependency */,
+			);
+			name = "lib_impl (x86_64) (AppStore, Debug) (7d2e3)";
+			productName = lib_impl;
+			productType = "com.apple.product-type.library.static";
+		};
 		8FA9DDD71D382CE2CA2EA479 /* CommandLineToolTests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = C2AF4B2E43CD186F81802626 /* Build configuration list for PBXNativeTarget "CommandLineToolTests" */;
@@ -8534,33 +8550,12 @@
 			);
 			dependencies = (
 				F3844F43AF08C58DC8AC4BBA /* PBXTargetDependency */,
-				BBF757D194C176423B838CFF /* PBXTargetDependency */,
+				A8E93EF9757F641480360C1D /* PBXTargetDependency */,
 			);
 			name = CommandLineToolTests;
 			productName = CommandLineToolTests;
 			productReference = 273ED34283627367087A2DE0 /* CommandLineToolTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
-		};
-		91F80CE88A7520813ACCC369 /* lib_swift (7d2e3) */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 1128F3E395E78E23EB6D5B91 /* Build configuration list for PBXNativeTarget "lib_swift (7d2e3)" */;
-			buildPhases = (
-				BD2288D4111437A7392E5A64 /* Create Compile Dependencies */,
-				0D7A3D9439ADAF6DEB49EF83 /* Sources */,
-				1F8F2A83D1F3028FC1639EBC /* Copy Swift Generated Header */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				75218D38F19B2B9B04AC1B21 /* PBXTargetDependency */,
-				394FFAEEC76EB8CD18C84272 /* PBXTargetDependency */,
-				744C45FDD9F30FE92F5E2817 /* PBXTargetDependency */,
-				0BA4E71970F01636A02ACBDB /* PBXTargetDependency */,
-				5C832B9A4286482DFE3DC5EA /* PBXTargetDependency */,
-			);
-			name = "lib_swift (7d2e3)";
-			productName = lib_swift;
-			productType = "com.apple.product-type.library.static";
 		};
 		967BEB9EDFB3230C10A206A8 /* ExampleNestedResources */ = {
 			isa = PBXNativeTarget;
@@ -8616,22 +8611,6 @@
 			productReference = 1EBCB856193A610747419205 /* LibFramework.iOS.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		9C71DD492D8A65449E4BC123 /* lib_impl (7d2e3) */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 4D10CA380FCA6483AA8BB8C6 /* Build configuration list for PBXNativeTarget "lib_impl (7d2e3)" */;
-			buildPhases = (
-				EC1F34FE5E774F428A851792 /* Create Compile Dependencies */,
-				80BBCEE7E8395C73D2E61681 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				F6403A398D9A393ADA366FAD /* PBXTargetDependency */,
-			);
-			name = "lib_impl (7d2e3)";
-			productName = lib_impl;
-			productType = "com.apple.product-type.library.static";
-		};
 		9CAD5D6707650AAEF4E3F2E1 /* UniversalCommandLineTool (x86_64) */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 234E93B143A482D3E6BAC00F /* Build configuration list for PBXNativeTarget "UniversalCommandLineTool (x86_64)" */;
@@ -8644,7 +8623,7 @@
 			);
 			dependencies = (
 				6D862D3B79A09124312600DB /* PBXTargetDependency */,
-				EF9768AF15F1747E2DDF952C /* PBXTargetDependency */,
+				65F45385847A99E9EB388ABA /* PBXTargetDependency */,
 			);
 			name = "UniversalCommandLineTool (x86_64)";
 			productName = tool.binary;
@@ -8754,6 +8733,27 @@
 			productReference = 8E205A52812E240195D79B15 /* iOSApp.app */;
 			productType = "com.apple.product-type.application";
 		};
+		B500D7461E49E54B4ABF62AD /* lib_swift (x86_64) (AppStore, Debug) (7d2e3) */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 2003168C8BD7440BCF5A0785 /* Build configuration list for PBXNativeTarget "lib_swift (x86_64) (AppStore, Debug) (7d2e3)" */;
+			buildPhases = (
+				BDB606D4824450DEC2BB8209 /* Create Compile Dependencies */,
+				980EBBEAA5C34F04519047C3 /* Sources */,
+				C95E422FB32766A306D9ABA7 /* Copy Swift Generated Header */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				3D49B9164394F075FFC6BA1E /* PBXTargetDependency */,
+				371134E5C2803884A7CF82FD /* PBXTargetDependency */,
+				ADE9FC8783121D536FE473EB /* PBXTargetDependency */,
+				CB7D3F280FFE375024126328 /* PBXTargetDependency */,
+				C10E806C9E8CDDE71EAC2B9F /* PBXTargetDependency */,
+			);
+			name = "lib_swift (x86_64) (AppStore, Debug) (7d2e3)";
+			productName = lib_swift;
+			productType = "com.apple.product-type.library.static";
+		};
 		C2146B07C477F3A0DBE35CF0 /* lib_impl (arm64) */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 45E3A2B7B62C7DE74553D29E /* Build configuration list for PBXNativeTarget "lib_impl (arm64)" */;
@@ -8789,6 +8789,22 @@
 			productName = macOSApp;
 			productReference = D26878E809365B31E2703935 /* macOSApp.app */;
 			productType = "com.apple.product-type.application";
+		};
+		C7E68ADCEEDA842BAB2871EB /* private_lib (x86_64) (AppStore, Debug) (7d2e3) */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C0BB834880525F419C3E1A7E /* Build configuration list for PBXNativeTarget "private_lib (x86_64) (AppStore, Debug) (7d2e3)" */;
+			buildPhases = (
+				13815978D231744B9F07B089 /* Create Compile Dependencies */,
+				626FE50E783A7D0829D3B6F4 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				532C175E95C8CAC605FC31D5 /* PBXTargetDependency */,
+			);
+			name = "private_lib (x86_64) (AppStore, Debug) (7d2e3)";
+			productName = private_lib;
+			productType = "com.apple.product-type.library.static";
 		};
 		C93619DEF86AEE901BCD284F /* MixedAnswerLib_Swift */ = {
 			isa = PBXNativeTarget;
@@ -8842,22 +8858,6 @@
 			productReference = 31B1ED6F4F8AF652CEF907BB /* macOSAppUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
 		};
-		D846E676B1F48432762135EA /* private_swift_lib (7d2e3) */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 44A40F49D6F3B3C380D8D9E7 /* Build configuration list for PBXNativeTarget "private_swift_lib (7d2e3)" */;
-			buildPhases = (
-				EF185F900EC0B2F226AAA91B /* Create Compile Dependencies */,
-				FA83AE917647550FD8FAD528 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				AC36454755E42F40D48D50EA /* PBXTargetDependency */,
-			);
-			name = "private_swift_lib (7d2e3)";
-			productName = private_swift_lib;
-			productType = "com.apple.product-type.library.static";
-		};
 		DA7E64AB7A271CC3B9544C5B /* iOSAppUITestSuite */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = C25E26F9376FAC3E7B759D5D /* Build configuration list for PBXNativeTarget "iOSAppUITestSuite" */;
@@ -8879,19 +8879,19 @@
 			productReference = F8B21E88873D0E1BFD997B1D /* iOSAppUITestSuite.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
 		};
-		E1AC9F0E8F6592B37546029E /* c_lib (7d2e3) */ = {
+		DF7734F9DE4017910A9F923A /* c_lib (x86_64) (AppStore, Debug) (7d2e3) */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 8FE580A94BC634B0A5F369F3 /* Build configuration list for PBXNativeTarget "c_lib (7d2e3)" */;
+			buildConfigurationList = 9E2E6F3C826280D76AC9B4DB /* Build configuration list for PBXNativeTarget "c_lib (x86_64) (AppStore, Debug) (7d2e3)" */;
 			buildPhases = (
-				534EBA2B0416BA074181EC8C /* Create Compile Dependencies */,
-				A023342241C016F204F076E0 /* Sources */,
+				78E53AE35BD6EF15BC40305A /* Create Compile Dependencies */,
+				483FA841CFEA6E039747635F /* Sources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				359BEC0F8CEC327ADD97B70E /* PBXTargetDependency */,
+				DCB0A7CBE6EB543A86922852 /* PBXTargetDependency */,
 			);
-			name = "c_lib (7d2e3)";
+			name = "c_lib (x86_64) (AppStore, Debug) (7d2e3)";
 			productName = c_lib;
 			productType = "com.apple.product-type.library.static";
 		};
@@ -8931,7 +8931,7 @@
 			);
 			dependencies = (
 				5BE620DBCA4D9D3D7F686A59 /* PBXTargetDependency */,
-				B584C747FBC65CCC3C853B46 /* PBXTargetDependency */,
+				5ED261CF54335CBDF549C992 /* PBXTargetDependency */,
 			);
 			name = CommandLineTool;
 			productName = CommandLineTool;
@@ -9117,11 +9117,19 @@
 						CreatedOnToolsVersion = 13.0.0;
 						LastSwiftMigration = 9999;
 					};
+					18EBFDB7226F943F66D75280 = {
+						CreatedOnToolsVersion = 13.0.0;
+						LastSwiftMigration = 9999;
+					};
 					195D1619C173ADE9E5CEE20A = {
 						CreatedOnToolsVersion = 13.0.0;
 						LastSwiftMigration = 9999;
 					};
 					197909C893D71098F7D5178C = {
+						CreatedOnToolsVersion = 13.0.0;
+						LastSwiftMigration = 9999;
+					};
+					1A9C34161E849CD15FAB705B = {
 						CreatedOnToolsVersion = 13.0.0;
 						LastSwiftMigration = 9999;
 					};
@@ -9133,7 +9141,7 @@
 						CreatedOnToolsVersion = 13.0.0;
 						LastSwiftMigration = 9999;
 					};
-					2734834A28FFEBBA6357B35B = {
+					2A467471C6406DBFAF8A6490 = {
 						CreatedOnToolsVersion = 13.0.0;
 						LastSwiftMigration = 9999;
 					};
@@ -9168,14 +9176,14 @@
 						CreatedOnToolsVersion = 13.0.0;
 						LastSwiftMigration = 9999;
 					};
+					45DECB1A5D5381A0B8C369B5 = {
+						CreatedOnToolsVersion = 13.0.0;
+						LastSwiftMigration = 9999;
+					};
 					467E28CECC74A90D0BF1F0D5 = {
 						CreatedOnToolsVersion = 13.0.0;
 						LastSwiftMigration = 9999;
 						TestTargetID = 182B42EFE70A5561F1C023E5;
-					};
-					4851285CEF582BBA2236C63B = {
-						CreatedOnToolsVersion = 13.0.0;
-						LastSwiftMigration = 9999;
 					};
 					4A81F3A0DADC86D2FCF01DB1 = {
 						CreatedOnToolsVersion = 13.0.0;
@@ -9185,11 +9193,11 @@
 						CreatedOnToolsVersion = 13.0.0;
 						LastSwiftMigration = 9999;
 					};
-					542253A7A8F5937E85688AC7 = {
+					54498588592BF5753EB929CC = {
 						CreatedOnToolsVersion = 13.0.0;
 						LastSwiftMigration = 9999;
 					};
-					54498588592BF5753EB929CC = {
+					57840EFFCCDD851E8DCF053C = {
 						CreatedOnToolsVersion = 13.0.0;
 						LastSwiftMigration = 9999;
 					};
@@ -9205,15 +9213,7 @@
 						CreatedOnToolsVersion = 13.0.0;
 						LastSwiftMigration = 9999;
 					};
-					611D8A1C90B39DBF5A8073AE = {
-						CreatedOnToolsVersion = 13.0.0;
-						LastSwiftMigration = 9999;
-					};
 					63A26735968A55ECFF1DB504 = {
-						CreatedOnToolsVersion = 13.0.0;
-						LastSwiftMigration = 9999;
-					};
-					7527C82F4364411F5744B4D8 = {
 						CreatedOnToolsVersion = 13.0.0;
 						LastSwiftMigration = 9999;
 					};
@@ -9230,19 +9230,19 @@
 						CreatedOnToolsVersion = 13.0.0;
 						LastSwiftMigration = 9999;
 					};
-					8558C22680359C7F2E153FBB = {
-						CreatedOnToolsVersion = 13.0.0;
-						LastSwiftMigration = 9999;
-					};
 					8623E585005AABB68B7E9EA9 = {
 						CreatedOnToolsVersion = 13.0.0;
 						LastSwiftMigration = 9999;
 					};
-					8FA9DDD71D382CE2CA2EA479 = {
+					88C064658F18E2860B4D1308 = {
 						CreatedOnToolsVersion = 13.0.0;
 						LastSwiftMigration = 9999;
 					};
-					91F80CE88A7520813ACCC369 = {
+					8B80C81E05DBE296D69AC29B = {
+						CreatedOnToolsVersion = 13.0.0;
+						LastSwiftMigration = 9999;
+					};
+					8FA9DDD71D382CE2CA2EA479 = {
 						CreatedOnToolsVersion = 13.0.0;
 						LastSwiftMigration = 9999;
 					};
@@ -9255,10 +9255,6 @@
 						LastSwiftMigration = 9999;
 					};
 					9A63A40F4548616B6FC99E1D = {
-						CreatedOnToolsVersion = 13.0.0;
-						LastSwiftMigration = 9999;
-					};
-					9C71DD492D8A65449E4BC123 = {
 						CreatedOnToolsVersion = 13.0.0;
 						LastSwiftMigration = 9999;
 					};
@@ -9286,11 +9282,19 @@
 						CreatedOnToolsVersion = 13.0.0;
 						LastSwiftMigration = 9999;
 					};
+					B500D7461E49E54B4ABF62AD = {
+						CreatedOnToolsVersion = 13.0.0;
+						LastSwiftMigration = 9999;
+					};
 					C2146B07C477F3A0DBE35CF0 = {
 						CreatedOnToolsVersion = 13.0.0;
 						LastSwiftMigration = 9999;
 					};
 					C57AEABC99C185745155C88B = {
+						CreatedOnToolsVersion = 13.0.0;
+						LastSwiftMigration = 9999;
+					};
+					C7E68ADCEEDA842BAB2871EB = {
 						CreatedOnToolsVersion = 13.0.0;
 						LastSwiftMigration = 9999;
 					};
@@ -9307,16 +9311,12 @@
 						LastSwiftMigration = 9999;
 						TestTargetID = C57AEABC99C185745155C88B;
 					};
-					D846E676B1F48432762135EA = {
-						CreatedOnToolsVersion = 13.0.0;
-						LastSwiftMigration = 9999;
-					};
 					DA7E64AB7A271CC3B9544C5B = {
 						CreatedOnToolsVersion = 13.0.0;
 						LastSwiftMigration = 9999;
 						TestTargetID = A6969986F4330BE56701A5EC;
 					};
-					E1AC9F0E8F6592B37546029E = {
+					DF7734F9DE4017910A9F923A = {
 						CreatedOnToolsVersion = 13.0.0;
 						LastSwiftMigration = 9999;
 					};
@@ -9386,9 +9386,9 @@
 				2B369B164AB3542A258E8E5F /* AppClip */,
 				3870FDB0799C63AFEE5652AF /* BasicTests */,
 				9E1DB51FB27ADC8C6C715FC1 /* Bundle */,
-				E1AC9F0E8F6592B37546029E /* c_lib (7d2e3) */,
 				1FE2666583AC1B0FDD36DE7F /* c_lib (arm64) */,
-				2734834A28FFEBBA6357B35B /* c_lib (f321a) */,
+				DF7734F9DE4017910A9F923A /* c_lib (x86_64) (AppStore, Debug) (7d2e3) */,
+				45DECB1A5D5381A0B8C369B5 /* c_lib (x86_64) (AppStore, Debug) (f321a) */,
 				E569989878EC4D26C4EA6DD0 /* CommandLineTool */,
 				8FA9DDD71D382CE2CA2EA479 /* CommandLineToolTests */,
 				967BEB9EDFB3230C10A206A8 /* ExampleNestedResources */,
@@ -9408,12 +9408,12 @@
 				DA7E64AB7A271CC3B9544C5B /* iOSAppUITestSuite */,
 				801E2436A69733A307109C9A /* Lib (iOS, tvOS) */,
 				D094AA317C2527FB0FCC5015 /* Lib (watchOS) */,
-				9C71DD492D8A65449E4BC123 /* lib_impl (7d2e3) */,
 				C2146B07C477F3A0DBE35CF0 /* lib_impl (arm64) */,
-				542253A7A8F5937E85688AC7 /* lib_impl (f321a) */,
-				91F80CE88A7520813ACCC369 /* lib_swift (7d2e3) */,
+				8B80C81E05DBE296D69AC29B /* lib_impl (x86_64) (AppStore, Debug) (7d2e3) */,
+				88C064658F18E2860B4D1308 /* lib_impl (x86_64) (AppStore, Debug) (f321a) */,
 				4D0BA3037D9626451A75ADA8 /* lib_swift (arm64) */,
-				7527C82F4364411F5744B4D8 /* lib_swift (f321a) */,
+				B500D7461E49E54B4ABF62AD /* lib_swift (x86_64) (AppStore, Debug) (7d2e3) */,
+				18EBFDB7226F943F66D75280 /* lib_swift (x86_64) (AppStore, Debug) (f321a) */,
 				9A63A40F4548616B6FC99E1D /* LibFramework.iOS */,
 				E59E7209EEB2E6FF3F683DA8 /* LibFramework.tvOS */,
 				FCD6C01B0D3A454C7E6FF907 /* LibFramework.watchOS */,
@@ -9422,12 +9422,12 @@
 				5FA2D9F9C17E1D1EB104E453 /* MixedAnswer */,
 				C93619DEF86AEE901BCD284F /* MixedAnswerLib_Swift */,
 				63A26735968A55ECFF1DB504 /* OnlyStructuredResources */,
-				611D8A1C90B39DBF5A8073AE /* private_lib (7d2e3) */,
 				FECC7CB2523F6B65321177A9 /* private_lib (arm64) */,
-				8558C22680359C7F2E153FBB /* private_lib (f321a) */,
-				D846E676B1F48432762135EA /* private_swift_lib (7d2e3) */,
+				C7E68ADCEEDA842BAB2871EB /* private_lib (x86_64) (AppStore, Debug) (7d2e3) */,
+				1A9C34161E849CD15FAB705B /* private_lib (x86_64) (AppStore, Debug) (f321a) */,
 				54498588592BF5753EB929CC /* private_swift_lib (arm64) */,
-				4851285CEF582BBA2236C63B /* private_swift_lib (f321a) */,
+				2A467471C6406DBFAF8A6490 /* private_swift_lib (x86_64) (AppStore, Debug) (7d2e3) */,
+				57840EFFCCDD851E8DCF053C /* private_swift_lib (x86_64) (AppStore, Debug) (f321a) */,
 				42A7256A505DA3DFEA69C941 /* TestingUtils */,
 				195D1619C173ADE9E5CEE20A /* tvOS */,
 				F3451D8089613E01522F3373 /* tvOSApp */,
@@ -9759,6 +9759,23 @@
 			shellScript = "set -euo pipefail\n\nif [[ \"$ACTION\" == \"indexbuild\" ]]; then\n  touch \"$SCRIPT_OUTPUT_FILE_0\"\nelse\nperl -pe 's/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\nfi\n";
 			showEnvVarsInLog = 0;
 		};
+		0812806A7C69C3FE429B89BF /* Create Compile Dependencies */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SWIFT_PARAMS_FILE)",
+			);
+			name = "Create Compile Dependencies";
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/swift.compile.params",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -euo pipefail\n\nperl -pe '\n  s/__BAZEL_XCODE_DEVELOPER_DIR__/\\$(DEVELOPER_DIR)/g;\n  s/__BAZEL_XCODE_SDKROOT__/\\$(SDKROOT)/g;\n  s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/gx;\n' \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
+			showEnvVarsInLog = 0;
+		};
 		0B00416E89C2B1A1A02270F5 /* Create Link Dependencies */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -9791,6 +9808,24 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "if [[ -z \"${SWIFT_OBJC_INTERFACE_HEADER_NAME:-}\" ]]; then\n  exit 0\nfi\n\ncp \"${SCRIPT_INPUT_FILE_0}\" \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		13815978D231744B9F07B089 /* Create Compile Dependencies */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(C_PARAMS_FILE)",
+			);
+			name = "Create Compile Dependencies";
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/c.compile.params",
+				"$(DERIVED_FILE_DIR)/xcode-overlay.yaml",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -euo pipefail\n\nperl -pe '\n  s/__BAZEL_XCODE_DEVELOPER_DIR__/\\$(DEVELOPER_DIR)/g;\n  s/__BAZEL_XCODE_SDKROOT__/\\$(SDKROOT)/g;\n  s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/gx;\n' \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n\n\"$BAZEL_INTEGRATION_DIR/create_xcode_overlay.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		16C7F09D81A18601D56E4865 /* Create Link Dependencies */ = {
@@ -9863,23 +9898,6 @@
 			shellScript = "set -euo pipefail\n\nperl -pe '\n  s/__BAZEL_XCODE_DEVELOPER_DIR__/\\$(DEVELOPER_DIR)/g;\n  s/__BAZEL_XCODE_SDKROOT__/\\$(SDKROOT)/g;\n  s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/gx;\n' \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n\n\"$BAZEL_INTEGRATION_DIR/create_xcode_overlay.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		1F8F2A83D1F3028FC1639EBC /* Copy Swift Generated Header */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(DERIVED_FILE_DIR)/$(SWIFT_OBJC_INTERFACE_HEADER_NAME)",
-			);
-			name = "Copy Swift Generated Header";
-			outputPaths = (
-				"$(CONFIGURATION_BUILD_DIR)/$(SWIFT_OBJC_INTERFACE_HEADER_NAME)",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if [[ -z \"${SWIFT_OBJC_INTERFACE_HEADER_NAME:-}\" ]]; then\n  exit 0\nfi\n\ncp \"${SCRIPT_INPUT_FILE_0}\" \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
 		261B60B9E0DCE83E8D584B64 /* Create Link Dependencies */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -9895,6 +9913,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -euo pipefail\n\nif [[ \"$ACTION\" == \"indexbuild\" ]]; then\n  touch \"$SCRIPT_OUTPUT_FILE_0\"\nelse\nperl -pe 's/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		2B7FD8BEBE4854259D135999 /* Create Compile Dependencies */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SWIFT_PARAMS_FILE)",
+			);
+			name = "Create Compile Dependencies";
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/swift.compile.params",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -euo pipefail\n\nperl -pe '\n  s/__BAZEL_XCODE_DEVELOPER_DIR__/\\$(DEVELOPER_DIR)/g;\n  s/__BAZEL_XCODE_SDKROOT__/\\$(SDKROOT)/g;\n  s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/gx;\n' \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
 			showEnvVarsInLog = 0;
 		};
 		2FB8CA190C5FD287F83F39E3 /* Create swift_debug_settings.py */ = {
@@ -9949,24 +9984,6 @@
 			shellScript = "set -euo pipefail\n\nperl -pe '\n  s/__BAZEL_XCODE_DEVELOPER_DIR__/\\$(DEVELOPER_DIR)/g;\n  s/__BAZEL_XCODE_SDKROOT__/\\$(SDKROOT)/g;\n  s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/gx;\n' \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n\n\"$BAZEL_INTEGRATION_DIR/create_xcode_overlay.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		3980CAE3BC22FBEBDBA516E2 /* Create Compile Dependencies */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(SWIFT_PARAMS_FILE)",
-			);
-			name = "Create Compile Dependencies";
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/swift.compile.params",
-				"$(DERIVED_FILE_DIR)/xcode-overlay.yaml",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -euo pipefail\n\nperl -pe '\n  s/__BAZEL_XCODE_DEVELOPER_DIR__/\\$(DEVELOPER_DIR)/g;\n  s/__BAZEL_XCODE_SDKROOT__/\\$(SDKROOT)/g;\n  s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/gx;\n' \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n\n\"$BAZEL_INTEGRATION_DIR/create_xcode_overlay.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		3AC7D1EEADED19DA32044056 /* Create Link Dependencies */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -9982,6 +9999,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -euo pipefail\n\nif [[ \"$ACTION\" == \"indexbuild\" ]]; then\n  touch \"$SCRIPT_OUTPUT_FILE_0\"\nelse\nperl -pe 's/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		419DDBDB245D93A06EB593E2 /* Copy Swift Generated Header */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(DERIVED_FILE_DIR)/$(SWIFT_OBJC_INTERFACE_HEADER_NAME)",
+			);
+			name = "Copy Swift Generated Header";
+			outputPaths = (
+				"$(CONFIGURATION_BUILD_DIR)/$(SWIFT_OBJC_INTERFACE_HEADER_NAME)",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [[ -z \"${SWIFT_OBJC_INTERFACE_HEADER_NAME:-}\" ]]; then\n  exit 0\nfi\n\ncp \"${SCRIPT_INPUT_FILE_0}\" \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 		43D6CB8FA23D96DF25327537 /* Create Link Dependencies */ = {
@@ -10141,24 +10175,6 @@
 			shellScript = "if [[ -z \"${SWIFT_OBJC_INTERFACE_HEADER_NAME:-}\" ]]; then\n  exit 0\nfi\n\ncp \"${SCRIPT_INPUT_FILE_0}\" \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		534EBA2B0416BA074181EC8C /* Create Compile Dependencies */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(C_PARAMS_FILE)",
-			);
-			name = "Create Compile Dependencies";
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/c.compile.params",
-				"$(DERIVED_FILE_DIR)/xcode-overlay.yaml",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -euo pipefail\n\nperl -pe '\n  s/__BAZEL_XCODE_DEVELOPER_DIR__/\\$(DEVELOPER_DIR)/g;\n  s/__BAZEL_XCODE_SDKROOT__/\\$(SDKROOT)/g;\n  s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/gx;\n' \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n\n\"$BAZEL_INTEGRATION_DIR/create_xcode_overlay.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		53FDD08BE542853401828581 /* Create Compile Dependencies */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -10175,41 +10191,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -euo pipefail\n\nperl -pe '\n  s/__BAZEL_XCODE_DEVELOPER_DIR__/\\$(DEVELOPER_DIR)/g;\n  s/__BAZEL_XCODE_SDKROOT__/\\$(SDKROOT)/g;\n  s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/gx;\n' \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n\n\"$BAZEL_INTEGRATION_DIR/create_xcode_overlay.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		5ABCA7A4156595FF718E4304 /* Create Compile Dependencies */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(C_PARAMS_FILE)",
-			);
-			name = "Create Compile Dependencies";
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/c.compile.params",
-				"$(DERIVED_FILE_DIR)/xcode-overlay.yaml",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -euo pipefail\n\nperl -pe '\n  s/__BAZEL_XCODE_DEVELOPER_DIR__/\\$(DEVELOPER_DIR)/g;\n  s/__BAZEL_XCODE_SDKROOT__/\\$(SDKROOT)/g;\n  s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/gx;\n' \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n\n\"$BAZEL_INTEGRATION_DIR/create_xcode_overlay.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		5B074C7D26426A511379C4AB /* Create Compile Dependencies */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(SWIFT_PARAMS_FILE)",
-			);
-			name = "Create Compile Dependencies";
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/swift.compile.params",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -euo pipefail\n\nperl -pe '\n  s/__BAZEL_XCODE_DEVELOPER_DIR__/\\$(DEVELOPER_DIR)/g;\n  s/__BAZEL_XCODE_SDKROOT__/\\$(SDKROOT)/g;\n  s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/gx;\n' \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
 			showEnvVarsInLog = 0;
 		};
 		5C7397440A38BBEED07AF5F1 /* Create Compile Dependencies */ = {
@@ -10248,6 +10229,24 @@
 			shellScript = "set -euo pipefail\n\nperl -pe '\n  s/__BAZEL_XCODE_DEVELOPER_DIR__/\\$(DEVELOPER_DIR)/g;\n  s/__BAZEL_XCODE_SDKROOT__/\\$(SDKROOT)/g;\n  s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/gx;\n' \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n\n\"$BAZEL_INTEGRATION_DIR/create_xcode_overlay.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
+		63E8B7B8CC200FDFA48C3B6A /* Create Compile Dependencies */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(C_PARAMS_FILE)",
+			);
+			name = "Create Compile Dependencies";
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/c.compile.params",
+				"$(DERIVED_FILE_DIR)/xcode-overlay.yaml",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -euo pipefail\n\nperl -pe '\n  s/__BAZEL_XCODE_DEVELOPER_DIR__/\\$(DEVELOPER_DIR)/g;\n  s/__BAZEL_XCODE_SDKROOT__/\\$(SDKROOT)/g;\n  s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/gx;\n' \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n\n\"$BAZEL_INTEGRATION_DIR/create_xcode_overlay.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		6405D59516D4825C839B80EC /* Pre-build Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -10265,6 +10264,24 @@
 			showEnvVarsInLog = 0;
 		};
 		69F3614D6F9037354F22010D /* Create Compile Dependencies */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SWIFT_PARAMS_FILE)",
+			);
+			name = "Create Compile Dependencies";
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/swift.compile.params",
+				"$(DERIVED_FILE_DIR)/xcode-overlay.yaml",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -euo pipefail\n\nperl -pe '\n  s/__BAZEL_XCODE_DEVELOPER_DIR__/\\$(DEVELOPER_DIR)/g;\n  s/__BAZEL_XCODE_SDKROOT__/\\$(SDKROOT)/g;\n  s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/gx;\n' \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n\n\"$BAZEL_INTEGRATION_DIR/create_xcode_overlay.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		6B7190B74B0F911B8B8A7703 /* Create Compile Dependencies */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -10333,6 +10350,24 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -euo pipefail\n\nif [[ \"$ACTION\" == \"indexbuild\" ]]; then\n  touch \"$SCRIPT_OUTPUT_FILE_0\"\nelse\nperl -pe 's/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		78E53AE35BD6EF15BC40305A /* Create Compile Dependencies */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(C_PARAMS_FILE)",
+			);
+			name = "Create Compile Dependencies";
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/c.compile.params",
+				"$(DERIVED_FILE_DIR)/xcode-overlay.yaml",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -euo pipefail\n\nperl -pe '\n  s/__BAZEL_XCODE_DEVELOPER_DIR__/\\$(DEVELOPER_DIR)/g;\n  s/__BAZEL_XCODE_SDKROOT__/\\$(SDKROOT)/g;\n  s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/gx;\n' \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n\n\"$BAZEL_INTEGRATION_DIR/create_xcode_overlay.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		80781F100A8CB619E0AF2278 /* Create Link Dependencies */ = {
@@ -10405,24 +10440,7 @@
 			shellScript = "if [[ -z \"${SWIFT_OBJC_INTERFACE_HEADER_NAME:-}\" ]]; then\n  exit 0\nfi\n\ncp \"${SCRIPT_INPUT_FILE_0}\" \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		904519DF4F65BB38BD8DA00B /* Create Link Dependencies */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(LINK_PARAMS_FILE)",
-			);
-			name = "Create Link Dependencies";
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/link.params",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -euo pipefail\n\nif [[ \"$ACTION\" == \"indexbuild\" ]]; then\n  touch \"$SCRIPT_OUTPUT_FILE_0\"\nelse\nperl -pe 's/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		91F3D5ABC835E831B75DAEDD /* Create Compile Dependencies */ = {
+		87B90DB893F637375CAA71A4 /* Create Compile Dependencies */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -10438,6 +10456,41 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -euo pipefail\n\nperl -pe '\n  s/__BAZEL_XCODE_DEVELOPER_DIR__/\\$(DEVELOPER_DIR)/g;\n  s/__BAZEL_XCODE_SDKROOT__/\\$(SDKROOT)/g;\n  s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/gx;\n' \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n\n\"$BAZEL_INTEGRATION_DIR/create_xcode_overlay.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		8AD42718481CD96E91DF1C54 /* Create Compile Dependencies */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(C_PARAMS_FILE)",
+			);
+			name = "Create Compile Dependencies";
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/c.compile.params",
+				"$(DERIVED_FILE_DIR)/xcode-overlay.yaml",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -euo pipefail\n\nperl -pe '\n  s/__BAZEL_XCODE_DEVELOPER_DIR__/\\$(DEVELOPER_DIR)/g;\n  s/__BAZEL_XCODE_SDKROOT__/\\$(SDKROOT)/g;\n  s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/gx;\n' \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n\n\"$BAZEL_INTEGRATION_DIR/create_xcode_overlay.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		904519DF4F65BB38BD8DA00B /* Create Link Dependencies */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(LINK_PARAMS_FILE)",
+			);
+			name = "Create Link Dependencies";
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/link.params",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -euo pipefail\n\nif [[ \"$ACTION\" == \"indexbuild\" ]]; then\n  touch \"$SCRIPT_OUTPUT_FILE_0\"\nelse\nperl -pe 's/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		9242719B785534CC3EE6064F /* Create Compile Dependencies */ = {
@@ -10718,7 +10771,7 @@
 			shellScript = "set -euo pipefail\n\nif [[ \"$ACTION\" == \"indexbuild\" ]]; then\n  touch \"$SCRIPT_OUTPUT_FILE_0\"\nelse\nperl -pe 's/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		A7D86610F30A0702134FB2E0 /* Create Compile Dependencies */ = {
+		A8FD19CB22AC63A8C473CE34 /* Create Compile Dependencies */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -10751,24 +10804,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -euo pipefail\n\nif [[ \"$ACTION\" == \"indexbuild\" ]]; then\n  touch \"$SCRIPT_OUTPUT_FILE_0\"\nelse\nperl -pe 's/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		A9A78F0B9D7C0BD1C3C18F17 /* Create Compile Dependencies */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(C_PARAMS_FILE)",
-			);
-			name = "Create Compile Dependencies";
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/c.compile.params",
-				"$(DERIVED_FILE_DIR)/xcode-overlay.yaml",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -euo pipefail\n\nperl -pe '\n  s/__BAZEL_XCODE_DEVELOPER_DIR__/\\$(DEVELOPER_DIR)/g;\n  s/__BAZEL_XCODE_SDKROOT__/\\$(SDKROOT)/g;\n  s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/gx;\n' \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n\n\"$BAZEL_INTEGRATION_DIR/create_xcode_overlay.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		AB12DAD43ECFA7E031AD8431 /* Create Compile Dependencies */ = {
@@ -10861,7 +10896,7 @@
 			shellScript = "set -euo pipefail\n\nif [[ \"$ACTION\" == \"indexbuild\" ]]; then\n  touch \"$SCRIPT_OUTPUT_FILE_0\"\nelse\nperl -pe 's/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\nfi\n\ntouch \"$SCRIPT_OUTPUT_FILE_1\"\n";
 			showEnvVarsInLog = 0;
 		};
-		BD2288D4111437A7392E5A64 /* Create Compile Dependencies */ = {
+		BDB606D4824450DEC2BB8209 /* Create Compile Dependencies */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -10950,6 +10985,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -euo pipefail\n\nif [[ \"$ACTION\" == \"indexbuild\" ]]; then\n  touch \"$SCRIPT_OUTPUT_FILE_0\"\nelse\nperl -pe 's/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		C95E422FB32766A306D9ABA7 /* Copy Swift Generated Header */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(DERIVED_FILE_DIR)/$(SWIFT_OBJC_INTERFACE_HEADER_NAME)",
+			);
+			name = "Copy Swift Generated Header";
+			outputPaths = (
+				"$(CONFIGURATION_BUILD_DIR)/$(SWIFT_OBJC_INTERFACE_HEADER_NAME)",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [[ -z \"${SWIFT_OBJC_INTERFACE_HEADER_NAME:-}\" ]]; then\n  exit 0\nfi\n\ncp \"${SCRIPT_INPUT_FILE_0}\" \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 		CAA5E66F0096DA74CC2925BB /* Create Compile Dependencies */ = {
@@ -11090,24 +11142,6 @@
 			shellScript = "set -euo pipefail\n\nif [[ \"$ACTION\" == \"indexbuild\" ]]; then\n  touch \"$SCRIPT_OUTPUT_FILE_0\"\nelse\nperl -pe 's/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		EC1F34FE5E774F428A851792 /* Create Compile Dependencies */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(C_PARAMS_FILE)",
-			);
-			name = "Create Compile Dependencies";
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/c.compile.params",
-				"$(DERIVED_FILE_DIR)/xcode-overlay.yaml",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -euo pipefail\n\nperl -pe '\n  s/__BAZEL_XCODE_DEVELOPER_DIR__/\\$(DEVELOPER_DIR)/g;\n  s/__BAZEL_XCODE_SDKROOT__/\\$(SDKROOT)/g;\n  s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/gx;\n' \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n\n\"$BAZEL_INTEGRATION_DIR/create_xcode_overlay.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		EC53E225848DAB5B92F6ABB5 /* Create Compile Dependencies */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -11160,23 +11194,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -euo pipefail\n\nperl -pe '\n  s/__BAZEL_XCODE_DEVELOPER_DIR__/\\$(DEVELOPER_DIR)/g;\n  s/__BAZEL_XCODE_SDKROOT__/\\$(SDKROOT)/g;\n  s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/gx;\n' \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n\n\"$BAZEL_INTEGRATION_DIR/create_xcode_overlay.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		EF185F900EC0B2F226AAA91B /* Create Compile Dependencies */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(SWIFT_PARAMS_FILE)",
-			);
-			name = "Create Compile Dependencies";
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/swift.compile.params",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -euo pipefail\n\nperl -pe '\n  s/__BAZEL_XCODE_DEVELOPER_DIR__/\\$(DEVELOPER_DIR)/g;\n  s/__BAZEL_XCODE_SDKROOT__/\\$(SDKROOT)/g;\n  s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/gx;\n' \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
 			showEnvVarsInLog = 0;
 		};
 		F217E5AB9C7282412A2A2227 /* Create Compile Dependencies */ = {
@@ -11248,23 +11265,6 @@
 			shellScript = "set -euo pipefail\n\nperl -pe '\n  s/__BAZEL_XCODE_DEVELOPER_DIR__/\\$(DEVELOPER_DIR)/g;\n  s/__BAZEL_XCODE_SDKROOT__/\\$(SDKROOT)/g;\n  s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/gx;\n' \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
 			showEnvVarsInLog = 0;
 		};
-		FA1DAC62B62F973746A5DE4C /* Copy Swift Generated Header */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(DERIVED_FILE_DIR)/$(SWIFT_OBJC_INTERFACE_HEADER_NAME)",
-			);
-			name = "Copy Swift Generated Header";
-			outputPaths = (
-				"$(CONFIGURATION_BUILD_DIR)/$(SWIFT_OBJC_INTERFACE_HEADER_NAME)",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if [[ -z \"${SWIFT_OBJC_INTERFACE_HEADER_NAME:-}\" ]]; then\n  exit 0\nfi\n\ncp \"${SCRIPT_INPUT_FILE_0}\" \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
 		FB7B6C05BF63B663970E4AA2 /* Create Compile Dependencies */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -11319,14 +11319,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		0D7A3D9439ADAF6DEB49EF83 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				1686E3240AD255E446558168 /* lib.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		11E354684DF4A82A670DBB58 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -11356,6 +11348,14 @@
 				DC87405ECDFCA041EC491884 /* Lib.swift in Sources */,
 				9C999017A9F3CD2A43CC4D94 /* Lib.swift in Sources */,
 				054B8BF41926F7C33E3C4A96 /* Lib.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1E3A54FBAF4ED761EB2D0ED7 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E24B13704F7B2585A99E345F /* private_lib.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11417,6 +11417,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		3CDFA93F6AF890AC33E34A77 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D050C0109A3CA375ABA53F59 /* private_lib.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		3CE6E4582269342467839EC9 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -11425,11 +11433,19 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		3FE7B4E3298797B49F97BD63 /* Sources */ = {
+		3D742D78BA9CCF908638191D /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				366945DE1E90608F47744C19 /* private_lib.c in Sources */,
+				99A63DA891F5FCA7972D7F2D /* lib.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		483FA841CFEA6E039747635F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FD8FE7C2A812138C994CBB43 /* c_lib.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11454,6 +11470,22 @@
 			buildActionMask = 2147483647;
 			files = (
 				6DFABA720515679A57B21E9A /* tvOSApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		626FE50E783A7D0829D3B6F4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6DCE495DCB4C76361B42F90B /* private_lib.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		69571B50DAE941E73E530C47 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7CBBDEAD3005532EE7C9C151 /* lib.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11489,11 +11521,11 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		80BBCEE7E8395C73D2E61681 /* Sources */ = {
+		8E5F126980F0EA99F719A38B /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8A50B36E3DD12CF3DA507190 /* lib.m in Sources */,
+				605987F9967F3D135903E41B /* private_lib.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11522,19 +11554,11 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		95D5218E2836A7CCDD63EDFA /* Sources */ = {
+		980EBBEAA5C34F04519047C3 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				94C8FC305B5B45AC1AB5A315 /* lib.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		A023342241C016F204F076E0 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				69CC32FA87F2EF045D96EF5E /* c_lib.c in Sources */,
+				4E0EA33B18DD0B68FF60F8EF /* lib.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11561,6 +11585,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				F9A1CDD0C7F69D98D0FD6E1F /* _CompileStub_.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A4C7AB9EEF71C4C135E51469 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				56842EB50C9C78B710DF2B4E /* lib.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11624,11 +11656,11 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		C6F97A8F1A2EA0F7A3F260D7 /* Sources */ = {
+		C3E6AAB46388D0B61EE36EE7 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B6A87B09B2A8DA464B4011A4 /* lib.swift in Sources */,
+				12F3422E8AAA3C2EE8A402C1 /* c_lib.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11689,14 +11721,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		E0988D9559BEA3812296EEF2 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				C3C07B69C4924DF9F07479EB /* private_lib.c in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		E1D40FFAD09B2D61C27CE809 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -11718,14 +11742,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				CB228941B7F5AD23A9A13FE8 /* UnitTests.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		EB34A1E53D56AFEE0D0219C6 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				60C1DCD7BB4EEE88887C9F87 /* c_lib.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -11754,22 +11770,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		FA83AE917647550FD8FAD528 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				61FB9BC55A5B5F5EFF2F003D /* private_lib.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		FC2D1EBD6441F6AB77E71466 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				35AB4DBFC7AE50D0AF6E36FA /* private_lib.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -11790,12 +11790,6 @@
 			name = BazelDependencies;
 			target = FE59281FE487F27A37DC2EE7 /* BazelDependencies */;
 			targetProxy = 24D0E5612BF040F08BA621B3 /* PBXContainerItemProxy */;
-		};
-		0BA4E71970F01636A02ACBDB /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "private_lib (7d2e3)";
-			target = 611D8A1C90B39DBF5A8073AE /* private_lib (7d2e3) */;
-			targetProxy = 9817730F50DC4F11FD4F3FD7 /* PBXContainerItemProxy */;
 		};
 		0CBCE083A929029F369CBB86 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -11863,6 +11857,12 @@
 			target = FE59281FE487F27A37DC2EE7 /* BazelDependencies */;
 			targetProxy = A8252B98C6EB8140BC626B35 /* PBXContainerItemProxy */;
 		};
+		248A0DAF6D48F5B24A42D29D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = BazelDependencies;
+			target = FE59281FE487F27A37DC2EE7 /* BazelDependencies */;
+			targetProxy = 9B27CBCDD047AC7667DA1E3C /* PBXContainerItemProxy */;
+		};
 		2C450C2E3992B8095103FFCB /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = OnlyStructuredResources;
@@ -11881,11 +11881,11 @@
 			target = A2CE5EDCDDA5334B00B16BC9 /* FrameworkCoreUtilsObjC */;
 			targetProxy = 59AB901F8840A59BA8293207 /* PBXContainerItemProxy */;
 		};
-		359BEC0F8CEC327ADD97B70E /* PBXTargetDependency */ = {
+		32BEBE775260B86528982694 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = BazelDependencies;
 			target = FE59281FE487F27A37DC2EE7 /* BazelDependencies */;
-			targetProxy = DC73EE843C874A3456BEB5EE /* PBXContainerItemProxy */;
+			targetProxy = 4E725F1A78BC7C54B37FE3B9 /* PBXContainerItemProxy */;
 		};
 		361C329FFCA21416793E6D21 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -11893,17 +11893,17 @@
 			target = FE59281FE487F27A37DC2EE7 /* BazelDependencies */;
 			targetProxy = D057EED00FD61A095C1D48F2 /* PBXContainerItemProxy */;
 		};
+		371134E5C2803884A7CF82FD /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "c_lib (x86_64) (AppStore, Debug) (7d2e3)";
+			target = DF7734F9DE4017910A9F923A /* c_lib (x86_64) (AppStore, Debug) (7d2e3) */;
+			targetProxy = AC03B0F7B49B73697952B491 /* PBXContainerItemProxy */;
+		};
 		390BFBF7AF151E13C3ADA452 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = iOSApp;
 			target = A6969986F4330BE56701A5EC /* iOSApp */;
 			targetProxy = EB86565E1B2BCC6729279AFA /* PBXContainerItemProxy */;
-		};
-		394FFAEEC76EB8CD18C84272 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "c_lib (7d2e3)";
-			target = E1AC9F0E8F6592B37546029E /* c_lib (7d2e3) */;
-			targetProxy = 74F3FF7C3BEADDD0578DECB0 /* PBXContainerItemProxy */;
 		};
 		397BAE5C95EC79ACC25B3D66 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -11917,17 +11917,17 @@
 			target = FE59281FE487F27A37DC2EE7 /* BazelDependencies */;
 			targetProxy = E8637931FCFB4B4D7E33793F /* PBXContainerItemProxy */;
 		};
+		3D49B9164394F075FFC6BA1E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = BazelDependencies;
+			target = FE59281FE487F27A37DC2EE7 /* BazelDependencies */;
+			targetProxy = 1C5009EF4D70E3695A0AF216 /* PBXContainerItemProxy */;
+		};
 		3FB7C7AD9228382B6860E7D7 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = ExternalResources;
 			target = 9EEE562EF383D06390A55602 /* ExternalResources */;
 			targetProxy = E4573A6FD29D46BCB02A7464 /* PBXContainerItemProxy */;
-		};
-		3FB9ECBFFB302E9C34244EE9 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = BazelDependencies;
-			target = FE59281FE487F27A37DC2EE7 /* BazelDependencies */;
-			targetProxy = A19D496B49248A77F54CC291 /* PBXContainerItemProxy */;
 		};
 		405D24326A4A9F95AD1FBFD5 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -11953,6 +11953,12 @@
 			target = A6969986F4330BE56701A5EC /* iOSApp */;
 			targetProxy = 6F0CE6397212FB3FD755C7F7 /* PBXContainerItemProxy */;
 		};
+		490BE75254CF14DBFD3967A9 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = BazelDependencies;
+			target = FE59281FE487F27A37DC2EE7 /* BazelDependencies */;
+			targetProxy = 6253DFCB68B0F35C5605034C /* PBXContainerItemProxy */;
+		};
 		4A5D29094F247671CB015045 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "Lib (iOS, tvOS)";
@@ -11970,6 +11976,12 @@
 			name = BazelDependencies;
 			target = FE59281FE487F27A37DC2EE7 /* BazelDependencies */;
 			targetProxy = 28B9C67EAED263621396FB38 /* PBXContainerItemProxy */;
+		};
+		532C175E95C8CAC605FC31D5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = BazelDependencies;
+			target = FE59281FE487F27A37DC2EE7 /* BazelDependencies */;
+			targetProxy = 2DF0EB97585668B432F62605 /* PBXContainerItemProxy */;
 		};
 		539C45D3668C1AB4BFC1C0A2 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -12013,17 +12025,11 @@
 			target = A55B010C52011358056D2692 /* UIFramework.watchOS */;
 			targetProxy = 28A2174A78850DC82A307292 /* PBXContainerItemProxy */;
 		};
-		5C832B9A4286482DFE3DC5EA /* PBXTargetDependency */ = {
+		5ED261CF54335CBDF549C992 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = "private_swift_lib (7d2e3)";
-			target = D846E676B1F48432762135EA /* private_swift_lib (7d2e3) */;
-			targetProxy = 18D15B77DBCA53EBF9C29BE4 /* PBXContainerItemProxy */;
-		};
-		5F548667511F21793E364B60 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = BazelDependencies;
-			target = FE59281FE487F27A37DC2EE7 /* BazelDependencies */;
-			targetProxy = 04CC3C9CC35E10E946082E12 /* PBXContainerItemProxy */;
+			name = "lib_swift (x86_64) (AppStore, Debug) (f321a)";
+			target = 18EBFDB7226F943F66D75280 /* lib_swift (x86_64) (AppStore, Debug) (f321a) */;
+			targetProxy = 59733E98E3820E833A9B4336 /* PBXContainerItemProxy */;
 		};
 		60CCD3D1150FA2D84D91D93A /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -12036,6 +12042,12 @@
 			name = "Lib (iOS, tvOS)";
 			target = 801E2436A69733A307109C9A /* Lib (iOS, tvOS) */;
 			targetProxy = 7E7AC142EDAE3A5597AECBF8 /* PBXContainerItemProxy */;
+		};
+		65F45385847A99E9EB388ABA /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "lib_swift (x86_64) (AppStore, Debug) (7d2e3)";
+			target = B500D7461E49E54B4ABF62AD /* lib_swift (x86_64) (AppStore, Debug) (7d2e3) */;
+			targetProxy = A78F86DAA5F14E4BBD7EF010 /* PBXContainerItemProxy */;
 		};
 		662897E57DFDACEA327610F9 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -12060,6 +12072,12 @@
 			name = "Lib (watchOS)";
 			target = D094AA317C2527FB0FCC5015 /* Lib (watchOS) */;
 			targetProxy = B17FA28108AC2FE05E5021F0 /* PBXContainerItemProxy */;
+		};
+		6A78C744F6EF05B5DF6A086A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = BazelDependencies;
+			target = FE59281FE487F27A37DC2EE7 /* BazelDependencies */;
+			targetProxy = BF1897C32881F371D69A141B /* PBXContainerItemProxy */;
 		};
 		6B6A7809CFFE750F71CB6452 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -12103,23 +12121,17 @@
 			target = FE59281FE487F27A37DC2EE7 /* BazelDependencies */;
 			targetProxy = 5A70D69E6803A2E1EC7550DC /* PBXContainerItemProxy */;
 		};
-		744C45FDD9F30FE92F5E2817 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "lib_impl (7d2e3)";
-			target = 9C71DD492D8A65449E4BC123 /* lib_impl (7d2e3) */;
-			targetProxy = A6C59C94D5471083E096D5DD /* PBXContainerItemProxy */;
-		};
-		75218D38F19B2B9B04AC1B21 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = BazelDependencies;
-			target = FE59281FE487F27A37DC2EE7 /* BazelDependencies */;
-			targetProxy = BF28CF27A4DAB78914F9F93D /* PBXContainerItemProxy */;
-		};
 		76237CA1BC614954DCBBD69B /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = tvOSApp;
 			target = F3451D8089613E01522F3373 /* tvOSApp */;
 			targetProxy = ABE60D2081FB38DF9AB9982B /* PBXContainerItemProxy */;
+		};
+		7645DA46167EA76B76D24DCA /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = BazelDependencies;
+			target = FE59281FE487F27A37DC2EE7 /* BazelDependencies */;
+			targetProxy = 207A806061A813CB7A2DE8AB /* PBXContainerItemProxy */;
 		};
 		77AE961773E6921672909D0F /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -12145,12 +12157,6 @@
 			target = FE59281FE487F27A37DC2EE7 /* BazelDependencies */;
 			targetProxy = 55A9CFB12722DA4D8C8A9557 /* PBXContainerItemProxy */;
 		};
-		853B16082C4B9D5701BA4140 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "private_swift_lib (f321a)";
-			target = 4851285CEF582BBA2236C63B /* private_swift_lib (f321a) */;
-			targetProxy = 8D100BAFDA353E2ADEB015D8 /* PBXContainerItemProxy */;
-		};
 		88AB3E0F0D7F995F35D988B2 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = BazelDependencies;
@@ -12162,12 +12168,6 @@
 			name = BazelDependencies;
 			target = FE59281FE487F27A37DC2EE7 /* BazelDependencies */;
 			targetProxy = 69FACF3FCAE1B6A644FAE204 /* PBXContainerItemProxy */;
-		};
-		8E212110C1EE678F0F796DCE /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "lib_impl (f321a)";
-			target = 542253A7A8F5937E85688AC7 /* lib_impl (f321a) */;
-			targetProxy = 067F28CE3926FD219498A734 /* PBXContainerItemProxy */;
 		};
 		8ED2528EED7593A2A51DD9DC /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -12217,6 +12217,12 @@
 			target = FE59281FE487F27A37DC2EE7 /* BazelDependencies */;
 			targetProxy = E48A8DA13DF6AC2778110F7F /* PBXContainerItemProxy */;
 		};
+		9C6A21C6D9A3B9501FA53A3E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "lib_impl (x86_64) (AppStore, Debug) (f321a)";
+			target = 88C064658F18E2860B4D1308 /* lib_impl (x86_64) (AppStore, Debug) (f321a) */;
+			targetProxy = 65BB234C15DD73F481823927 /* PBXContainerItemProxy */;
+		};
 		9EFC694384A729960E31728C /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = FrameworkCoreUtilsObjC;
@@ -12247,6 +12253,12 @@
 			target = FE59281FE487F27A37DC2EE7 /* BazelDependencies */;
 			targetProxy = AF7D3C9269E3B0ECEC1ADBEB /* PBXContainerItemProxy */;
 		};
+		A8E93EF9757F641480360C1D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "lib_swift (x86_64) (AppStore, Debug) (f321a)";
+			target = 18EBFDB7226F943F66D75280 /* lib_swift (x86_64) (AppStore, Debug) (f321a) */;
+			targetProxy = 72EF2FE1CAA89FC61EE1BD3F /* PBXContainerItemProxy */;
+		};
 		A96C9B502827029262E8ED8A /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = BazelDependencies;
@@ -12265,12 +12277,6 @@
 			target = FE59281FE487F27A37DC2EE7 /* BazelDependencies */;
 			targetProxy = 91EDC295440349EB0D5E1B1A /* PBXContainerItemProxy */;
 		};
-		AC36454755E42F40D48D50EA /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = BazelDependencies;
-			target = FE59281FE487F27A37DC2EE7 /* BazelDependencies */;
-			targetProxy = 6A68A4C5BB55E3D9D543AD2B /* PBXContainerItemProxy */;
-		};
 		AC981B8074A22F7124D86021 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = ExternalResources;
@@ -12282,6 +12288,12 @@
 			name = "lib_impl (arm64)";
 			target = C2146B07C477F3A0DBE35CF0 /* lib_impl (arm64) */;
 			targetProxy = 2433156151DE1097A97F3F64 /* PBXContainerItemProxy */;
+		};
+		ADE9FC8783121D536FE473EB /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "lib_impl (x86_64) (AppStore, Debug) (7d2e3)";
+			target = 8B80C81E05DBE296D69AC29B /* lib_impl (x86_64) (AppStore, Debug) (7d2e3) */;
+			targetProxy = CC5757B817F8DBE2D1A5DA42 /* PBXContainerItemProxy */;
 		};
 		AE75B8CD19263F811A1D19CD /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -12301,18 +12313,6 @@
 			target = FE59281FE487F27A37DC2EE7 /* BazelDependencies */;
 			targetProxy = 4CCF9F788AC4A1B84D4C9BB3 /* PBXContainerItemProxy */;
 		};
-		B584C747FBC65CCC3C853B46 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "lib_swift (f321a)";
-			target = 7527C82F4364411F5744B4D8 /* lib_swift (f321a) */;
-			targetProxy = 5C5372AF692B38ED5AD1E064 /* PBXContainerItemProxy */;
-		};
-		BBF757D194C176423B838CFF /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "lib_swift (f321a)";
-			target = 7527C82F4364411F5744B4D8 /* lib_swift (f321a) */;
-			targetProxy = 71F80AE4B0931FA69EA90908 /* PBXContainerItemProxy */;
-		};
 		BD021B76CADF1D7DE1A2034D /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = tvOSApp;
@@ -12330,6 +12330,12 @@
 			name = BazelDependencies;
 			target = FE59281FE487F27A37DC2EE7 /* BazelDependencies */;
 			targetProxy = 9C6A67C7CAD218F6D033CCD0 /* PBXContainerItemProxy */;
+		};
+		C10E806C9E8CDDE71EAC2B9F /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "private_swift_lib (x86_64) (AppStore, Debug) (7d2e3)";
+			target = 2A467471C6406DBFAF8A6490 /* private_swift_lib (x86_64) (AppStore, Debug) (7d2e3) */;
+			targetProxy = 9CC815054A7EE29518CFC1E8 /* PBXContainerItemProxy */;
 		};
 		C112A62A191956EE2E91F3C5 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -12355,6 +12361,18 @@
 			target = FE59281FE487F27A37DC2EE7 /* BazelDependencies */;
 			targetProxy = 43436D7A65E128E2EE4EBFC0 /* PBXContainerItemProxy */;
 		};
+		C5F64742812AB9D21735AEEF /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "private_lib (x86_64) (AppStore, Debug) (f321a)";
+			target = 1A9C34161E849CD15FAB705B /* private_lib (x86_64) (AppStore, Debug) (f321a) */;
+			targetProxy = 338CBDE4515EA6B8612D848A /* PBXContainerItemProxy */;
+		};
+		C94E60053FE49F1B5D71ADAD /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = BazelDependencies;
+			target = FE59281FE487F27A37DC2EE7 /* BazelDependencies */;
+			targetProxy = 96323FF766777D21AC534434 /* PBXContainerItemProxy */;
+		};
 		CAEACDDCD781A76F8D6EBA90 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = Utils;
@@ -12373,17 +12391,11 @@
 			target = 182B42EFE70A5561F1C023E5 /* watchOSApp */;
 			targetProxy = 2A2F6D7F84E6070FAC5C8657 /* PBXContainerItemProxy */;
 		};
-		CDD27EFC7FD934C6E54D9B63 /* PBXTargetDependency */ = {
+		CB7D3F280FFE375024126328 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = BazelDependencies;
-			target = FE59281FE487F27A37DC2EE7 /* BazelDependencies */;
-			targetProxy = 819FE9CCADFF8E34D4D3A684 /* PBXContainerItemProxy */;
-		};
-		CECEE269FD5823A1AECB5DC6 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "private_lib (f321a)";
-			target = 8558C22680359C7F2E153FBB /* private_lib (f321a) */;
-			targetProxy = 9959E5C98A48E1A82AFF1C9D /* PBXContainerItemProxy */;
+			name = "private_lib (x86_64) (AppStore, Debug) (7d2e3)";
+			target = C7E68ADCEEDA842BAB2871EB /* private_lib (x86_64) (AppStore, Debug) (7d2e3) */;
+			targetProxy = 50AF74207A0F8E636616EBD2 /* PBXContainerItemProxy */;
 		};
 		D1B3453772A36EAD0719B970 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -12439,17 +12451,23 @@
 			target = FE59281FE487F27A37DC2EE7 /* BazelDependencies */;
 			targetProxy = 509A4C0467EB5A4100A50E5F /* PBXContainerItemProxy */;
 		};
-		DB0E09D20576B42DE2C48628 /* PBXTargetDependency */ = {
+		DCB0A7CBE6EB543A86922852 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = "c_lib (f321a)";
-			target = 2734834A28FFEBBA6357B35B /* c_lib (f321a) */;
-			targetProxy = 41FBEED137EE585B3CF723D0 /* PBXContainerItemProxy */;
+			name = BazelDependencies;
+			target = FE59281FE487F27A37DC2EE7 /* BazelDependencies */;
+			targetProxy = 158DE6C869C2C2D92CAC3633 /* PBXContainerItemProxy */;
 		};
 		DF349841D126962008D45D4A /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = LibFramework.tvOS;
 			target = E59E7209EEB2E6FF3F683DA8 /* LibFramework.tvOS */;
 			targetProxy = 2E5DDD0BDAF2FD9CB5E45621 /* PBXContainerItemProxy */;
+		};
+		E15911C0BCA9605B3E309E92 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "private_swift_lib (x86_64) (AppStore, Debug) (f321a)";
+			target = 57840EFFCCDD851E8DCF053C /* private_swift_lib (x86_64) (AppStore, Debug) (f321a) */;
+			targetProxy = 411FEE099F6977264A460603 /* PBXContainerItemProxy */;
 		};
 		E6DF8AB88AFBE93299AD4256 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -12493,29 +12511,11 @@
 			target = 801E2436A69733A307109C9A /* Lib (iOS, tvOS) */;
 			targetProxy = 58828F70B0573A5CB6B2CC10 /* PBXContainerItemProxy */;
 		};
-		EF9768AF15F1747E2DDF952C /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "lib_swift (7d2e3)";
-			target = 91F80CE88A7520813ACCC369 /* lib_swift (7d2e3) */;
-			targetProxy = B7AAECD762BC05500F1CE48E /* PBXContainerItemProxy */;
-		};
 		EFE8ED7613C3394597D2C933 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = Utils;
 			target = 42E984F26D5B4ECBE0F0F076 /* Utils */;
 			targetProxy = 4F48433DA824F09493FB5F16 /* PBXContainerItemProxy */;
-		};
-		F06D93E7BB82298144297B31 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = BazelDependencies;
-			target = FE59281FE487F27A37DC2EE7 /* BazelDependencies */;
-			targetProxy = 3F461885C7BC8FEB3E57F57E /* PBXContainerItemProxy */;
-		};
-		F11F1E3E0D3BE2856787CF03 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = BazelDependencies;
-			target = FE59281FE487F27A37DC2EE7 /* BazelDependencies */;
-			targetProxy = 5CCFFE8D15F166CAE25116AD /* PBXContainerItemProxy */;
 		};
 		F13F157EDF45745F61D5F183 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -12529,23 +12529,11 @@
 			target = FE59281FE487F27A37DC2EE7 /* BazelDependencies */;
 			targetProxy = FECDA6B3950300F8F7F7E3C0 /* PBXContainerItemProxy */;
 		};
-		F6403A398D9A393ADA366FAD /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = BazelDependencies;
-			target = FE59281FE487F27A37DC2EE7 /* BazelDependencies */;
-			targetProxy = 772D430D1DF09A26D18B636A /* PBXContainerItemProxy */;
-		};
 		F893845B108000503F012F68 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = BazelDependencies;
 			target = FE59281FE487F27A37DC2EE7 /* BazelDependencies */;
 			targetProxy = 92D97789B9BA0EC17D085B35 /* PBXContainerItemProxy */;
-		};
-		FA1292EB5770848F064B2E72 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = BazelDependencies;
-			target = FE59281FE487F27A37DC2EE7 /* BazelDependencies */;
-			targetProxy = 0CB004D72351A1E2D7BB9481 /* PBXContainerItemProxy */;
 		};
 		FB0120397D9099A63CE0DAA8 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -12553,11 +12541,23 @@
 			target = C93619DEF86AEE901BCD284F /* MixedAnswerLib_Swift */;
 			targetProxy = 01FCC91D6927105EA2B8D389 /* PBXContainerItemProxy */;
 		};
+		FBD0D605B2E46735AB9C0662 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = BazelDependencies;
+			target = FE59281FE487F27A37DC2EE7 /* BazelDependencies */;
+			targetProxy = F350A9413E8754DB052FAC46 /* PBXContainerItemProxy */;
+		};
 		FC24B99A330052D21AE04299 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = BazelDependencies;
 			target = FE59281FE487F27A37DC2EE7 /* BazelDependencies */;
 			targetProxy = D3FFFE846E724924CA2600C8 /* PBXContainerItemProxy */;
+		};
+		FD44F577181C4EA4B1686B10 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "c_lib (x86_64) (AppStore, Debug) (f321a)";
+			target = 45DECB1A5D5381A0B8C369B5 /* c_lib (x86_64) (AppStore, Debug) (f321a) */;
+			targetProxy = 340D17F35CF5FC4A68D9955B /* PBXContainerItemProxy */;
 		};
 		FFBB45A95367974EE3849F59 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -12606,6 +12606,50 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		00231A0092C3CAB5E22A5CC7 /* AppStore */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				ASAN_OTHER_CFLAGS__ = "$(ASAN_OTHER_CFLAGS__NO)";
+				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) -ivfsoverlay $(DERIVED_FILE_DIR)/xcode-overlay.yaml -ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/c.compile.params";
+				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
+				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:lib_impl";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36/bin/CommandLine/CommandLineToolLib";
+				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:lib_impl macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
+				COMPILE_TARGET_NAME = lib_impl;
+				C_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36/bin/CommandLine/CommandLineToolLib/lib_impl.rules_xcodeproj.c.compile.params";
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				OTHER_CFLAGS = "$(ASAN_OTHER_CFLAGS__$(CLANG_ADDRESS_SANITIZER))";
+				PRODUCT_NAME = lib_impl;
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				TARGET_NAME = lib_impl;
+			};
+			name = AppStore;
+		};
+		015E34A9029A6B54FD47F90E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:private_swift_lib";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/CommandLine/CommandLineToolLib";
+				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:private_swift_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
+				COMPILE_TARGET_NAME = private_swift_lib;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				OTHER_SWIFT_FLAGS = "-vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/swift.compile.params";
+				PRODUCT_MODULE_NAME = _SwiftLib;
+				PRODUCT_NAME = private_swift_lib;
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/CommandLine/CommandLineToolLib/private_swift_lib.rules_xcodeproj.swift.compile.params";
+				TARGET_NAME = private_swift_lib;
+			};
+			name = Debug;
+		};
 		01D95C6DA1A314EF678C50AC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -12640,6 +12684,29 @@
 			};
 			name = Debug;
 		};
+		0251264D5249201F10F0C261 /* AppStore */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				ASAN_OTHER_CFLAGS__ = "$(ASAN_OTHER_CFLAGS__NO)";
+				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) -ivfsoverlay $(DERIVED_FILE_DIR)/xcode-overlay.yaml -ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/c.compile.params";
+				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
+				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:private_lib";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38/bin/CommandLine/CommandLineToolLib";
+				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:private_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
+				COMPILE_TARGET_NAME = private_lib;
+				C_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38/bin/CommandLine/CommandLineToolLib/private_lib.rules_xcodeproj.c.compile.params";
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				OTHER_CFLAGS = "$(ASAN_OTHER_CFLAGS__$(CLANG_ADDRESS_SANITIZER))";
+				PRODUCT_NAME = private_lib;
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				TARGET_NAME = private_lib;
+			};
+			name = AppStore;
+		};
 		09ABAFD0453A70F58C7EE02B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -12672,28 +12739,28 @@
 			};
 			name = Debug;
 		};
-		131743F2B8F7D27653EB6D01 /* Debug */ = {
+		0C8076078FD8A1203D217030 /* AppStore */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
-				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:lib_swift";
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/CommandLine/CommandLineToolLib";
-				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:lib_swift macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33";
+				ASAN_OTHER_CFLAGS__ = "$(ASAN_OTHER_CFLAGS__NO)";
+				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) -ivfsoverlay $(DERIVED_FILE_DIR)/xcode-overlay.yaml -ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/c.compile.params";
+				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
+				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:private_lib";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36/bin/CommandLine/CommandLineToolLib";
+				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:private_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36";
 				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
-				COMPILE_TARGET_NAME = lib_swift;
+				COMPILE_TARGET_NAME = private_lib;
+				C_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36/bin/CommandLine/CommandLineToolLib/private_lib.rules_xcodeproj.c.compile.params";
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				OTHER_SWIFT_FLAGS = "-Xcc -ivfsoverlay -Xcc $(DERIVED_FILE_DIR)/xcode-overlay.yaml -Xcc -ivfsoverlay -Xcc $(OBJROOT)/bazel-out-overlay.yaml -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/swift.compile.params -F$(BAZEL_EXTERNAL)/examples_command_line_external";
-				PRODUCT_MODULE_NAME = LibSwift;
-				PRODUCT_NAME = lib_swift;
+				OTHER_CFLAGS = "$(ASAN_OTHER_CFLAGS__$(CLANG_ADDRESS_SANITIZER))";
+				PRODUCT_NAME = private_lib;
 				SDKROOT = macosx;
 				SUPPORTED_PLATFORMS = macosx;
-				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/CommandLine/CommandLineToolLib";
-				SWIFT_OBJC_INTERFACE_HEADER_NAME = "private/LibSwift-Swift.h";
-				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/CommandLine/CommandLineToolLib/lib_swift.rules_xcodeproj.swift.compile.params";
-				TARGET_NAME = lib_swift;
+				TARGET_NAME = private_lib;
 			};
-			name = Debug;
+			name = AppStore;
 		};
 		13587F1B7FA158359EF802CC /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -12829,6 +12896,29 @@
 			};
 			name = AppStore;
 		};
+		191ED8A5E6A1D2596D6EDCFE /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:lib_swift";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35/bin/CommandLine/CommandLineToolLib";
+				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:lib_swift macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
+				COMPILE_TARGET_NAME = lib_swift;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				OTHER_SWIFT_FLAGS = "-Xcc -ivfsoverlay -Xcc $(DERIVED_FILE_DIR)/xcode-overlay.yaml -Xcc -ivfsoverlay -Xcc $(OBJROOT)/bazel-out-overlay.yaml -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/swift.compile.params -F$(BAZEL_EXTERNAL)/examples_command_line_external";
+				PRODUCT_MODULE_NAME = LibSwift;
+				PRODUCT_NAME = lib_swift;
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35/bin/CommandLine/CommandLineToolLib";
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "private/LibSwift-Swift.h";
+				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35/bin/CommandLine/CommandLineToolLib/lib_swift.rules_xcodeproj.swift.compile.params";
+				TARGET_NAME = lib_swift;
+			};
+			name = Debug;
+		};
 		1BF5FC2A9E47901FF1A44BF1 /* AppStore */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -12849,6 +12939,27 @@
 				TARGET_NAME = BazelDependencies;
 			};
 			name = AppStore;
+		};
+		1D5875DE1570DE5929F45108 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:private_swift_lib";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35/bin/CommandLine/CommandLineToolLib";
+				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:private_swift_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
+				COMPILE_TARGET_NAME = private_swift_lib;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				OTHER_SWIFT_FLAGS = "-vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/swift.compile.params";
+				PRODUCT_MODULE_NAME = _SwiftLib;
+				PRODUCT_NAME = private_swift_lib;
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35/bin/CommandLine/CommandLineToolLib/private_swift_lib.rules_xcodeproj.swift.compile.params";
+				TARGET_NAME = private_swift_lib;
+			};
+			name = Debug;
 		};
 		1D724E44CAA02E95A162194C /* AppStore */ = {
 			isa = XCBuildConfiguration;
@@ -13265,34 +13376,36 @@
 			};
 			name = AppStore;
 		};
-		34C07AF1AB2680C1F6BD9FC8 /* Debug */ = {
+		340F148AD92A561352BE4985 /* AppStore */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
-				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:private_swift_lib";
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/CommandLine/CommandLineToolLib";
-				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:private_swift_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33";
+				ASAN_OTHER_CFLAGS__ = "$(ASAN_OTHER_CFLAGS__NO)";
+				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) -ivfsoverlay $(DERIVED_FILE_DIR)/xcode-overlay.yaml -ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/c.compile.params";
+				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
+				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:lib_impl";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38/bin/CommandLine/CommandLineToolLib";
+				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:lib_impl macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38";
 				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
-				COMPILE_TARGET_NAME = private_swift_lib;
+				COMPILE_TARGET_NAME = lib_impl;
+				C_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38/bin/CommandLine/CommandLineToolLib/lib_impl.rules_xcodeproj.c.compile.params";
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				OTHER_SWIFT_FLAGS = "-vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/swift.compile.params";
-				PRODUCT_MODULE_NAME = _SwiftLib;
-				PRODUCT_NAME = private_swift_lib;
+				OTHER_CFLAGS = "$(ASAN_OTHER_CFLAGS__$(CLANG_ADDRESS_SANITIZER))";
+				PRODUCT_NAME = lib_impl;
 				SDKROOT = macosx;
 				SUPPORTED_PLATFORMS = macosx;
-				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/CommandLine/CommandLineToolLib/private_swift_lib.rules_xcodeproj.swift.compile.params";
-				TARGET_NAME = private_swift_lib;
+				TARGET_NAME = lib_impl;
 			};
-			name = Debug;
+			name = AppStore;
 		};
-		373429C94845428323082667 /* AppStore */ = {
+		36BC450F8B78777030EAB73E /* AppStore */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
 				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:private_swift_lib";
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36/bin/CommandLine/CommandLineToolLib";
-				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:private_swift_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38/bin/CommandLine/CommandLineToolLib";
+				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:private_swift_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38";
 				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				COMPILE_TARGET_NAME = private_swift_lib;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
@@ -13303,7 +13416,7 @@
 				SDKROOT = macosx;
 				SUPPORTED_PLATFORMS = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36/bin/CommandLine/CommandLineToolLib/private_swift_lib.rules_xcodeproj.swift.compile.params";
+				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38/bin/CommandLine/CommandLineToolLib/private_swift_lib.rules_xcodeproj.swift.compile.params";
 				TARGET_NAME = private_swift_lib;
 			};
 			name = AppStore;
@@ -13493,29 +13606,6 @@
 			};
 			name = AppStore;
 		};
-		4B1C71B86C55C9482A1A78DD /* AppStore */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = x86_64;
-				ASAN_OTHER_CFLAGS__ = "$(ASAN_OTHER_CFLAGS__NO)";
-				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) -ivfsoverlay $(DERIVED_FILE_DIR)/xcode-overlay.yaml -ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/c.compile.params";
-				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
-				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:lib_impl";
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36/bin/CommandLine/CommandLineToolLib";
-				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:lib_impl macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36";
-				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
-				COMPILE_TARGET_NAME = lib_impl;
-				C_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36/bin/CommandLine/CommandLineToolLib/lib_impl.rules_xcodeproj.c.compile.params";
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				OTHER_CFLAGS = "$(ASAN_OTHER_CFLAGS__$(CLANG_ADDRESS_SANITIZER))";
-				PRODUCT_NAME = lib_impl;
-				SDKROOT = macosx;
-				SUPPORTED_PLATFORMS = macosx;
-				TARGET_NAME = lib_impl;
-			};
-			name = AppStore;
-		};
 		4B4F00FF0467A4B6CC6FE5A1 /* AppStore */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -13552,6 +13642,29 @@
 				TARGET_NAME = iOS;
 			};
 			name = AppStore;
+		};
+		4B7D26A6890743C1E90834CB /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				ASAN_OTHER_CFLAGS__ = "$(ASAN_OTHER_CFLAGS__NO)";
+				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) -ivfsoverlay $(DERIVED_FILE_DIR)/xcode-overlay.yaml -ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/c.compile.params";
+				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
+				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:lib_impl";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35/bin/CommandLine/CommandLineToolLib";
+				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:lib_impl macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
+				COMPILE_TARGET_NAME = lib_impl;
+				C_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35/bin/CommandLine/CommandLineToolLib/lib_impl.rules_xcodeproj.c.compile.params";
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				OTHER_CFLAGS = "$(ASAN_OTHER_CFLAGS__$(CLANG_ADDRESS_SANITIZER))";
+				PRODUCT_NAME = lib_impl;
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				TARGET_NAME = lib_impl;
+			};
+			name = Debug;
 		};
 		520905911A7281FB171E30E8 /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -13641,6 +13754,29 @@
 				TVOS_DEPLOYMENT_TARGET = 15.0;
 			};
 			name = AppStore;
+		};
+		5ABD2CCCD79C54A71E017545 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				ASAN_OTHER_CFLAGS__ = "$(ASAN_OTHER_CFLAGS__NO)";
+				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) -ivfsoverlay $(DERIVED_FILE_DIR)/xcode-overlay.yaml -ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/c.compile.params";
+				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
+				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:private_lib";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35/bin/CommandLine/CommandLineToolLib";
+				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:private_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
+				COMPILE_TARGET_NAME = private_lib;
+				C_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35/bin/CommandLine/CommandLineToolLib/private_lib.rules_xcodeproj.c.compile.params";
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				OTHER_CFLAGS = "$(ASAN_OTHER_CFLAGS__$(CLANG_ADDRESS_SANITIZER))";
+				PRODUCT_NAME = private_lib;
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				TARGET_NAME = private_lib;
+			};
+			name = Debug;
 		};
 		5B330457A78BD7AA1FDA69DA /* AppStore */ = {
 			isa = XCBuildConfiguration;
@@ -13859,6 +13995,29 @@
 			};
 			name = AppStore;
 		};
+		67787586C74AAC131013625E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				ASAN_OTHER_CFLAGS__ = "$(ASAN_OTHER_CFLAGS__NO)";
+				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) -ivfsoverlay $(DERIVED_FILE_DIR)/xcode-overlay.yaml -ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/c.compile.params";
+				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
+				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:lib_impl";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/CommandLine/CommandLineToolLib";
+				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:lib_impl macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
+				COMPILE_TARGET_NAME = lib_impl;
+				C_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/CommandLine/CommandLineToolLib/lib_impl.rules_xcodeproj.c.compile.params";
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				OTHER_CFLAGS = "$(ASAN_OTHER_CFLAGS__$(CLANG_ADDRESS_SANITIZER))";
+				PRODUCT_NAME = lib_impl;
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				TARGET_NAME = lib_impl;
+			};
+			name = Debug;
+		};
 		67F44AB65FA7A2E38A56F5FB /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -13974,29 +14133,6 @@
 				TVOS_DEPLOYMENT_TARGET = 15.0;
 			};
 			name = AppStore;
-		};
-		6C89621AE2EE202748B569D9 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = x86_64;
-				ASAN_OTHER_CFLAGS__ = "$(ASAN_OTHER_CFLAGS__NO)";
-				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) -ivfsoverlay $(DERIVED_FILE_DIR)/xcode-overlay.yaml -ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/c.compile.params";
-				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
-				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:lib_impl";
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/CommandLine/CommandLineToolLib";
-				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:lib_impl macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33";
-				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
-				COMPILE_TARGET_NAME = lib_impl;
-				C_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/CommandLine/CommandLineToolLib/lib_impl.rules_xcodeproj.c.compile.params";
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				OTHER_CFLAGS = "$(ASAN_OTHER_CFLAGS__$(CLANG_ADDRESS_SANITIZER))";
-				PRODUCT_NAME = lib_impl;
-				SDKROOT = macosx;
-				SUPPORTED_PLATFORMS = macosx;
-				TARGET_NAME = lib_impl;
-			};
-			name = Debug;
 		};
 		6E22EF7E719DCB6C63391183 /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -14314,29 +14450,6 @@
 			};
 			name = AppStore;
 		};
-		7B018E714A6DE6A96CEE167B /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = x86_64;
-				ASAN_OTHER_CFLAGS__ = "$(ASAN_OTHER_CFLAGS__NO)";
-				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) -ivfsoverlay $(DERIVED_FILE_DIR)/xcode-overlay.yaml -ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/c.compile.params";
-				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
-				BAZEL_LABEL = "@//CommandLine/swift_c_module:c_lib";
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/CommandLine/swift_c_module";
-				BAZEL_TARGET_ID = "//CommandLine/swift_c_module:c_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33";
-				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
-				COMPILE_TARGET_NAME = c_lib;
-				C_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/CommandLine/swift_c_module/c_lib.rules_xcodeproj.c.compile.params";
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				OTHER_CFLAGS = "$(ASAN_OTHER_CFLAGS__$(CLANG_ADDRESS_SANITIZER))";
-				PRODUCT_NAME = c_lib;
-				SDKROOT = macosx;
-				SUPPORTED_PLATFORMS = macosx;
-				TARGET_NAME = c_lib;
-			};
-			name = Debug;
-		};
 		7FE3A2AB42E97700B2F00D6A /* AppStore */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -14458,30 +14571,6 @@
 				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-30/bin/macOSApp/Test/UITests/macOSAppUITests.library.rules_xcodeproj.swift.compile.params";
 				TARGET_NAME = macOSAppUITests;
 				TEST_TARGET_NAME = macOSApp;
-			};
-			name = AppStore;
-		};
-		87EAC25B44F2397AB8C5523D /* AppStore */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = x86_64;
-				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:lib_swift";
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38/bin/CommandLine/CommandLineToolLib";
-				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:lib_swift macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38";
-				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
-				COMPILE_TARGET_NAME = lib_swift;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				OTHER_SWIFT_FLAGS = "-Xcc -ivfsoverlay -Xcc $(DERIVED_FILE_DIR)/xcode-overlay.yaml -Xcc -ivfsoverlay -Xcc $(OBJROOT)/bazel-out-overlay.yaml -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/swift.compile.params -F$(BAZEL_EXTERNAL)/examples_command_line_external";
-				PRODUCT_MODULE_NAME = LibSwift;
-				PRODUCT_NAME = lib_swift;
-				SDKROOT = macosx;
-				SUPPORTED_PLATFORMS = macosx;
-				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38/bin/CommandLine/CommandLineToolLib";
-				SWIFT_OBJC_INTERFACE_HEADER_NAME = "private/LibSwift-Swift.h";
-				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38/bin/CommandLine/CommandLineToolLib/lib_swift.rules_xcodeproj.swift.compile.params";
-				TARGET_NAME = lib_swift;
 			};
 			name = AppStore;
 		};
@@ -14737,29 +14826,6 @@
 				TEST_HOST = "$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-13/bin/iOSApp/Source/iOSApp.app/iOSApp_ExecutableName";
 			};
 			name = Debug;
-		};
-		94D53B028A5BBDEEFF34012A /* AppStore */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = x86_64;
-				ASAN_OTHER_CFLAGS__ = "$(ASAN_OTHER_CFLAGS__NO)";
-				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) -ivfsoverlay $(DERIVED_FILE_DIR)/xcode-overlay.yaml -ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/c.compile.params";
-				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
-				BAZEL_LABEL = "@//CommandLine/swift_c_module:c_lib";
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36/bin/CommandLine/swift_c_module";
-				BAZEL_TARGET_ID = "//CommandLine/swift_c_module:c_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36";
-				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
-				COMPILE_TARGET_NAME = c_lib;
-				C_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36/bin/CommandLine/swift_c_module/c_lib.rules_xcodeproj.c.compile.params";
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				OTHER_CFLAGS = "$(ASAN_OTHER_CFLAGS__$(CLANG_ADDRESS_SANITIZER))";
-				PRODUCT_NAME = c_lib;
-				SDKROOT = macosx;
-				SUPPORTED_PLATFORMS = macosx;
-				TARGET_NAME = c_lib;
-			};
-			name = AppStore;
 		};
 		9540CAA6C77486C1F48ACA47 /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -15046,52 +15112,6 @@
 			};
 			name = AppStore;
 		};
-		9BD8F8CB9881601E65C45606 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = x86_64;
-				ASAN_OTHER_CFLAGS__ = "$(ASAN_OTHER_CFLAGS__NO)";
-				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) -ivfsoverlay $(DERIVED_FILE_DIR)/xcode-overlay.yaml -ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/c.compile.params";
-				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
-				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:private_lib";
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/CommandLine/CommandLineToolLib";
-				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:private_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33";
-				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
-				COMPILE_TARGET_NAME = private_lib;
-				C_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/CommandLine/CommandLineToolLib/private_lib.rules_xcodeproj.c.compile.params";
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				OTHER_CFLAGS = "$(ASAN_OTHER_CFLAGS__$(CLANG_ADDRESS_SANITIZER))";
-				PRODUCT_NAME = private_lib;
-				SDKROOT = macosx;
-				SUPPORTED_PLATFORMS = macosx;
-				TARGET_NAME = private_lib;
-			};
-			name = Debug;
-		};
-		9CF525C0ACBFA01DD71ED1D4 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = x86_64;
-				ASAN_OTHER_CFLAGS__ = "$(ASAN_OTHER_CFLAGS__NO)";
-				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) -ivfsoverlay $(DERIVED_FILE_DIR)/xcode-overlay.yaml -ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/c.compile.params";
-				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
-				BAZEL_LABEL = "@//CommandLine/swift_c_module:c_lib";
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35/bin/CommandLine/swift_c_module";
-				BAZEL_TARGET_ID = "//CommandLine/swift_c_module:c_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35";
-				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
-				COMPILE_TARGET_NAME = c_lib;
-				C_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35/bin/CommandLine/swift_c_module/c_lib.rules_xcodeproj.c.compile.params";
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				OTHER_CFLAGS = "$(ASAN_OTHER_CFLAGS__$(CLANG_ADDRESS_SANITIZER))";
-				PRODUCT_NAME = c_lib;
-				SDKROOT = macosx;
-				SUPPORTED_PLATFORMS = macosx;
-				TARGET_NAME = c_lib;
-			};
-			name = Debug;
-		};
 		A072243CAE17521A9B4E9048 /* AppStore */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -15131,6 +15151,29 @@
 				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				COMPILE_TARGET_NAME = c_lib;
 				C_PARAMS_FILE = "$(BAZEL_OUT)/macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-34/bin/CommandLine/swift_c_module/c_lib.rules_xcodeproj.c.compile.params";
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				OTHER_CFLAGS = "$(ASAN_OTHER_CFLAGS__$(CLANG_ADDRESS_SANITIZER))";
+				PRODUCT_NAME = c_lib;
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				TARGET_NAME = c_lib;
+			};
+			name = Debug;
+		};
+		A27B82B934C2941355F8CFD3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				ASAN_OTHER_CFLAGS__ = "$(ASAN_OTHER_CFLAGS__NO)";
+				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) -ivfsoverlay $(DERIVED_FILE_DIR)/xcode-overlay.yaml -ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/c.compile.params";
+				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
+				BAZEL_LABEL = "@//CommandLine/swift_c_module:c_lib";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/CommandLine/swift_c_module";
+				BAZEL_TARGET_ID = "//CommandLine/swift_c_module:c_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
+				COMPILE_TARGET_NAME = c_lib;
+				C_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/CommandLine/swift_c_module/c_lib.rules_xcodeproj.c.compile.params";
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = "$(ASAN_OTHER_CFLAGS__$(CLANG_ADDRESS_SANITIZER))";
@@ -15188,7 +15231,7 @@
 			};
 			name = Debug;
 		};
-		AAE08190172DDC92D1A4995A /* Debug */ = {
+		A937A0C679157271145539F3 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
@@ -15196,11 +15239,11 @@
 				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) -ivfsoverlay $(DERIVED_FILE_DIR)/xcode-overlay.yaml -ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/c.compile.params";
 				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
 				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:private_lib";
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35/bin/CommandLine/CommandLineToolLib";
-				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:private_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/CommandLine/CommandLineToolLib";
+				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:private_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33";
 				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				COMPILE_TARGET_NAME = private_lib;
-				C_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35/bin/CommandLine/CommandLineToolLib/private_lib.rules_xcodeproj.c.compile.params";
+				C_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/CommandLine/CommandLineToolLib/private_lib.rules_xcodeproj.c.compile.params";
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = "$(ASAN_OTHER_CFLAGS__$(CLANG_ADDRESS_SANITIZER))";
@@ -15264,29 +15307,6 @@
 				SDKROOT = macosx;
 				SUPPORTED_PLATFORMS = macosx;
 				TARGET_NAME = private_lib;
-			};
-			name = AppStore;
-		};
-		B0CB7F559F1C442CDC873341 /* AppStore */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = x86_64;
-				ASAN_OTHER_CFLAGS__ = "$(ASAN_OTHER_CFLAGS__NO)";
-				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) -ivfsoverlay $(DERIVED_FILE_DIR)/xcode-overlay.yaml -ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/c.compile.params";
-				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
-				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:lib_impl";
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38/bin/CommandLine/CommandLineToolLib";
-				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:lib_impl macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38";
-				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
-				COMPILE_TARGET_NAME = lib_impl;
-				C_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38/bin/CommandLine/CommandLineToolLib/lib_impl.rules_xcodeproj.c.compile.params";
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				OTHER_CFLAGS = "$(ASAN_OTHER_CFLAGS__$(CLANG_ADDRESS_SANITIZER))";
-				PRODUCT_NAME = lib_impl;
-				SDKROOT = macosx;
-				SUPPORTED_PLATFORMS = macosx;
-				TARGET_NAME = lib_impl;
 			};
 			name = AppStore;
 		};
@@ -15539,27 +15559,6 @@
 			};
 			name = Debug;
 		};
-		C00A25C9D8ACD0AC9C45F50B /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = x86_64;
-				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:private_swift_lib";
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35/bin/CommandLine/CommandLineToolLib";
-				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:private_swift_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35";
-				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
-				COMPILE_TARGET_NAME = private_swift_lib;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				OTHER_SWIFT_FLAGS = "-vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/swift.compile.params";
-				PRODUCT_MODULE_NAME = _SwiftLib;
-				PRODUCT_NAME = private_swift_lib;
-				SDKROOT = macosx;
-				SUPPORTED_PLATFORMS = macosx;
-				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35/bin/CommandLine/CommandLineToolLib/private_swift_lib.rules_xcodeproj.swift.compile.params";
-				TARGET_NAME = private_swift_lib;
-			};
-			name = Debug;
-		};
 		C096313AB49E6E5EC946225E /* AppStore */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -15630,29 +15629,6 @@
 				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36/bin/CommandLine/CommandLineToolLib";
 				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36/bin/CommandLine/Tests/CommandLineLibSwiftTestsLib.rules_xcodeproj.swift.compile.params";
 				TARGET_NAME = CommandLineToolTests;
-			};
-			name = AppStore;
-		};
-		C217BFCCF313B7CFC26BCE84 /* AppStore */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = x86_64;
-				ASAN_OTHER_CFLAGS__ = "$(ASAN_OTHER_CFLAGS__NO)";
-				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) -ivfsoverlay $(DERIVED_FILE_DIR)/xcode-overlay.yaml -ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/c.compile.params";
-				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
-				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:private_lib";
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36/bin/CommandLine/CommandLineToolLib";
-				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:private_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36";
-				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
-				COMPILE_TARGET_NAME = private_lib;
-				C_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36/bin/CommandLine/CommandLineToolLib/private_lib.rules_xcodeproj.c.compile.params";
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				OTHER_CFLAGS = "$(ASAN_OTHER_CFLAGS__$(CLANG_ADDRESS_SANITIZER))";
-				PRODUCT_NAME = private_lib;
-				SDKROOT = macosx;
-				SUPPORTED_PLATFORMS = macosx;
-				TARGET_NAME = private_lib;
 			};
 			name = AppStore;
 		};
@@ -15865,6 +15841,30 @@
 			};
 			name = Debug;
 		};
+		D220A5BE75C6E83A4B14CE09 /* AppStore */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:lib_swift";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38/bin/CommandLine/CommandLineToolLib";
+				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:lib_swift macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
+				COMPILE_TARGET_NAME = lib_swift;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				OTHER_SWIFT_FLAGS = "-Xcc -ivfsoverlay -Xcc $(DERIVED_FILE_DIR)/xcode-overlay.yaml -Xcc -ivfsoverlay -Xcc $(OBJROOT)/bazel-out-overlay.yaml -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/swift.compile.params -F$(BAZEL_EXTERNAL)/examples_command_line_external";
+				PRODUCT_MODULE_NAME = LibSwift;
+				PRODUCT_NAME = lib_swift;
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38/bin/CommandLine/CommandLineToolLib";
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "private/LibSwift-Swift.h";
+				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38/bin/CommandLine/CommandLineToolLib/lib_swift.rules_xcodeproj.swift.compile.params";
+				TARGET_NAME = lib_swift;
+			};
+			name = AppStore;
+		};
 		D267E569887A944AD121E345 /* AppStore */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -15888,6 +15888,76 @@
 				TARGET_NAME = lib_swift;
 			};
 			name = AppStore;
+		};
+		D33BD3F717DAAF8B03F54C9D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:lib_swift";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/CommandLine/CommandLineToolLib";
+				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:lib_swift macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
+				COMPILE_TARGET_NAME = lib_swift;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				OTHER_SWIFT_FLAGS = "-Xcc -ivfsoverlay -Xcc $(DERIVED_FILE_DIR)/xcode-overlay.yaml -Xcc -ivfsoverlay -Xcc $(OBJROOT)/bazel-out-overlay.yaml -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/swift.compile.params -F$(BAZEL_EXTERNAL)/examples_command_line_external";
+				PRODUCT_MODULE_NAME = LibSwift;
+				PRODUCT_NAME = lib_swift;
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/CommandLine/CommandLineToolLib";
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "private/LibSwift-Swift.h";
+				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/CommandLine/CommandLineToolLib/lib_swift.rules_xcodeproj.swift.compile.params";
+				TARGET_NAME = lib_swift;
+			};
+			name = Debug;
+		};
+		D361B3A7FA607B1E7F2E429F /* AppStore */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:lib_swift";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36/bin/CommandLine/CommandLineToolLib";
+				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:lib_swift macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
+				COMPILE_TARGET_NAME = lib_swift;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				OTHER_SWIFT_FLAGS = "-Xcc -ivfsoverlay -Xcc $(DERIVED_FILE_DIR)/xcode-overlay.yaml -Xcc -ivfsoverlay -Xcc $(OBJROOT)/bazel-out-overlay.yaml -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/swift.compile.params -F$(BAZEL_EXTERNAL)/examples_command_line_external";
+				PRODUCT_MODULE_NAME = LibSwift;
+				PRODUCT_NAME = lib_swift;
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36/bin/CommandLine/CommandLineToolLib";
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "private/LibSwift-Swift.h";
+				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36/bin/CommandLine/CommandLineToolLib/lib_swift.rules_xcodeproj.swift.compile.params";
+				TARGET_NAME = lib_swift;
+			};
+			name = AppStore;
+		};
+		D3C20F656FF10A4C1A282F3E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				ASAN_OTHER_CFLAGS__ = "$(ASAN_OTHER_CFLAGS__NO)";
+				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) -ivfsoverlay $(DERIVED_FILE_DIR)/xcode-overlay.yaml -ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/c.compile.params";
+				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
+				BAZEL_LABEL = "@//CommandLine/swift_c_module:c_lib";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35/bin/CommandLine/swift_c_module";
+				BAZEL_TARGET_ID = "//CommandLine/swift_c_module:c_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
+				COMPILE_TARGET_NAME = c_lib;
+				C_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35/bin/CommandLine/swift_c_module/c_lib.rules_xcodeproj.c.compile.params";
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				OTHER_CFLAGS = "$(ASAN_OTHER_CFLAGS__$(CLANG_ADDRESS_SANITIZER))";
+				PRODUCT_NAME = c_lib;
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				TARGET_NAME = c_lib;
+			};
+			name = Debug;
 		};
 		D447B4DA21BB15935E0EC8D5 /* AppStore */ = {
 			isa = XCBuildConfiguration;
@@ -15914,6 +15984,28 @@
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				TARGET_NAME = ExampleNestedResources;
+			};
+			name = AppStore;
+		};
+		D8334A386E2875213E6FCCC9 /* AppStore */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:private_swift_lib";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36/bin/CommandLine/CommandLineToolLib";
+				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:private_swift_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
+				COMPILE_TARGET_NAME = private_swift_lib;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				OTHER_SWIFT_FLAGS = "-vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/swift.compile.params";
+				PRODUCT_MODULE_NAME = _SwiftLib;
+				PRODUCT_NAME = private_swift_lib;
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36/bin/CommandLine/CommandLineToolLib/private_swift_lib.rules_xcodeproj.swift.compile.params";
+				TARGET_NAME = private_swift_lib;
 			};
 			name = AppStore;
 		};
@@ -15952,30 +16044,6 @@
 				TARGET_BUILD_DIR = "$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-opt-STABLE-15/bin/iOSApp/Source$(TARGET_BUILD_SUBPATH)";
 				TARGET_NAME = iOSAppObjCUnitTests;
 				TEST_HOST = "$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-opt-STABLE-15/bin/iOSApp/Source/iOSApp.app/iOSApp_ExecutableName";
-			};
-			name = AppStore;
-		};
-		DED8C34E96A1BA9D03E11314 /* AppStore */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = x86_64;
-				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:lib_swift";
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36/bin/CommandLine/CommandLineToolLib";
-				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:lib_swift macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36";
-				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
-				COMPILE_TARGET_NAME = lib_swift;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				OTHER_SWIFT_FLAGS = "-Xcc -ivfsoverlay -Xcc $(DERIVED_FILE_DIR)/xcode-overlay.yaml -Xcc -ivfsoverlay -Xcc $(OBJROOT)/bazel-out-overlay.yaml -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/swift.compile.params -F$(BAZEL_EXTERNAL)/examples_command_line_external";
-				PRODUCT_MODULE_NAME = LibSwift;
-				PRODUCT_NAME = lib_swift;
-				SDKROOT = macosx;
-				SUPPORTED_PLATFORMS = macosx;
-				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36/bin/CommandLine/CommandLineToolLib";
-				SWIFT_OBJC_INTERFACE_HEADER_NAME = "private/LibSwift-Swift.h";
-				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36/bin/CommandLine/CommandLineToolLib/lib_swift.rules_xcodeproj.swift.compile.params";
-				TARGET_NAME = lib_swift;
 			};
 			name = AppStore;
 		};
@@ -16198,6 +16266,29 @@
 			};
 			name = Debug;
 		};
+		E9919D05313DB34C7F6F439F /* AppStore */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				ASAN_OTHER_CFLAGS__ = "$(ASAN_OTHER_CFLAGS__NO)";
+				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) -ivfsoverlay $(DERIVED_FILE_DIR)/xcode-overlay.yaml -ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/c.compile.params";
+				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
+				BAZEL_LABEL = "@//CommandLine/swift_c_module:c_lib";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38/bin/CommandLine/swift_c_module";
+				BAZEL_TARGET_ID = "//CommandLine/swift_c_module:c_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
+				COMPILE_TARGET_NAME = c_lib;
+				C_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38/bin/CommandLine/swift_c_module/c_lib.rules_xcodeproj.c.compile.params";
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				OTHER_CFLAGS = "$(ASAN_OTHER_CFLAGS__$(CLANG_ADDRESS_SANITIZER))";
+				PRODUCT_NAME = c_lib;
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				TARGET_NAME = c_lib;
+			};
+			name = AppStore;
+		};
 		EA951DAE1AF8EF75068EDA6B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -16377,29 +16468,6 @@
 			};
 			name = AppStore;
 		};
-		EDB98500129AEA859052C304 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = x86_64;
-				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:lib_swift";
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35/bin/CommandLine/CommandLineToolLib";
-				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:lib_swift macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35";
-				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
-				COMPILE_TARGET_NAME = lib_swift;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				OTHER_SWIFT_FLAGS = "-Xcc -ivfsoverlay -Xcc $(DERIVED_FILE_DIR)/xcode-overlay.yaml -Xcc -ivfsoverlay -Xcc $(OBJROOT)/bazel-out-overlay.yaml -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/swift.compile.params -F$(BAZEL_EXTERNAL)/examples_command_line_external";
-				PRODUCT_MODULE_NAME = LibSwift;
-				PRODUCT_NAME = lib_swift;
-				SDKROOT = macosx;
-				SUPPORTED_PLATFORMS = macosx;
-				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35/bin/CommandLine/CommandLineToolLib";
-				SWIFT_OBJC_INTERFACE_HEADER_NAME = "private/LibSwift-Swift.h";
-				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35/bin/CommandLine/CommandLineToolLib/lib_swift.rules_xcodeproj.swift.compile.params";
-				TARGET_NAME = lib_swift;
-			};
-			name = Debug;
-		};
 		EE5EE818E3865E86ABA7D0BF /* AppStore */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -16432,29 +16500,6 @@
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TARGET_NAME = iOSAppUITestSuite;
 				TEST_TARGET_NAME = iOSApp;
-			};
-			name = AppStore;
-		};
-		EFBF41EDE930741B9FBDDE77 /* AppStore */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = x86_64;
-				ASAN_OTHER_CFLAGS__ = "$(ASAN_OTHER_CFLAGS__NO)";
-				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) -ivfsoverlay $(DERIVED_FILE_DIR)/xcode-overlay.yaml -ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/c.compile.params";
-				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
-				BAZEL_LABEL = "@//CommandLine/swift_c_module:c_lib";
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38/bin/CommandLine/swift_c_module";
-				BAZEL_TARGET_ID = "//CommandLine/swift_c_module:c_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38";
-				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
-				COMPILE_TARGET_NAME = c_lib;
-				C_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38/bin/CommandLine/swift_c_module/c_lib.rules_xcodeproj.c.compile.params";
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				OTHER_CFLAGS = "$(ASAN_OTHER_CFLAGS__$(CLANG_ADDRESS_SANITIZER))";
-				PRODUCT_NAME = c_lib;
-				SDKROOT = macosx;
-				SUPPORTED_PLATFORMS = macosx;
-				TARGET_NAME = c_lib;
 			};
 			name = AppStore;
 		};
@@ -16542,6 +16587,29 @@
 				TARGET_NAME = private_swift_lib;
 			};
 			name = Debug;
+		};
+		F1FD370CAAE55762AA0AD0CD /* AppStore */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				ASAN_OTHER_CFLAGS__ = "$(ASAN_OTHER_CFLAGS__NO)";
+				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) -ivfsoverlay $(DERIVED_FILE_DIR)/xcode-overlay.yaml -ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/c.compile.params";
+				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
+				BAZEL_LABEL = "@//CommandLine/swift_c_module:c_lib";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36/bin/CommandLine/swift_c_module";
+				BAZEL_TARGET_ID = "//CommandLine/swift_c_module:c_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
+				COMPILE_TARGET_NAME = c_lib;
+				C_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36/bin/CommandLine/swift_c_module/c_lib.rules_xcodeproj.c.compile.params";
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				OTHER_CFLAGS = "$(ASAN_OTHER_CFLAGS__$(CLANG_ADDRESS_SANITIZER))";
+				PRODUCT_NAME = c_lib;
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				TARGET_NAME = c_lib;
+			};
+			name = AppStore;
 		};
 		F51898FE27B209EDBD08ED39 /* AppStore */ = {
 			isa = XCBuildConfiguration;
@@ -16710,29 +16778,6 @@
 			};
 			name = Debug;
 		};
-		FA9BBC030C44F8F3E315F9D2 /* AppStore */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = x86_64;
-				ASAN_OTHER_CFLAGS__ = "$(ASAN_OTHER_CFLAGS__NO)";
-				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) -ivfsoverlay $(DERIVED_FILE_DIR)/xcode-overlay.yaml -ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/c.compile.params";
-				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
-				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:private_lib";
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38/bin/CommandLine/CommandLineToolLib";
-				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:private_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38";
-				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
-				COMPILE_TARGET_NAME = private_lib;
-				C_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38/bin/CommandLine/CommandLineToolLib/private_lib.rules_xcodeproj.c.compile.params";
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				OTHER_CFLAGS = "$(ASAN_OTHER_CFLAGS__$(CLANG_ADDRESS_SANITIZER))";
-				PRODUCT_NAME = private_lib;
-				SDKROOT = macosx;
-				SUPPORTED_PLATFORMS = macosx;
-				TARGET_NAME = private_lib;
-			};
-			name = AppStore;
-		};
 		FC86319E47ED3880D14AA83B /* AppStore */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -16795,29 +16840,6 @@
 			};
 			name = Debug;
 		};
-		FD4EE5BE98B08794F924046B /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = x86_64;
-				ASAN_OTHER_CFLAGS__ = "$(ASAN_OTHER_CFLAGS__NO)";
-				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) -ivfsoverlay $(DERIVED_FILE_DIR)/xcode-overlay.yaml -ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/c.compile.params";
-				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
-				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:lib_impl";
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35/bin/CommandLine/CommandLineToolLib";
-				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:lib_impl macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35";
-				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
-				COMPILE_TARGET_NAME = lib_impl;
-				C_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35/bin/CommandLine/CommandLineToolLib/lib_impl.rules_xcodeproj.c.compile.params";
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				OTHER_CFLAGS = "$(ASAN_OTHER_CFLAGS__$(CLANG_ADDRESS_SANITIZER))";
-				PRODUCT_NAME = lib_impl;
-				SDKROOT = macosx;
-				SUPPORTED_PLATFORMS = macosx;
-				TARGET_NAME = lib_impl;
-			};
-			name = Debug;
-		};
 		FDFF8A41D5CA5F83BE0117C0 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -16869,28 +16891,6 @@
 			};
 			name = Debug;
 		};
-		FF8CE98FBFE30209FDB877B5 /* AppStore */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = x86_64;
-				BAZEL_LABEL = "@//CommandLine/CommandLineToolLib:private_swift_lib";
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38/bin/CommandLine/CommandLineToolLib";
-				BAZEL_TARGET_ID = "//CommandLine/CommandLineToolLib:private_swift_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38";
-				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
-				COMPILE_TARGET_NAME = private_swift_lib;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				OTHER_SWIFT_FLAGS = "-vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/swift.compile.params";
-				PRODUCT_MODULE_NAME = _SwiftLib;
-				PRODUCT_NAME = private_swift_lib;
-				SDKROOT = macosx;
-				SUPPORTED_PLATFORMS = macosx;
-				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38/bin/CommandLine/CommandLineToolLib/private_swift_lib.rules_xcodeproj.swift.compile.params";
-				TARGET_NAME = private_swift_lib;
-			};
-			name = AppStore;
-		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -16899,24 +16899,6 @@
 			buildConfigurations = (
 				E61CC8A90214389F6DA3382A /* AppStore */,
 				256C56394A0772AFFAB6E08C /* Debug */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Debug;
-		};
-		09155DEE008B6A1F2281FDA3 /* Build configuration list for PBXNativeTarget "private_swift_lib (f321a)" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				373429C94845428323082667 /* AppStore */,
-				34C07AF1AB2680C1F6BD9FC8 /* Debug */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Debug;
-		};
-		0C75F94110BF70FFE03C758F /* Build configuration list for PBXNativeTarget "private_lib (7d2e3)" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				FA9BBC030C44F8F3E315F9D2 /* AppStore */,
-				AAE08190172DDC92D1A4995A /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
@@ -16930,29 +16912,20 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
-		1095547928A5213280187B21 /* Build configuration list for PBXNativeTarget "lib_impl (f321a)" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				4B1C71B86C55C9482A1A78DD /* AppStore */,
-				6C89621AE2EE202748B569D9 /* Debug */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Debug;
-		};
-		1128F3E395E78E23EB6D5B91 /* Build configuration list for PBXNativeTarget "lib_swift (7d2e3)" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				87EAC25B44F2397AB8C5523D /* AppStore */,
-				EDB98500129AEA859052C304 /* Debug */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Debug;
-		};
 		11448ED2A6A7CA5148C647A8 /* Build configuration list for PBXNativeTarget "watchOSAppExtensionUnitTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				4A78CBF0DA167790CE98F3DC /* AppStore */,
 				4555CE65A652CA1A1F1EF13B /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		1EC13BFED89B1AC6B5C81EA2 /* Build configuration list for PBXNativeTarget "private_swift_lib (x86_64) (AppStore, Debug) (7d2e3)" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				36BC450F8B78777030EAB73E /* AppStore */,
+				1D5875DE1570DE5929F45108 /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
@@ -16966,11 +16939,29 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
+		2003168C8BD7440BCF5A0785 /* Build configuration list for PBXNativeTarget "lib_swift (x86_64) (AppStore, Debug) (7d2e3)" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D220A5BE75C6E83A4B14CE09 /* AppStore */,
+				191ED8A5E6A1D2596D6EDCFE /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
 		234E93B143A482D3E6BAC00F /* Build configuration list for PBXNativeTarget "UniversalCommandLineTool (x86_64)" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				CA4BAA5A36DB68508A8AA5BD /* AppStore */,
 				9540CAA6C77486C1F48ACA47 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		23F0C19595B9825F67644351 /* Build configuration list for PBXNativeTarget "private_swift_lib (x86_64) (AppStore, Debug) (f321a)" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D8334A386E2875213E6FCCC9 /* AppStore */,
+				015E34A9029A6B54FD47F90E /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
@@ -17038,24 +17029,6 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
-		41486CA13CC9C13F8E072C5A /* Build configuration list for PBXNativeTarget "private_lib (f321a)" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				C217BFCCF313B7CFC26BCE84 /* AppStore */,
-				9BD8F8CB9881601E65C45606 /* Debug */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Debug;
-		};
-		44A40F49D6F3B3C380D8D9E7 /* Build configuration list for PBXNativeTarget "private_swift_lib (7d2e3)" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				FF8CE98FBFE30209FDB877B5 /* AppStore */,
-				C00A25C9D8ACD0AC9C45F50B /* Debug */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Debug;
-		};
 		45E3A2B7B62C7DE74553D29E /* Build configuration list for PBXNativeTarget "lib_impl (arm64)" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -17083,11 +17056,11 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
-		4D10CA380FCA6483AA8BB8C6 /* Build configuration list for PBXNativeTarget "lib_impl (7d2e3)" */ = {
+		4E70667A9C7709E9114CE9E7 /* Build configuration list for PBXNativeTarget "private_lib (x86_64) (AppStore, Debug) (f321a)" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				B0CB7F559F1C442CDC873341 /* AppStore */,
-				FD4EE5BE98B08794F924046B /* Debug */,
+				0C8076078FD8A1203D217030 /* AppStore */,
+				A937A0C679157271145539F3 /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
@@ -17191,15 +17164,6 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
-		8326DD2A212C1AE4B1977C4E /* Build configuration list for PBXNativeTarget "lib_swift (f321a)" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				DED8C34E96A1BA9D03E11314 /* AppStore */,
-				131743F2B8F7D27653EB6D01 /* Debug */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Debug;
-		};
 		84568858393A25F9D32CC947 /* Build configuration list for PBXNativeTarget "UIFramework.watchOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -17218,20 +17182,20 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
-		8FE580A94BC634B0A5F369F3 /* Build configuration list for PBXNativeTarget "c_lib (7d2e3)" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				EFBF41EDE930741B9FBDDE77 /* AppStore */,
-				9CF525C0ACBFA01DD71ED1D4 /* Debug */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Debug;
-		};
 		9AEA6F92C4DB724D2A2A56CB /* Build configuration list for PBXNativeTarget "macOSApp" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				EC08261D77D30969C349A361 /* AppStore */,
 				EFDED053C8359D1929857858 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		9E2E6F3C826280D76AC9B4DB /* Build configuration list for PBXNativeTarget "c_lib (x86_64) (AppStore, Debug) (7d2e3)" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E9919D05313DB34C7F6F439F /* AppStore */,
+				D3C20F656FF10A4C1A282F3E /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
@@ -17281,20 +17245,38 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
-		B963F55C245117E81DB6E0E1 /* Build configuration list for PBXNativeTarget "c_lib (f321a)" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				94D53B028A5BBDEEFF34012A /* AppStore */,
-				7B018E714A6DE6A96CEE167B /* Debug */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Debug;
-		};
 		BE5CB862F862C942EF38477D /* Build configuration list for PBXNativeTarget "FXPageControl" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				610D79B266D075DCE63A4D5F /* AppStore */,
 				5B9D1A8FC92CAD0B4D3B85AA /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		BF8BBCA83CD8BF317DB0F35B /* Build configuration list for PBXNativeTarget "lib_swift (x86_64) (AppStore, Debug) (f321a)" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D361B3A7FA607B1E7F2E429F /* AppStore */,
+				D33BD3F717DAAF8B03F54C9D /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		BFDE7EAE4E4C4CC64C96FAC7 /* Build configuration list for PBXNativeTarget "lib_impl (x86_64) (AppStore, Debug) (7d2e3)" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				340F148AD92A561352BE4985 /* AppStore */,
+				4B7D26A6890743C1E90834CB /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		C0BB834880525F419C3E1A7E /* Build configuration list for PBXNativeTarget "private_lib (x86_64) (AppStore, Debug) (7d2e3)" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0251264D5249201F10F0C261 /* AppStore */,
+				5ABD2CCCD79C54A71E017545 /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
@@ -17322,6 +17304,15 @@
 			buildConfigurations = (
 				FC86319E47ED3880D14AA83B /* AppStore */,
 				01D95C6DA1A314EF678C50AC /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		CD26F273670416B5D6C5FCDC /* Build configuration list for PBXNativeTarget "c_lib (x86_64) (AppStore, Debug) (f321a)" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F1FD370CAAE55762AA0AD0CD /* AppStore */,
+				A27B82B934C2941355F8CFD3 /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
@@ -17439,6 +17430,15 @@
 			buildConfigurations = (
 				EAC914156EBD8E7515F23CD1 /* AppStore */,
 				EA951DAE1AF8EF75068EDA6B /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		F37E2A4E58E880A623B46859 /* Build configuration list for PBXNativeTarget "lib_impl (x86_64) (AppStore, Debug) (f321a)" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				00231A0092C3CAB5E22A5CC7 /* AppStore */,
+				67787586C74AAC131013625E /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/c_lib (x86_64) (AppStore, Debug) (7d2e3).xcscheme
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/c_lib (x86_64) (AppStore, Debug) (7d2e3).xcscheme
@@ -14,10 +14,10 @@
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
-                     BlueprintIdentifier = "6BF04914EEB0EEB5E420D297"
-                     BuildableName = "c_lib (7d2e3)"
-                     BlueprintName = "c_lib (7d2e3)"
-                     ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+                     BlueprintIdentifier = "DF7734F9DE4017910A9F923A"
+                     BuildableName = "c_lib (x86_64) (AppStore, Debug) (7d2e3)"
+                     BlueprintName = "c_lib (x86_64) (AppStore, Debug) (7d2e3)"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
                   </BuildableReference>
                </EnvironmentBuildable>
             </ActionContent>
@@ -25,15 +25,15 @@
          <ExecutionAction
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
-               title = "Set Bazel Build Output Groups for c_lib (7d2e3)"
+               title = "Set Bazel Build Output Groups for c_lib (x86_64) (AppStore, Debug) (7d2e3)"
                scriptText = "echo &quot;$BAZEL_LABEL,$BAZEL_TARGET_ID&quot; &gt;&gt; &quot;$SCHEME_TARGET_IDS_FILE&quot;&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
-                     BlueprintIdentifier = "6BF04914EEB0EEB5E420D297"
-                     BuildableName = "c_lib (7d2e3)"
-                     BlueprintName = "c_lib (7d2e3)"
-                     ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+                     BlueprintIdentifier = "DF7734F9DE4017910A9F923A"
+                     BuildableName = "c_lib (x86_64) (AppStore, Debug) (7d2e3)"
+                     BlueprintName = "c_lib (x86_64) (AppStore, Debug) (7d2e3)"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
                   </BuildableReference>
                </EnvironmentBuildable>
             </ActionContent>
@@ -48,10 +48,10 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "6BF04914EEB0EEB5E420D297"
-               BuildableName = "c_lib (7d2e3)"
-               BlueprintName = "c_lib (7d2e3)"
-               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+               BlueprintIdentifier = "DF7734F9DE4017910A9F923A"
+               BuildableName = "c_lib (x86_64) (AppStore, Debug) (7d2e3)"
+               BlueprintName = "c_lib (x86_64) (AppStore, Debug) (7d2e3)"
+               ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>

--- a/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/c_lib (x86_64) (AppStore, Debug) (f321a).xcscheme
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/c_lib (x86_64) (AppStore, Debug) (f321a).xcscheme
@@ -14,10 +14,10 @@
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
-                     BlueprintIdentifier = "CF2B52D46610C73C56C4C5B1"
-                     BuildableName = "private_swift_lib (f321a)"
-                     BlueprintName = "private_swift_lib (f321a)"
-                     ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+                     BlueprintIdentifier = "45DECB1A5D5381A0B8C369B5"
+                     BuildableName = "c_lib (x86_64) (AppStore, Debug) (f321a)"
+                     BlueprintName = "c_lib (x86_64) (AppStore, Debug) (f321a)"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
                   </BuildableReference>
                </EnvironmentBuildable>
             </ActionContent>
@@ -25,15 +25,15 @@
          <ExecutionAction
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
-               title = "Set Bazel Build Output Groups for private_swift_lib (f321a)"
+               title = "Set Bazel Build Output Groups for c_lib (x86_64) (AppStore, Debug) (f321a)"
                scriptText = "echo &quot;$BAZEL_LABEL,$BAZEL_TARGET_ID&quot; &gt;&gt; &quot;$SCHEME_TARGET_IDS_FILE&quot;&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
-                     BlueprintIdentifier = "CF2B52D46610C73C56C4C5B1"
-                     BuildableName = "private_swift_lib (f321a)"
-                     BlueprintName = "private_swift_lib (f321a)"
-                     ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+                     BlueprintIdentifier = "45DECB1A5D5381A0B8C369B5"
+                     BuildableName = "c_lib (x86_64) (AppStore, Debug) (f321a)"
+                     BlueprintName = "c_lib (x86_64) (AppStore, Debug) (f321a)"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
                   </BuildableReference>
                </EnvironmentBuildable>
             </ActionContent>
@@ -48,10 +48,10 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "CF2B52D46610C73C56C4C5B1"
-               BuildableName = "private_swift_lib (f321a)"
-               BlueprintName = "private_swift_lib (f321a)"
-               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+               BlueprintIdentifier = "45DECB1A5D5381A0B8C369B5"
+               BuildableName = "c_lib (x86_64) (AppStore, Debug) (f321a)"
+               BlueprintName = "c_lib (x86_64) (AppStore, Debug) (f321a)"
+               ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>

--- a/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/lib_impl (x86_64) (AppStore, Debug) (7d2e3).xcscheme
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/lib_impl (x86_64) (AppStore, Debug) (7d2e3).xcscheme
@@ -14,10 +14,10 @@
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
-                     BlueprintIdentifier = "EC377162E15E765DA8DDC9D3"
-                     BuildableName = "private_lib (7d2e3)"
-                     BlueprintName = "private_lib (7d2e3)"
-                     ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+                     BlueprintIdentifier = "8B80C81E05DBE296D69AC29B"
+                     BuildableName = "lib_impl (x86_64) (AppStore, Debug) (7d2e3)"
+                     BlueprintName = "lib_impl (x86_64) (AppStore, Debug) (7d2e3)"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
                   </BuildableReference>
                </EnvironmentBuildable>
             </ActionContent>
@@ -25,15 +25,15 @@
          <ExecutionAction
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
-               title = "Set Bazel Build Output Groups for private_lib (7d2e3)"
+               title = "Set Bazel Build Output Groups for lib_impl (x86_64) (AppStore, Debug) (7d2e3)"
                scriptText = "echo &quot;$BAZEL_LABEL,$BAZEL_TARGET_ID&quot; &gt;&gt; &quot;$SCHEME_TARGET_IDS_FILE&quot;&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
-                     BlueprintIdentifier = "EC377162E15E765DA8DDC9D3"
-                     BuildableName = "private_lib (7d2e3)"
-                     BlueprintName = "private_lib (7d2e3)"
-                     ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+                     BlueprintIdentifier = "8B80C81E05DBE296D69AC29B"
+                     BuildableName = "lib_impl (x86_64) (AppStore, Debug) (7d2e3)"
+                     BlueprintName = "lib_impl (x86_64) (AppStore, Debug) (7d2e3)"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
                   </BuildableReference>
                </EnvironmentBuildable>
             </ActionContent>
@@ -48,10 +48,10 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "EC377162E15E765DA8DDC9D3"
-               BuildableName = "private_lib (7d2e3)"
-               BlueprintName = "private_lib (7d2e3)"
-               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+               BlueprintIdentifier = "8B80C81E05DBE296D69AC29B"
+               BuildableName = "lib_impl (x86_64) (AppStore, Debug) (7d2e3)"
+               BlueprintName = "lib_impl (x86_64) (AppStore, Debug) (7d2e3)"
+               ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>

--- a/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/lib_impl (x86_64) (AppStore, Debug) (f321a).xcscheme
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/lib_impl (x86_64) (AppStore, Debug) (f321a).xcscheme
@@ -14,10 +14,10 @@
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
-                     BlueprintIdentifier = "D1C427A70AABE7276459D0C4"
-                     BuildableName = "c_lib (f321a)"
-                     BlueprintName = "c_lib (f321a)"
-                     ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+                     BlueprintIdentifier = "88C064658F18E2860B4D1308"
+                     BuildableName = "lib_impl (x86_64) (AppStore, Debug) (f321a)"
+                     BlueprintName = "lib_impl (x86_64) (AppStore, Debug) (f321a)"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
                   </BuildableReference>
                </EnvironmentBuildable>
             </ActionContent>
@@ -25,15 +25,15 @@
          <ExecutionAction
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
-               title = "Set Bazel Build Output Groups for c_lib (f321a)"
+               title = "Set Bazel Build Output Groups for lib_impl (x86_64) (AppStore, Debug) (f321a)"
                scriptText = "echo &quot;$BAZEL_LABEL,$BAZEL_TARGET_ID&quot; &gt;&gt; &quot;$SCHEME_TARGET_IDS_FILE&quot;&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
-                     BlueprintIdentifier = "D1C427A70AABE7276459D0C4"
-                     BuildableName = "c_lib (f321a)"
-                     BlueprintName = "c_lib (f321a)"
-                     ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+                     BlueprintIdentifier = "88C064658F18E2860B4D1308"
+                     BuildableName = "lib_impl (x86_64) (AppStore, Debug) (f321a)"
+                     BlueprintName = "lib_impl (x86_64) (AppStore, Debug) (f321a)"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
                   </BuildableReference>
                </EnvironmentBuildable>
             </ActionContent>
@@ -48,10 +48,10 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "D1C427A70AABE7276459D0C4"
-               BuildableName = "c_lib (f321a)"
-               BlueprintName = "c_lib (f321a)"
-               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+               BlueprintIdentifier = "88C064658F18E2860B4D1308"
+               BuildableName = "lib_impl (x86_64) (AppStore, Debug) (f321a)"
+               BlueprintName = "lib_impl (x86_64) (AppStore, Debug) (f321a)"
+               ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>

--- a/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/lib_swift (x86_64) (AppStore, Debug) (7d2e3).xcscheme
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/lib_swift (x86_64) (AppStore, Debug) (7d2e3).xcscheme
@@ -14,10 +14,10 @@
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
-                     BlueprintIdentifier = "49DFB89FFA70419624B2A930"
-                     BuildableName = "private_swift_lib (7d2e3)"
-                     BlueprintName = "private_swift_lib (7d2e3)"
-                     ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+                     BlueprintIdentifier = "B500D7461E49E54B4ABF62AD"
+                     BuildableName = "lib_swift (x86_64) (AppStore, Debug) (7d2e3)"
+                     BlueprintName = "lib_swift (x86_64) (AppStore, Debug) (7d2e3)"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
                   </BuildableReference>
                </EnvironmentBuildable>
             </ActionContent>
@@ -25,15 +25,15 @@
          <ExecutionAction
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
-               title = "Set Bazel Build Output Groups for private_swift_lib (7d2e3)"
+               title = "Set Bazel Build Output Groups for lib_swift (x86_64) (AppStore, Debug) (7d2e3)"
                scriptText = "echo &quot;$BAZEL_LABEL,$BAZEL_TARGET_ID&quot; &gt;&gt; &quot;$SCHEME_TARGET_IDS_FILE&quot;&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
-                     BlueprintIdentifier = "49DFB89FFA70419624B2A930"
-                     BuildableName = "private_swift_lib (7d2e3)"
-                     BlueprintName = "private_swift_lib (7d2e3)"
-                     ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+                     BlueprintIdentifier = "B500D7461E49E54B4ABF62AD"
+                     BuildableName = "lib_swift (x86_64) (AppStore, Debug) (7d2e3)"
+                     BlueprintName = "lib_swift (x86_64) (AppStore, Debug) (7d2e3)"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
                   </BuildableReference>
                </EnvironmentBuildable>
             </ActionContent>
@@ -48,10 +48,10 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "49DFB89FFA70419624B2A930"
-               BuildableName = "private_swift_lib (7d2e3)"
-               BlueprintName = "private_swift_lib (7d2e3)"
-               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+               BlueprintIdentifier = "B500D7461E49E54B4ABF62AD"
+               BuildableName = "lib_swift (x86_64) (AppStore, Debug) (7d2e3)"
+               BlueprintName = "lib_swift (x86_64) (AppStore, Debug) (7d2e3)"
+               ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>

--- a/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/lib_swift (x86_64) (AppStore, Debug) (f321a).xcscheme
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/lib_swift (x86_64) (AppStore, Debug) (f321a).xcscheme
@@ -14,9 +14,9 @@
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
-                     BlueprintIdentifier = "91F80CE88A7520813ACCC369"
-                     BuildableName = "lib_swift (7d2e3)"
-                     BlueprintName = "lib_swift (7d2e3)"
+                     BlueprintIdentifier = "18EBFDB7226F943F66D75280"
+                     BuildableName = "lib_swift (x86_64) (AppStore, Debug) (f321a)"
+                     BlueprintName = "lib_swift (x86_64) (AppStore, Debug) (f321a)"
                      ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
                   </BuildableReference>
                </EnvironmentBuildable>
@@ -25,14 +25,14 @@
          <ExecutionAction
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
-               title = "Set Bazel Build Output Groups for lib_swift (7d2e3)"
+               title = "Set Bazel Build Output Groups for lib_swift (x86_64) (AppStore, Debug) (f321a)"
                scriptText = "echo &quot;$BAZEL_LABEL,$BAZEL_TARGET_ID&quot; &gt;&gt; &quot;$SCHEME_TARGET_IDS_FILE&quot;&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
-                     BlueprintIdentifier = "91F80CE88A7520813ACCC369"
-                     BuildableName = "lib_swift (7d2e3)"
-                     BlueprintName = "lib_swift (7d2e3)"
+                     BlueprintIdentifier = "18EBFDB7226F943F66D75280"
+                     BuildableName = "lib_swift (x86_64) (AppStore, Debug) (f321a)"
+                     BlueprintName = "lib_swift (x86_64) (AppStore, Debug) (f321a)"
                      ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
                   </BuildableReference>
                </EnvironmentBuildable>
@@ -48,9 +48,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "91F80CE88A7520813ACCC369"
-               BuildableName = "lib_swift (7d2e3)"
-               BlueprintName = "lib_swift (7d2e3)"
+               BlueprintIdentifier = "18EBFDB7226F943F66D75280"
+               BuildableName = "lib_swift (x86_64) (AppStore, Debug) (f321a)"
+               BlueprintName = "lib_swift (x86_64) (AppStore, Debug) (f321a)"
                ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>

--- a/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/private_lib (x86_64) (AppStore, Debug) (7d2e3).xcscheme
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/private_lib (x86_64) (AppStore, Debug) (7d2e3).xcscheme
@@ -14,9 +14,9 @@
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
-                     BlueprintIdentifier = "542253A7A8F5937E85688AC7"
-                     BuildableName = "lib_impl (f321a)"
-                     BlueprintName = "lib_impl (f321a)"
+                     BlueprintIdentifier = "C7E68ADCEEDA842BAB2871EB"
+                     BuildableName = "private_lib (x86_64) (AppStore, Debug) (7d2e3)"
+                     BlueprintName = "private_lib (x86_64) (AppStore, Debug) (7d2e3)"
                      ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
                   </BuildableReference>
                </EnvironmentBuildable>
@@ -25,14 +25,14 @@
          <ExecutionAction
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
-               title = "Set Bazel Build Output Groups for lib_impl (f321a)"
+               title = "Set Bazel Build Output Groups for private_lib (x86_64) (AppStore, Debug) (7d2e3)"
                scriptText = "echo &quot;$BAZEL_LABEL,$BAZEL_TARGET_ID&quot; &gt;&gt; &quot;$SCHEME_TARGET_IDS_FILE&quot;&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
-                     BlueprintIdentifier = "542253A7A8F5937E85688AC7"
-                     BuildableName = "lib_impl (f321a)"
-                     BlueprintName = "lib_impl (f321a)"
+                     BlueprintIdentifier = "C7E68ADCEEDA842BAB2871EB"
+                     BuildableName = "private_lib (x86_64) (AppStore, Debug) (7d2e3)"
+                     BlueprintName = "private_lib (x86_64) (AppStore, Debug) (7d2e3)"
                      ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
                   </BuildableReference>
                </EnvironmentBuildable>
@@ -48,9 +48,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "542253A7A8F5937E85688AC7"
-               BuildableName = "lib_impl (f321a)"
-               BlueprintName = "lib_impl (f321a)"
+               BlueprintIdentifier = "C7E68ADCEEDA842BAB2871EB"
+               BuildableName = "private_lib (x86_64) (AppStore, Debug) (7d2e3)"
+               BlueprintName = "private_lib (x86_64) (AppStore, Debug) (7d2e3)"
                ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>

--- a/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/private_lib (x86_64) (AppStore, Debug) (f321a).xcscheme
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/private_lib (x86_64) (AppStore, Debug) (f321a).xcscheme
@@ -14,10 +14,10 @@
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
-                     BlueprintIdentifier = "C41577B6AE75D0FB7EF37BAD"
-                     BuildableName = "lib_impl (7d2e3)"
-                     BlueprintName = "lib_impl (7d2e3)"
-                     ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+                     BlueprintIdentifier = "1A9C34161E849CD15FAB705B"
+                     BuildableName = "private_lib (x86_64) (AppStore, Debug) (f321a)"
+                     BlueprintName = "private_lib (x86_64) (AppStore, Debug) (f321a)"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
                   </BuildableReference>
                </EnvironmentBuildable>
             </ActionContent>
@@ -25,15 +25,15 @@
          <ExecutionAction
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
-               title = "Set Bazel Build Output Groups for lib_impl (7d2e3)"
+               title = "Set Bazel Build Output Groups for private_lib (x86_64) (AppStore, Debug) (f321a)"
                scriptText = "echo &quot;$BAZEL_LABEL,$BAZEL_TARGET_ID&quot; &gt;&gt; &quot;$SCHEME_TARGET_IDS_FILE&quot;&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
-                     BlueprintIdentifier = "C41577B6AE75D0FB7EF37BAD"
-                     BuildableName = "lib_impl (7d2e3)"
-                     BlueprintName = "lib_impl (7d2e3)"
-                     ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+                     BlueprintIdentifier = "1A9C34161E849CD15FAB705B"
+                     BuildableName = "private_lib (x86_64) (AppStore, Debug) (f321a)"
+                     BlueprintName = "private_lib (x86_64) (AppStore, Debug) (f321a)"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
                   </BuildableReference>
                </EnvironmentBuildable>
             </ActionContent>
@@ -48,10 +48,10 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "C41577B6AE75D0FB7EF37BAD"
-               BuildableName = "lib_impl (7d2e3)"
-               BlueprintName = "lib_impl (7d2e3)"
-               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+               BlueprintIdentifier = "1A9C34161E849CD15FAB705B"
+               BuildableName = "private_lib (x86_64) (AppStore, Debug) (f321a)"
+               BlueprintName = "private_lib (x86_64) (AppStore, Debug) (f321a)"
+               ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>

--- a/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/private_swift_lib (x86_64) (AppStore, Debug) (7d2e3).xcscheme
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/private_swift_lib (x86_64) (AppStore, Debug) (7d2e3).xcscheme
@@ -14,10 +14,10 @@
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
-                     BlueprintIdentifier = "383BE46EAF3E45FAC4CA665C"
-                     BuildableName = "lib_swift (f321a)"
-                     BlueprintName = "lib_swift (f321a)"
-                     ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+                     BlueprintIdentifier = "2A467471C6406DBFAF8A6490"
+                     BuildableName = "private_swift_lib (x86_64) (AppStore, Debug) (7d2e3)"
+                     BlueprintName = "private_swift_lib (x86_64) (AppStore, Debug) (7d2e3)"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
                   </BuildableReference>
                </EnvironmentBuildable>
             </ActionContent>
@@ -25,15 +25,15 @@
          <ExecutionAction
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
-               title = "Set Bazel Build Output Groups for lib_swift (f321a)"
+               title = "Set Bazel Build Output Groups for private_swift_lib (x86_64) (AppStore, Debug) (7d2e3)"
                scriptText = "echo &quot;$BAZEL_LABEL,$BAZEL_TARGET_ID&quot; &gt;&gt; &quot;$SCHEME_TARGET_IDS_FILE&quot;&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
-                     BlueprintIdentifier = "383BE46EAF3E45FAC4CA665C"
-                     BuildableName = "lib_swift (f321a)"
-                     BlueprintName = "lib_swift (f321a)"
-                     ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+                     BlueprintIdentifier = "2A467471C6406DBFAF8A6490"
+                     BuildableName = "private_swift_lib (x86_64) (AppStore, Debug) (7d2e3)"
+                     BlueprintName = "private_swift_lib (x86_64) (AppStore, Debug) (7d2e3)"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
                   </BuildableReference>
                </EnvironmentBuildable>
             </ActionContent>
@@ -48,10 +48,10 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "383BE46EAF3E45FAC4CA665C"
-               BuildableName = "lib_swift (f321a)"
-               BlueprintName = "lib_swift (f321a)"
-               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+               BlueprintIdentifier = "2A467471C6406DBFAF8A6490"
+               BuildableName = "private_swift_lib (x86_64) (AppStore, Debug) (7d2e3)"
+               BlueprintName = "private_swift_lib (x86_64) (AppStore, Debug) (7d2e3)"
+               ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>

--- a/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/private_swift_lib (x86_64) (AppStore, Debug) (f321a).xcscheme
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/private_swift_lib (x86_64) (AppStore, Debug) (f321a).xcscheme
@@ -14,10 +14,10 @@
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
-                     BlueprintIdentifier = "BA52C6F37366B8B20D17ADBE"
-                     BuildableName = "private_lib (f321a)"
-                     BlueprintName = "private_lib (f321a)"
-                     ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+                     BlueprintIdentifier = "57840EFFCCDD851E8DCF053C"
+                     BuildableName = "private_swift_lib (x86_64) (AppStore, Debug) (f321a)"
+                     BlueprintName = "private_swift_lib (x86_64) (AppStore, Debug) (f321a)"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
                   </BuildableReference>
                </EnvironmentBuildable>
             </ActionContent>
@@ -25,15 +25,15 @@
          <ExecutionAction
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
-               title = "Set Bazel Build Output Groups for private_lib (f321a)"
+               title = "Set Bazel Build Output Groups for private_swift_lib (x86_64) (AppStore, Debug) (f321a)"
                scriptText = "echo &quot;$BAZEL_LABEL,$BAZEL_TARGET_ID&quot; &gt;&gt; &quot;$SCHEME_TARGET_IDS_FILE&quot;&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
-                     BlueprintIdentifier = "BA52C6F37366B8B20D17ADBE"
-                     BuildableName = "private_lib (f321a)"
-                     BlueprintName = "private_lib (f321a)"
-                     ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+                     BlueprintIdentifier = "57840EFFCCDD851E8DCF053C"
+                     BuildableName = "private_swift_lib (x86_64) (AppStore, Debug) (f321a)"
+                     BlueprintName = "private_swift_lib (x86_64) (AppStore, Debug) (f321a)"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
                   </BuildableReference>
                </EnvironmentBuildable>
             </ActionContent>
@@ -48,10 +48,10 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "BA52C6F37366B8B20D17ADBE"
-               BuildableName = "private_lib (f321a)"
-               BlueprintName = "private_lib (f321a)"
-               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+               BlueprintIdentifier = "57840EFFCCDD851E8DCF053C"
+               BuildableName = "private_swift_lib (x86_64) (AppStore, Debug) (f321a)"
+               BlueprintName = "private_swift_lib (x86_64) (AppStore, Debug) (f321a)"
+               ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>

--- a/tools/generators/legacy/src/Generator/DisambiguateTargets.swift
+++ b/tools/generators/legacy/src/Generator/DisambiguateTargets.swift
@@ -194,24 +194,6 @@ struct ProductTypeComponents {
 
         let includeOS = oses.count > 1
 
-        guard !needsConfigurationDistinguishing(target: target) else {
-            // The target name would be ambiguous, even with our distinguisher
-            // components. We will show a shorted configuration hash instead,
-            // which will be unique.
-            if includeOS {
-                consolidatedDistinguishers.append(
-                    contentsOf: targets.map(\.platform.os.prettyName)
-                )
-                distinguishers.append(
-                    consolidatedDistinguishers.joined(separator: ", ")
-                )
-            }
-
-            distinguishers.append(prettyConfiguration(targets: targets))
-
-            return distinguishers
-        }
-
         for target in targets {
             let osDistinguisher = oses[target.platform.os]!.distinguisher(
                 target: target,
@@ -238,6 +220,13 @@ struct ProductTypeComponents {
             distinguishers.append(
                 xcodeConfigurations.sorted().joined(separator: ", ")
             )
+        }
+
+        if needsConfigurationDistinguishing(target: target) {
+            // The target name would be ambiguous, even with our distinguisher
+            // components. We will show a shorted configuration hash as well,
+            // which will be unique.
+            distinguishers.append(prettyConfiguration(targets: targets))
         }
 
         return distinguishers

--- a/tools/generators/pbxproject_targets/src/Generator/DisambiguateTargets.swift
+++ b/tools/generators/pbxproject_targets/src/Generator/DisambiguateTargets.swift
@@ -216,25 +216,6 @@ struct ProductTypeComponents {
 
         let includeOS = oses.count > 1
 
-        guard !needsConfigurationDistinguishing(target: consolidatedTarget)
-        else {
-            // The target name would be ambiguous, even with our distinguisher
-            // components. We will show a shorted configuration hash instead,
-            // which will be unique.
-            if includeOS {
-                consolidatedDistinguishers.append(
-                    contentsOf: targets.map(\.platform.os.prettyName)
-                )
-                distinguishers.append(
-                    consolidatedDistinguishers.joined(separator: ", ")
-                )
-            }
-
-            distinguishers.append(prettyConfiguration(targets: targets))
-
-            return distinguishers
-        }
-
         for target in targets {
             let osDistinguisher = oses[target.platform.os]!.distinguisher(
                 target: target,
@@ -261,6 +242,13 @@ struct ProductTypeComponents {
             distinguishers.append(
                 xcodeConfigurations.sorted().joined(separator: ", ")
             )
+        }
+
+        if needsConfigurationDistinguishing(target: consolidatedTarget) {
+            // The target name would be ambiguous, even with our distinguisher
+            // components. We will show a shorted configuration hash instead,
+            // which will be unique.
+            distinguishers.append(prettyConfiguration(targets: targets))
         }
 
         return distinguishers

--- a/tools/generators/pbxproject_targets/test/Generator/DisambiguateTargetsTests.swift
+++ b/tools/generators/pbxproject_targets/test/Generator/DisambiguateTargetsTests.swift
@@ -710,6 +710,114 @@ final class DisambiguateTargetsTests: XCTestCase {
         )
     }
 
+    func test_architectureAndConfiguration() throws {
+        // Arrange
+
+        let targets: [Target] = [
+            .mock(
+                id: "A-arm64 1",
+                label: "//:A",
+                xcodeConfigurations: ["Debug", "AppStore"], // No effect
+                arch: "arm64"
+            ),
+            .mock(
+                id: "A-arm64 2",
+                label: "//:A",
+                xcodeConfigurations: ["Debug", "AppStore"], // No effect
+                arch: "arm64"
+            ),
+            .mock(
+                id: "A-x86_64 2",
+                label: "//:A",
+                xcodeConfigurations: ["Debug", "AppStore"], // No effect
+                arch: "x86_64"
+            ),
+            .mock(
+                id: "B",
+                label: "//:B"
+            ),
+        ]
+        let consolidatedTargets = Array<ConsolidatedTarget>(targets: targets)
+
+        let expectedTargetNames: [ConsolidatedTarget.Key: String] = [
+            ["A-arm64 1"]: """
+A (arm64) (\(ProductTypeComponents.prettyConfigurations(["1"])))
+""",
+            ["A-arm64 2"]: """
+A (arm64) (\(ProductTypeComponents.prettyConfigurations(["2"])))
+""",
+            ["A-x86_64 2"]: "A (x86_64)",
+            ["B"]: "B",
+        ]
+
+        // Act
+
+        let disambiguatedTargets =
+            Generator.DisambiguateTargets.defaultCallable(consolidatedTargets)
+
+        // Assert
+
+        XCTAssertNoDifference(
+            disambiguatedTargets,
+            names: expectedTargetNames,
+            targets: consolidatedTargets
+        )
+    }
+
+    func test_architectureAndConfiguration_multipleXcodeConfigurations() throws {
+        // Arrange
+
+        let targets: [Target] = [
+            .mock(
+                id: "A-arm64 1",
+                label: "//:A",
+                xcodeConfigurations: ["Debug", "AppStore"], // No effect
+                arch: "arm64"
+            ),
+            .mock(
+                id: "A-arm64 2",
+                label: "//:A",
+                xcodeConfigurations: ["Debug", "AppStore"], // No effect
+                arch: "arm64"
+            ),
+            .mock(
+                id: "A-x86_64 2",
+                label: "//:A",
+                xcodeConfigurations: ["Profile"], // No effect
+                arch: "x86_64"
+            ),
+            .mock(
+                id: "B",
+                label: "//:B"
+            ),
+        ]
+        let consolidatedTargets = Array<ConsolidatedTarget>(targets: targets)
+
+        let expectedTargetNames: [ConsolidatedTarget.Key: String] = [
+            ["A-arm64 1"]: """
+A (arm64) (\(ProductTypeComponents.prettyConfigurations(["1"])))
+""",
+            ["A-arm64 2"]: """
+A (arm64) (\(ProductTypeComponents.prettyConfigurations(["2"])))
+""",
+            ["A-x86_64 2"]: "A (x86_64)",
+            ["B"]: "B",
+        ]
+
+        // Act
+
+        let disambiguatedTargets =
+            Generator.DisambiguateTargets.defaultCallable(consolidatedTargets)
+
+        // Assert
+
+        XCTAssertNoDifference(
+            disambiguatedTargets,
+            names: expectedTargetNames,
+            targets: consolidatedTargets
+        )
+    }
+
     func test_productTypeAndConfiguration() throws {
         // Arrange
 

--- a/tools/generators/pbxproject_targets/test/Generator/DisambiguateTargetsTests.swift
+++ b/tools/generators/pbxproject_targets/test/Generator/DisambiguateTargetsTests.swift
@@ -920,6 +920,108 @@ A (iOS) (\(ProductTypeComponents.prettyConfigurations(["2"])))
         )
     }
 
+    func test_xcodeConfigurationAndConfiguration() throws {
+        // Arrange
+
+        let targets: [Target] = [
+            .mock(
+                id: "A-Debug 1",
+                label: "//:A",
+                xcodeConfigurations: ["Debug"]
+            ),
+            .mock(
+                id: "A-Debug 2",
+                label: "//:A",
+                xcodeConfigurations: ["Debug"]
+            ),
+            .mock(
+                id: "A-Release 3",
+                label: "//:A",
+                xcodeConfigurations: ["Release"]
+            ),
+            .mock(
+                id: "B",
+                label: "//:B"
+            ),
+        ]
+        let consolidatedTargets = Array<ConsolidatedTarget>(targets: targets)
+
+        let expectedTargetNames: [ConsolidatedTarget.Key: String] = [
+            ["A-Debug 1"]: """
+A (Debug) (\(ProductTypeComponents.prettyConfigurations(["1"])))
+""",
+            ["A-Debug 2"]: """
+A (Debug) (\(ProductTypeComponents.prettyConfigurations(["2"])))
+""",
+            ["A-Release 3"]: "A (Release)",
+            ["B"]: "B",
+        ]
+
+        // Act
+
+        let disambiguatedTargets =
+            Generator.DisambiguateTargets.defaultCallable(consolidatedTargets)
+
+        // Assert
+
+        XCTAssertNoDifference(
+            disambiguatedTargets,
+            names: expectedTargetNames,
+            targets: consolidatedTargets
+        )
+    }
+
+    func test_multipleXcodeConfigurationAndConfiguration() throws {
+        // Arrange
+
+        let targets: [Target] = [
+            .mock(
+                id: "A-DebugProfile 1",
+                label: "//:A",
+                xcodeConfigurations: ["Debug", "Profile"]
+            ),
+            .mock(
+                id: "A-DebugProfile 2",
+                label: "//:A",
+                xcodeConfigurations: ["Debug", "Profile"]
+            ),
+            .mock(
+                id: "A-Release 3",
+                label: "//:A",
+                xcodeConfigurations: ["Release"]
+            ),
+            .mock(
+                id: "B",
+                label: "//:B"
+            ),
+        ]
+        let consolidatedTargets = Array<ConsolidatedTarget>(targets: targets)
+
+        let expectedTargetNames: [ConsolidatedTarget.Key: String] = [
+            ["A-DebugProfile 1"]: """
+A (Debug, Profile) (\(ProductTypeComponents.prettyConfigurations(["1"])))
+""",
+            ["A-DebugProfile 2"]: """
+A (Debug, Profile) (\(ProductTypeComponents.prettyConfigurations(["2"])))
+""",
+            ["A-Release 3"]: "A (Release)",
+            ["B"]: "B",
+        ]
+
+        // Act
+
+        let disambiguatedTargets =
+            Generator.DisambiguateTargets.defaultCallable(consolidatedTargets)
+
+        // Assert
+
+        XCTAssertNoDifference(
+            disambiguatedTargets,
+            names: expectedTargetNames,
+            targets: consolidatedTargets
+        )
+    }
+
     // MARK: - Consolidated Targets
 
     func test_consolidated() throws {


### PR DESCRIPTION
We wouldn’t show architecture or Xcode configurations before.