### PR TITLE
Stop including normal groups in `bazelPathAndIdentifiers`

### DIFF
--- a/tools/generators/files_and_groups/src/ElementCreator/CreateGroup.swift
+++ b/tools/generators/files_and_groups/src/ElementCreator/CreateGroup.swift
@@ -90,6 +90,7 @@ extension ElementCreator.CreateGroup {
         return GroupChild.ElementAndChildren(
             bazelPath: bazelPath,
             element: group,
+            includeParentInBazelPathAndIdentifiers: false,
             resolvedRepository: resolvedRepository,
             children: children
         )

--- a/tools/generators/files_and_groups/src/ElementCreator/CreateGroupChild.swift
+++ b/tools/generators/files_and_groups/src/ElementCreator/CreateGroupChild.swift
@@ -189,11 +189,14 @@ extension GroupChild.ElementAndChildren {
     init(
         bazelPath: BazelPath,
         element: Element,
+        includeParentInBazelPathAndIdentifiers: Bool = true,
         resolvedRepository: ResolvedRepository?,
         children: GroupChildElements
     ) {
         var bazelPathAndIdentifiers = children.bazelPathAndIdentifiers
-        bazelPathAndIdentifiers.append((bazelPath, element.object.identifier))
+        if includeParentInBazelPathAndIdentifiers {
+            bazelPathAndIdentifiers.append((bazelPath, element.object.identifier))
+        }
 
         var transitiveObjects = children.transitiveObjects
         transitiveObjects.append(element.object)

--- a/tools/generators/files_and_groups/src/ElementCreator/CreateSpecialRootGroup.swift
+++ b/tools/generators/files_and_groups/src/ElementCreator/CreateSpecialRootGroup.swift
@@ -82,6 +82,7 @@ extension ElementCreator.CreateSpecialRootGroup {
         return GroupChild.ElementAndChildren(
             bazelPath: bazelPath,
             element: group,
+            includeParentInBazelPathAndIdentifiers: false,
             resolvedRepository: nil,
             children: children
         )

--- a/tools/generators/files_and_groups/test/ElementCreator/CreateGroupTests.swift
+++ b/tools/generators/files_and_groups/test/ElementCreator/CreateGroupTests.swift
@@ -164,8 +164,7 @@ final class CreateGroupTests: XCTestCase {
             transitiveObjects: stubbedGroupChildElements.transitiveObjects +
                 [stubbedElement.object],
             bazelPathAndIdentifiers:
-                stubbedGroupChildElements.bazelPathAndIdentifiers +
-                    [(expectedBazelPath, stubbedElement.object.identifier)],
+                stubbedGroupChildElements.bazelPathAndIdentifiers,
             knownRegions: stubbedGroupChildElements.knownRegions,
             resolvedRepositories:
                 stubbedGroupChildElements.resolvedRepositories +

--- a/tools/generators/files_and_groups/test/ElementCreator/CreateSpecialRootGroupTests.swift
+++ b/tools/generators/files_and_groups/test/ElementCreator/CreateSpecialRootGroupTests.swift
@@ -193,6 +193,7 @@ final class CreateSpecialRootGroupTests: XCTestCase {
         let expectedResult = GroupChild.ElementAndChildren(
             bazelPath: expectedBazelPath,
             element: stubbedElement,
+            includeParentInBazelPathAndIdentifiers: false,
             resolvedRepository: nil,
             children: stubbedGroupChildElements
         )


### PR DESCRIPTION
`bazelPathAndIdentifiers` will be used to map `BazelPath`s to identifiers for `PBXBuildFile` creation. A `PBXBuildFile` won’t need to reference a group, so we don’t need to add those identifiers to `bazelPathAndIdentifiers`.