### PR TITLE
Fix wrong execution root used in Index Build indexstore importing

### DIFF
--- a/examples/cc/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -1061,7 +1061,7 @@
 				INDEXING_DEPLOYMENT_LOCATION__NO = YES;
 				INDEXING_DEPLOYMENT_LOCATION__YES = NO;
 				INDEXING_PROJECT_DIR__ = "$(INDEXING_PROJECT_DIR__NO)";
-				INDEXING_PROJECT_DIR__NO = "$(PROJECT_DIR)";
+				INDEXING_PROJECT_DIR__NO = "../../../../../bazel-output-base/rules_xcodeproj.noindex/build_output_base/execroot/__main__";
 				INDEXING_PROJECT_DIR__YES = "../../../../../bazel-output-base/rules_xcodeproj.noindex/indexbuild_output_base/execroot/__main__";
 				INDEX_DATA_STORE_DIR = "$(INDEX_DATA_STORE_DIR)";
 				INDEX_FORCE_SCRIPT_EXECUTION = YES;

--- a/examples/cc/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/cc/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -982,7 +982,7 @@
 				INDEXING_DEPLOYMENT_LOCATION__NO = YES;
 				INDEXING_DEPLOYMENT_LOCATION__YES = NO;
 				INDEXING_PROJECT_DIR__ = "$(INDEXING_PROJECT_DIR__NO)";
-				INDEXING_PROJECT_DIR__NO = "$(PROJECT_DIR)";
+				INDEXING_PROJECT_DIR__NO = "../../../../../bazel-output-base/rules_xcodeproj.noindex/build_output_base/execroot/__main__";
 				INDEXING_PROJECT_DIR__YES = "../../../../../bazel-output-base/rules_xcodeproj.noindex/indexbuild_output_base/execroot/__main__";
 				INDEX_DATA_STORE_DIR = "$(INDEX_DATA_STORE_DIR)";
 				INDEX_FORCE_SCRIPT_EXECUTION = YES;

--- a/examples/integration/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -13049,7 +13049,7 @@
 				INDEXING_DEPLOYMENT_LOCATION__NO = YES;
 				INDEXING_DEPLOYMENT_LOCATION__YES = NO;
 				INDEXING_PROJECT_DIR__ = "$(INDEXING_PROJECT_DIR__NO)";
-				INDEXING_PROJECT_DIR__NO = "$(PROJECT_DIR)";
+				INDEXING_PROJECT_DIR__NO = "../../../../../bazel-output-base/rules_xcodeproj.noindex/build_output_base/execroot/__main__";
 				INDEXING_PROJECT_DIR__YES = "../../../../../bazel-output-base/rules_xcodeproj.noindex/indexbuild_output_base/execroot/__main__";
 				INDEX_DATA_STORE_DIR = "$(INDEX_DATA_STORE_DIR)";
 				INDEX_FORCE_SCRIPT_EXECUTION = YES;
@@ -15220,7 +15220,7 @@
 				INDEXING_DEPLOYMENT_LOCATION__NO = YES;
 				INDEXING_DEPLOYMENT_LOCATION__YES = NO;
 				INDEXING_PROJECT_DIR__ = "$(INDEXING_PROJECT_DIR__NO)";
-				INDEXING_PROJECT_DIR__NO = "$(PROJECT_DIR)";
+				INDEXING_PROJECT_DIR__NO = "../../../../../bazel-output-base/rules_xcodeproj.noindex/build_output_base/execroot/__main__";
 				INDEXING_PROJECT_DIR__YES = "../../../../../bazel-output-base/rules_xcodeproj.noindex/indexbuild_output_base/execroot/__main__";
 				INDEX_DATA_STORE_DIR = "$(INDEX_DATA_STORE_DIR)";
 				INDEX_FORCE_SCRIPT_EXECUTION = YES;

--- a/examples/integration/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -14605,7 +14605,7 @@
 				INDEXING_DEPLOYMENT_LOCATION__NO = YES;
 				INDEXING_DEPLOYMENT_LOCATION__YES = NO;
 				INDEXING_PROJECT_DIR__ = "$(INDEXING_PROJECT_DIR__NO)";
-				INDEXING_PROJECT_DIR__NO = "$(PROJECT_DIR)";
+				INDEXING_PROJECT_DIR__NO = "../../../../../bazel-output-base/rules_xcodeproj.noindex/build_output_base/execroot/__main__";
 				INDEXING_PROJECT_DIR__YES = "../../../../../bazel-output-base/rules_xcodeproj.noindex/indexbuild_output_base/execroot/__main__";
 				INDEX_DATA_STORE_DIR = "$(INDEX_DATA_STORE_DIR)";
 				INDEX_FORCE_SCRIPT_EXECUTION = YES;
