### PR TITLE
Fix disambiguating of targets with multiple Xcode configurations

### DIFF
--- a/tools/generators/legacy/src/DTO/Target.swift
+++ b/tools/generators/legacy/src/DTO/Target.swift
@@ -1,11 +1,10 @@
-import OrderedCollections
 import PathKit
 
 struct Target: Equatable {
     var name: String
     var label: BazelLabel
     let configuration: String
-    let xcodeConfigurations: OrderedSet<String>
+    let xcodeConfigurations: Set<String>
     var compileTargets: [CompileTarget]
     let packageBinDir: Path
     var platform: Platform
@@ -82,7 +81,7 @@ extension Target: Decodable {
         label = try container.decode(BazelLabel.self, forKey: .label)
         configuration = try container.decode(String.self, forKey: .configuration)
         xcodeConfigurations = try container.decodeIfPresent(
-            OrderedSet<String>.self,
+            Set<String>.self,
             forKey: .xcodeConfigurations
         ) ?? ["Debug"]
         compileTargets = try container

--- a/tools/generators/legacy/test/DisambiguateTargetsTests.swift
+++ b/tools/generators/legacy/test/DisambiguateTargetsTests.swift
@@ -883,8 +883,18 @@ A (iOS) (\(ProductTypeComponents.prettyConfigurations(["2"])))
                 xcodeConfigurations: ["Release"],
                 product: .init(type: .staticLibrary, name: "A", path: "")
             ),
-            "B": Target.mock(
+            "B 1": Target.mock(
+                configuration: "1",
+                xcodeConfigurations: ["Debug", "Release"],
                 product: .init(type: .staticLibrary, name: "B", path: "")
+            ),
+            "B 2": Target.mock(
+                configuration: "2",
+                xcodeConfigurations: ["Debug"],
+                product: .init(type: .staticLibrary, name: "B", path: "")
+            ),
+            "C": Target.mock(
+                product: .init(type: .staticLibrary, name: "C", path: "")
             ),
         ]
         let consolidatedTargets = ConsolidatedTargets(targets: targets)
@@ -896,7 +906,13 @@ A (Debug) (\(ProductTypeComponents.prettyConfigurations(["1"])))
 A (Debug) (\(ProductTypeComponents.prettyConfigurations(["2"])))
 """,
             "A 3": "A (Release)",
-            "B": "B",
+            "B 1": """
+B (Debug, Release) (\(ProductTypeComponents.prettyConfigurations(["1"])))
+""",
+            "B 2": """
+B (Debug) (\(ProductTypeComponents.prettyConfigurations(["2"])))
+""",
+            "C": "C",
         ]
 
         // Act

--- a/tools/generators/legacy/test/Target+Testing.swift
+++ b/tools/generators/legacy/test/Target+Testing.swift
@@ -1,5 +1,4 @@
 import GeneratorCommon
-import OrderedCollections
 import PathKit
 import XcodeProj
 import XCTest
@@ -10,7 +9,7 @@ extension Target {
     static func mock(
         label: BazelLabel? = nil,
         configuration: String = "a1b2c",
-        xcodeConfigurations: OrderedSet<String> = ["Profile"],
+        xcodeConfigurations: Set<String> = ["Profile"],
         compileTargets: [CompileTarget] = [],
         packageBinDir: Path = "bazel-out/a1b2c/some/package",
         platform: Platform? = nil,

--- a/tools/generators/pbxtargetdependencies/test/Generator/DisambiguateTargetsTests.swift
+++ b/tools/generators/pbxtargetdependencies/test/Generator/DisambiguateTargetsTests.swift
@@ -940,8 +940,18 @@ A (iOS) (\(ProductTypeComponents.prettyConfigurations(["2"])))
                 xcodeConfigurations: ["Release"]
             ),
             .mock(
-                id: "B",
-                label: "//:B"
+                id: "B-DebugRelease 1",
+                label: "//:B",
+                xcodeConfigurations: ["Debug", "Release"]
+            ),
+            .mock(
+                id: "B-Debug 2",
+                label: "//:B",
+                xcodeConfigurations: ["Debug"]
+            ),
+            .mock(
+                id: "C",
+                label: "//:C"
             ),
         ]
         let consolidatedTargets = Array<ConsolidatedTarget>(targets: targets)
@@ -954,7 +964,13 @@ A (Debug) (\(ProductTypeComponents.prettyConfigurations(["1"])))
 A (Debug) (\(ProductTypeComponents.prettyConfigurations(["2"])))
 """,
             ["A-Release 3"]: "A (Release)",
-            ["B"]: "B",
+            ["B-DebugRelease 1"]: """
+B (Debug, Release) (\(ProductTypeComponents.prettyConfigurations(["1"])))
+""",
+            ["B-Debug 2"]: """
+B (Debug) (\(ProductTypeComponents.prettyConfigurations(["2"])))
+""",
+            ["C"]: "C",
         ]
 
         // Act


### PR DESCRIPTION
A `Target` with multiple Xcode configurations should really be seen as multiple targets that share the same `TargetID`. This change reflects that, fixing a certain disambiguation.

I also used the opportunity to make a better key type, which is more efficient. A future change will prevent having to create this key multiple times.