@@ -15663,7 +15663,7 @@
 				INDEXING_DEPLOYMENT_LOCATION__NO = YES;
 				INDEXING_DEPLOYMENT_LOCATION__YES = NO;
 				INDEXING_PROJECT_DIR__ = "$(INDEXING_PROJECT_DIR__NO)";
-				INDEXING_PROJECT_DIR__NO = "$(PROJECT_DIR)";
+				INDEXING_PROJECT_DIR__NO = "../../../../../bazel-output-base/rules_xcodeproj.noindex/build_output_base/execroot/__main__";
 				INDEXING_PROJECT_DIR__YES = "../../../../../bazel-output-base/rules_xcodeproj.noindex/indexbuild_output_base/execroot/__main__";
 				INDEX_DATA_STORE_DIR = "$(INDEX_DATA_STORE_DIR)";
 				INDEX_FORCE_SCRIPT_EXECUTION = YES;

--- a/examples/rules_ios/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/rules_ios/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -4781,7 +4781,7 @@
 				INDEXING_DEPLOYMENT_LOCATION__NO = YES;
 				INDEXING_DEPLOYMENT_LOCATION__YES = NO;
 				INDEXING_PROJECT_DIR__ = "$(INDEXING_PROJECT_DIR__NO)";
-				INDEXING_PROJECT_DIR__NO = "$(PROJECT_DIR)";
+				INDEXING_PROJECT_DIR__NO = "../../../../../bazel-output-base/rules_xcodeproj.noindex/build_output_base/execroot/__main__";
 				INDEXING_PROJECT_DIR__YES = "../../../../../bazel-output-base/rules_xcodeproj.noindex/indexbuild_output_base/execroot/__main__";
 				INDEX_DATA_STORE_DIR = "$(INDEX_DATA_STORE_DIR)";
 				INDEX_FORCE_SCRIPT_EXECUTION = YES;

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -842,7 +842,7 @@
 				INDEXING_DEPLOYMENT_LOCATION__NO = YES;
 				INDEXING_DEPLOYMENT_LOCATION__YES = NO;
 				INDEXING_PROJECT_DIR__ = "$(INDEXING_PROJECT_DIR__NO)";
-				INDEXING_PROJECT_DIR__NO = "$(PROJECT_DIR)";
+				INDEXING_PROJECT_DIR__NO = "../../../../../bazel-output-base/rules_xcodeproj.noindex/build_output_base/execroot/__main__";
 				INDEXING_PROJECT_DIR__YES = "../../../../../bazel-output-base/rules_xcodeproj.noindex/indexbuild_output_base/execroot/__main__";
 				INDEX_DATA_STORE_DIR = "$(INDEX_DATA_STORE_DIR)";
 				INDEX_FORCE_SCRIPT_EXECUTION = YES;

--- a/examples/sanitizers/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/sanitizers/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -817,7 +817,7 @@
 				INDEXING_DEPLOYMENT_LOCATION__NO = YES;
 				INDEXING_DEPLOYMENT_LOCATION__YES = NO;
 				INDEXING_PROJECT_DIR__ = "$(INDEXING_PROJECT_DIR__NO)";
-				INDEXING_PROJECT_DIR__NO = "$(PROJECT_DIR)";
+				INDEXING_PROJECT_DIR__NO = "../../../../../bazel-output-base/rules_xcodeproj.noindex/build_output_base/execroot/__main__";
 				INDEXING_PROJECT_DIR__YES = "../../../../../bazel-output-base/rules_xcodeproj.noindex/indexbuild_output_base/execroot/__main__";
 				INDEX_DATA_STORE_DIR = "$(INDEX_DATA_STORE_DIR)";
 				INDEX_FORCE_SCRIPT_EXECUTION = YES;

--- a/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
@@ -4363,7 +4363,7 @@
 				INDEXING_DEPLOYMENT_LOCATION__NO = YES;
 				INDEXING_DEPLOYMENT_LOCATION__YES = NO;
 				INDEXING_PROJECT_DIR__ = "$(INDEXING_PROJECT_DIR__NO)";
-				INDEXING_PROJECT_DIR__NO = "$(PROJECT_DIR)";
+				INDEXING_PROJECT_DIR__NO = "../../../../../bazel-output-base/rules_xcodeproj.noindex/build_output_base/execroot/rules_xcodeproj";
 				INDEXING_PROJECT_DIR__YES = "../../../../../bazel-output-base/rules_xcodeproj.noindex/indexbuild_output_base/execroot/rules_xcodeproj";
 				INDEX_DATA_STORE_DIR = "$(INDEX_DATA_STORE_DIR)";
 				INDEX_FORCE_SCRIPT_EXECUTION = YES;
@@ -5063,7 +5063,7 @@
 				INDEXING_DEPLOYMENT_LOCATION__NO = YES;
 				INDEXING_DEPLOYMENT_LOCATION__YES = NO;
 				INDEXING_PROJECT_DIR__ = "$(INDEXING_PROJECT_DIR__NO)";
-				INDEXING_PROJECT_DIR__NO = "$(PROJECT_DIR)";
+				INDEXING_PROJECT_DIR__NO = "../../../../../bazel-output-base/rules_xcodeproj.noindex/build_output_base/execroot/rules_xcodeproj";
 				INDEXING_PROJECT_DIR__YES = "../../../../../bazel-output-base/rules_xcodeproj.noindex/indexbuild_output_base/execroot/rules_xcodeproj";
 				INDEX_DATA_STORE_DIR = "$(INDEX_DATA_STORE_DIR)";
 				INDEX_FORCE_SCRIPT_EXECUTION = YES;
@@ -5461,7 +5461,7 @@
 				INDEXING_DEPLOYMENT_LOCATION__NO = YES;
 				INDEXING_DEPLOYMENT_LOCATION__YES = NO;
 				INDEXING_PROJECT_DIR__ = "$(INDEXING_PROJECT_DIR__NO)";
-				INDEXING_PROJECT_DIR__NO = "$(PROJECT_DIR)";
+				INDEXING_PROJECT_DIR__NO = "../../../../../bazel-output-base/rules_xcodeproj.noindex/build_output_base/execroot/rules_xcodeproj";
 				INDEXING_PROJECT_DIR__YES = "../../../../../bazel-output-base/rules_xcodeproj.noindex/indexbuild_output_base/execroot/rules_xcodeproj";
 				INDEX_DATA_STORE_DIR = "$(INDEX_DATA_STORE_DIR)";
 				INDEX_FORCE_SCRIPT_EXECUTION = YES;

--- a/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
@@ -4649,7 +4649,7 @@
 				INDEXING_DEPLOYMENT_LOCATION__NO = YES;
 				INDEXING_DEPLOYMENT_LOCATION__YES = NO;
 				INDEXING_PROJECT_DIR__ = "$(INDEXING_PROJECT_DIR__NO)";
-				INDEXING_PROJECT_DIR__NO = "$(PROJECT_DIR)";
+				INDEXING_PROJECT_DIR__NO = "../../../../../bazel-output-base/rules_xcodeproj.noindex/build_output_base/execroot/rules_xcodeproj";
 				INDEXING_PROJECT_DIR__YES = "../../../../../bazel-output-base/rules_xcodeproj.noindex/indexbuild_output_base/execroot/rules_xcodeproj";
 				INDEX_DATA_STORE_DIR = "$(INDEX_DATA_STORE_DIR)";
 				INDEX_FORCE_SCRIPT_EXECUTION = YES;
@@ -4989,7 +4989,7 @@
 				INDEXING_DEPLOYMENT_LOCATION__NO = YES;
 				INDEXING_DEPLOYMENT_LOCATION__YES = NO;
 				INDEXING_PROJECT_DIR__ = "$(INDEXING_PROJECT_DIR__NO)";
-				INDEXING_PROJECT_DIR__NO = "$(PROJECT_DIR)";
+				INDEXING_PROJECT_DIR__NO = "../../../../../bazel-output-base/rules_xcodeproj.noindex/build_output_base/execroot/rules_xcodeproj";
 				INDEXING_PROJECT_DIR__YES = "../../../../../bazel-output-base/rules_xcodeproj.noindex/indexbuild_output_base/execroot/rules_xcodeproj";
 				INDEX_DATA_STORE_DIR = "$(INDEX_DATA_STORE_DIR)";
 				INDEX_FORCE_SCRIPT_EXECUTION = YES;
@@ -5288,7 +5288,7 @@
 				INDEXING_DEPLOYMENT_LOCATION__NO = YES;
 				INDEXING_DEPLOYMENT_LOCATION__YES = NO;
 				INDEXING_PROJECT_DIR__ = "$(INDEXING_PROJECT_DIR__NO)";
-				INDEXING_PROJECT_DIR__NO = "$(PROJECT_DIR)";
+				INDEXING_PROJECT_DIR__NO = "../../../../../bazel-output-base/rules_xcodeproj.noindex/build_output_base/execroot/rules_xcodeproj";
 				INDEXING_PROJECT_DIR__YES = "../../../../../bazel-output-base/rules_xcodeproj.noindex/indexbuild_output_base/execroot/rules_xcodeproj";
 				INDEX_DATA_STORE_DIR = "$(INDEX_DATA_STORE_DIR)";
 				INDEX_FORCE_SCRIPT_EXECUTION = YES;

--- a/tools/generators/legacy/src/Generator/CreateProject.swift
+++ b/tools/generators/legacy/src/Generator/CreateProject.swift
@@ -119,7 +119,7 @@ $(INDEXING_DEPLOYMENT_LOCATION__NO)
             "INDEXING_DEPLOYMENT_LOCATION__NO": true,
             "INDEXING_DEPLOYMENT_LOCATION__YES": false,
             "INDEXING_PROJECT_DIR__": "$(INDEXING_PROJECT_DIR__NO)",
-            "INDEXING_PROJECT_DIR__NO": "$(PROJECT_DIR)",
+            "INDEXING_PROJECT_DIR__NO": absoluteProjectDirPath,
             "INDEXING_PROJECT_DIR__YES": indexingProjectDirPath,
             "INSTALL_PATH": "$(BAZEL_PACKAGE_BIN_DIR)/$(TARGET_NAME)/bin",
             "INTERNAL_DIR": """

--- a/tools/generators/legacy/test/CreateProjectTests.swift
+++ b/tools/generators/legacy/test/CreateProjectTests.swift
@@ -78,7 +78,9 @@ $(INDEXING_DEPLOYMENT_LOCATION__NO)
             "INDEXING_DEPLOYMENT_LOCATION__NO": true,
             "INDEXING_DEPLOYMENT_LOCATION__YES": false,
             "INDEXING_PROJECT_DIR__": "$(INDEXING_PROJECT_DIR__NO)",
-            "INDEXING_PROJECT_DIR__NO": "$(PROJECT_DIR)",
+            "INDEXING_PROJECT_DIR__NO": """
+/tmp/bazel-output-base/rules_xcodeproj/build_output_base/execroot/rules_xcodeproj
+""",
             "INDEXING_PROJECT_DIR__YES": """
 /tmp/bazel-output-base/rules_xcodeproj/indexbuild_output_base/execroot/rules_xcodeproj
 """,
@@ -238,7 +240,9 @@ $(INDEXING_DEPLOYMENT_LOCATION__NO)
             "INDEXING_DEPLOYMENT_LOCATION__NO": true,
             "INDEXING_DEPLOYMENT_LOCATION__YES": false,
             "INDEXING_PROJECT_DIR__": "$(INDEXING_PROJECT_DIR__NO)",
-            "INDEXING_PROJECT_DIR__NO": "$(PROJECT_DIR)",
+            "INDEXING_PROJECT_DIR__NO": """
+/tmp/bazel-output-base/rules_xcodeproj/build_output_base/execroot/rules_xcodeproj
+""",
             "INDEXING_PROJECT_DIR__YES": """
 /tmp/bazel-output-base/rules_xcodeproj/indexbuild_output_base/execroot/rules_xcodeproj
 """,

--- a/tools/generators/pbxproj_prefix/README.md
+++ b/tools/generators/pbxproj_prefix/README.md
@@ -219,7 +219,7 @@ Here is an example output:
 				INDEXING_DEPLOYMENT_LOCATION__NO = YES;
 				INDEXING_DEPLOYMENT_LOCATION__YES = NO;
 				INDEXING_PROJECT_DIR__ = "$(INDEXING_PROJECT_DIR__NO)";
-				INDEXING_PROJECT_DIR__NO = "$(PROJECT_DIR)";
+				INDEXING_PROJECT_DIR__NO = "/tmp/workspace/bazel-output-base/rules_xcodeproj.noindex/build_output_base/execroot/_main";
 				INDEXING_PROJECT_DIR__YES = "/tmp/workspace/bazel-output-base/rules_xcodeproj.noindex/indexbuild_output_base/execroot/_main";
 				INDEX_FORCE_SCRIPT_EXECUTION = YES;
 				INSTALL_PATH = "$(BAZEL_PACKAGE_BIN_DIR)/$(TARGET_NAME)/bin";
@@ -285,7 +285,7 @@ Here is an example output:
 				INDEXING_DEPLOYMENT_LOCATION__NO = YES;
 				INDEXING_DEPLOYMENT_LOCATION__YES = NO;
 				INDEXING_PROJECT_DIR__ = "$(INDEXING_PROJECT_DIR__NO)";
-				INDEXING_PROJECT_DIR__NO = "$(PROJECT_DIR)";
+				INDEXING_PROJECT_DIR__NO = "/tmp/workspace/bazel-output-base/rules_xcodeproj.noindex/build_output_base/execroot/_main";
 				INDEXING_PROJECT_DIR__YES = "/tmp/workspace/bazel-output-base/rules_xcodeproj.noindex/indexbuild_output_base/execroot/_main";
 				INDEX_FORCE_SCRIPT_EXECUTION = YES;
 				INSTALL_PATH = "$(BAZEL_PACKAGE_BIN_DIR)/$(TARGET_NAME)/bin";

--- a/tools/generators/pbxproj_prefix/src/Generator/Environment.swift
+++ b/tools/generators/pbxproj_prefix/src/Generator/Environment.swift
@@ -33,6 +33,7 @@ extension Generator {
             _ buildMode: BuildMode,
             _ indexImport: String,
             _ indexingProjectDir: String,
+            _ projectDir: String,
             _ resolvedRepositories: String,
             _ workspace: String,
             _ createBuildSettingsAttribute: CreateBuildSettingsAttribute

--- a/tools/generators/pbxproj_prefix/src/Generator/Generator.swift
+++ b/tools/generators/pbxproj_prefix/src/Generator/Generator.swift
@@ -53,6 +53,7 @@ struct Generator {
                 /*indexingProjectDir:*/ environment.indexingProjectDir(
                     /*projectDir:*/ projectDir
                 ),
+                /*projectDir:*/ projectDir,
                 /*resolvedRepositories:*/
                     try environment.readResolvedRepositoriesFile(
                         arguments.resolvedRepositoriesFile

--- a/tools/generators/pbxproj_prefix/src/Generator/PBXProjectBuildSettings.swift
+++ b/tools/generators/pbxproj_prefix/src/Generator/PBXProjectBuildSettings.swift
@@ -11,6 +11,7 @@ extension Generator {
     ///     `index_import` executable.
     ///   - indexingProjectDir: The value returned from
     ///     `Generator.indexingProjectDir()`.
+    ///   - projectDir: The value returned from `Generator.projectDir()`.
     ///   - resolvedRepositories: The value to be used for the
     ///     `RESOLVED_REPOSITORIES` build setting.
     ///   - workspace: The absolute path to the Bazel workspace.
@@ -18,6 +19,7 @@ extension Generator {
         buildMode: BuildMode,
         indexImport: String,
         indexingProjectDir: String,
+        projectDir: String,
         resolvedRepositories: String,
         workspace: String,
         createBuildSettingsAttribute: CreateBuildSettingsAttribute
@@ -105,7 +107,7 @@ extension Generator {
             ),
             .init(
                 key: "INDEXING_PROJECT_DIR__NO",
-                value: #""$(PROJECT_DIR)""#
+                value: projectDir.pbxProjEscaped
             ),
             .init(
                 key: "INDEXING_PROJECT_DIR__YES",
@@ -166,7 +168,7 @@ extension Generator {
                 value: #""$(PROJECT_DIR)/../..""#
             ),
         ]
-        
+
         if buildMode.usesBazelModeBuildScripts {
             buildSettings.append(contentsOf: [
                 .init(
@@ -197,7 +199,7 @@ extension Generator {
                 .init(key: "SWIFT_USE_INTEGRATED_DRIVER", value: "NO"),
             ])
         }
-        
+
         return createBuildSettingsAttribute(buildSettings: buildSettings)
     }
 }

--- a/tools/generators/pbxproj_prefix/test/PBXProjectBuildSettingsTests.swift
+++ b/tools/generators/pbxproj_prefix/test/PBXProjectBuildSettingsTests.swift
@@ -12,6 +12,7 @@ class PBXProjectBuildSettingsTests: XCTestCase {
         let buildMode: BuildMode = .bazel
         let indexImport = "external/index-import"
         let indexingProjectDir = "/some/indexing/project dir"
+        let projectDir = "/some/project dir"
         let resolvedRepositories = #""" "/tmp/workspace""#
         let workspace = "/Users/TimApple/Star Board"
 
@@ -49,7 +50,7 @@ class PBXProjectBuildSettingsTests: XCTestCase {
 				INDEXING_DEPLOYMENT_LOCATION__NO = YES;
 				INDEXING_DEPLOYMENT_LOCATION__YES = NO;
 				INDEXING_PROJECT_DIR__ = "$(INDEXING_PROJECT_DIR__NO)";
-				INDEXING_PROJECT_DIR__NO = "$(PROJECT_DIR)";
+				INDEXING_PROJECT_DIR__NO = "/some/project dir";
 				INDEXING_PROJECT_DIR__YES = "/some/indexing/project dir";
 				INDEX_DATA_STORE_DIR = "$(INDEX_DATA_STORE_DIR)";
 				INDEX_FORCE_SCRIPT_EXECUTION = YES;
@@ -87,6 +88,7 @@ class PBXProjectBuildSettingsTests: XCTestCase {
             buildMode: buildMode,
             indexImport: indexImport,
             indexingProjectDir: indexingProjectDir,
+            projectDir: projectDir,
             resolvedRepositories: resolvedRepositories,
             workspace: workspace,
             createBuildSettingsAttribute: CreateBuildSettingsAttribute()
@@ -103,6 +105,7 @@ class PBXProjectBuildSettingsTests: XCTestCase {
         let buildMode: BuildMode = .xcode
         let indexImport = "external/index-import"
         let indexingProjectDir = "/some/indexing/project_dir"
+        let projectDir = "/some/project_dir"
         let resolvedRepositories = #""" "/tmp/workspace""#
         let workspace = "/Users/TimApple/StarBoard"
 
@@ -137,7 +140,7 @@ class PBXProjectBuildSettingsTests: XCTestCase {
 				INDEXING_DEPLOYMENT_LOCATION__NO = YES;
 				INDEXING_DEPLOYMENT_LOCATION__YES = NO;
 				INDEXING_PROJECT_DIR__ = "$(INDEXING_PROJECT_DIR__NO)";
-				INDEXING_PROJECT_DIR__NO = "$(PROJECT_DIR)";
+				INDEXING_PROJECT_DIR__NO = /some/project_dir;
 				INDEXING_PROJECT_DIR__YES = /some/indexing/project_dir;
 				INDEX_DATA_STORE_DIR = "$(INDEX_DATA_STORE_DIR)";
 				INDEX_FORCE_SCRIPT_EXECUTION = YES;
@@ -170,6 +173,7 @@ class PBXProjectBuildSettingsTests: XCTestCase {
             buildMode: buildMode,
             indexImport: indexImport,
             indexingProjectDir: indexingProjectDir,
+            projectDir: projectDir,
             resolvedRepositories: resolvedRepositories,
             workspace: workspace,
             createBuildSettingsAttribute: CreateBuildSettingsAttribute()

--- a/xcodeproj/internal/bazel_integration_files/generate_bazel_dependencies.sh
+++ b/xcodeproj/internal/bazel_integration_files/generate_bazel_dependencies.sh
@@ -184,7 +184,7 @@ done
 # Import indexes
 if [ -n "${indexstores_filelists:-}" ]; then
   "$BAZEL_INTEGRATION_DIR/import_indexstores.sh" \
-    "$PROJECT_DIR" \
+    "$INDEXING_PROJECT_DIR__NO" \
     "${indexstores_filelists[@]/#/$output_path/}" \
     >"$log_dir/import_indexstores.async.log" 2>&1 &
 fi

--- a/xcodeproj/internal/bazel_integration_files/generate_index_build_bazel_dependencies.sh
+++ b/xcodeproj/internal/bazel_integration_files/generate_index_build_bazel_dependencies.sh
@@ -49,6 +49,6 @@ source "$BAZEL_INTEGRATION_DIR/bazel_build.sh"
 # Import indexes
 if [ -n "${indexstores_filelists:-}" ]; then
   "$BAZEL_INTEGRATION_DIR/import_indexstores.sh" \
-    "$PROJECT_DIR" \
+    "$INDEXING_PROJECT_DIR__NO" \
     "${indexstores_filelists[@]/#/$output_path/}"
 fi


### PR DESCRIPTION
Previously unit files would remap to include the Index Build Bazel output base instead of the Build output base.