### PR TITLE
Replace most “elements” references with “objects”

### DIFF
--- a/tools/generators/README.md
+++ b/tools/generators/README.md
@@ -29,13 +29,13 @@ information.
 
 - [`pbxproj_prefix`](pbxproj_prefix/README.md):
   - The start of the `PBXProj` element
-  - All of the `BazelDependencies` related elements:
+  - All of the `BazelDependencies` related objects:
     - `Generate Bazel Dependencies` script build phase
     - `Create swift_debug_settings.py` script build phase
     - `XCBuildConfiguration`
     - `XCBuildConfigurationList`
   - `BazelDependencies` `PBXAggregateTarget`
-  - All of the `PBXProject` related elements:
+  - All of the `PBXProject` related objects:
     - `XCBuildConfiguration`
     - `XCBuildConfigurationList`
   - The start of the `PBXProject` element
@@ -43,7 +43,7 @@ information.
     `attributes.TargetAttributes`, `targets`, and `knownRegions`
 - [`pbxtargetdependencies`](pbxtargetdependencies/README.md):
   - Creates four+ files:
-    - A partial containing the `PBXTargetDependency` and `PBXContainerItemProxy` elements
+    - A partial containing the `PBXTargetDependency` and `PBXContainerItemProxy` objects
     - A partial containing the `PBXProject.attributes.TargetAttributes` property
     - A partial containing:
       - The `PBXProject.targets` property
@@ -51,7 +51,7 @@ information.
     - A set of files, each detailing how a set of configured targets are consolidated together
 - `pbxnativetargets`:
   - Run once on each shard of all the targets
-  - All of the `PBXNativeTarget` related elements:
+  - All of the `PBXNativeTarget` related objects:
     - `XCBuildConfiguration`
     - `XCBuildConfigurationList`
     - and various build phases

--- a/tools/generators/files_and_groups/src/Generator/CreateShardBuildFileElements.swift
+++ b/tools/generators/files_and_groups/src/Generator/CreateShardBuildFileElements.swift
@@ -24,7 +24,7 @@ extension Generator {
             self.callable = callable
         }
 
-        /// Creates `PBXBuildFile` elements by reading the
+        /// Creates `PBXBuildFile` objects by reading the
         /// `Identifiers.BuildFile.SubIdentifier`s from a file and matching them
         /// with file identifiers.
         func callAsFunction(

--- a/tools/generators/lib/PBXProj/src/Identifiers.swift
+++ b/tools/generators/lib/PBXProj/src/Identifiers.swift
@@ -2,7 +2,7 @@ import CryptoKit
 import Foundation
 import GeneratorCommon
 
-/// Helps set identifiers for `PBXProj` elements.
+/// Helps set identifiers for `PBXProj` objects.
 ///
 /// Identifiers are unique 12 byte numbers encoded as 24 character hex strings.
 /// Since the various `PBXProj` partial generators need to work independently
@@ -13,9 +13,9 @@ import GeneratorCommon
 /// them. The first two characters indicate that it's a global element (`FF`), a
 /// file or group element (`FE`), or a generator shard (`00`-`FD`).
 ///
-/// - Global elements (which start with `FF`) are then classified as belonging
+/// - Global objects (which start with `FF`) are then classified as belonging
 ///   to the project as a whole (`00`) or the `BazelDependencies` target
-///   (`01`). For both of them, their associated elements (e.g. configuration
+///   (`01`). For both of them, their associated objects (e.g. configuration
 ///   list, build phases, etc.) use
 ///   `00000000000000000000`-`000000000000000000FF`, and their configurations
 ///   (e.g. "Debug", "Release", etc.) use
@@ -25,14 +25,14 @@ import GeneratorCommon
 ///   (`0000000000000000000000`-`FFFFFFFFFFFFFFFFFFFFFF`).
 ///
 /// - Generator shards (which start with `00`-`FD`) use the next two
-///   characters to indicate a target and its associated elements (`00`), a
+///   characters to indicate a target and its associated objects (`00`), a
 ///   target dependency (`01`), a container item proxy (`02`), or a build file
 ///   (`FF`).
 ///
 ///   - Targets (which start with `xx00`) use the next eight characters to
 ///     identify a target (`00000000`-`FFFFFFFF`, called a target
 ///     sub-identifier). Then it uses `000000000000`-`0000000000FF` for its
-///     associated elements (e.g. configuration list, build phases, etc.), and
+///     associated objects (e.g. configuration list, build phases, etc.), and
 ///     `000000000100`-`0000000001FF` for its configurations (e.g. "Debug",
 ///     "Release", etc.).
 ///

--- a/tools/generators/pbxproj_prefix/README.md
+++ b/tools/generators/pbxproj_prefix/README.md
@@ -1,7 +1,7 @@
 # `PBXProj` prefix partial generator
 
 The `pbxproj_prefix` generator creates a `PBXProj` partial containing the
-start of the `PBXProj` element, `PBXProject` related elements, and _part of_ the
+start of the `PBXProj` element, `PBXProject` related objects, and _part of_ the
 start of the `PBXProject` element.
 
 ## Inputs

--- a/tools/generators/pbxproj_prefix/src/Generator/BazelDependenciesBuildSettings.swift
+++ b/tools/generators/pbxproj_prefix/src/Generator/BazelDependenciesBuildSettings.swift
@@ -2,7 +2,7 @@ import PBXProj
 
 extension Generator {
     /// Calculates the `buildSettings` attribute of the `XCBuildConfiguration`
-    /// elements used by the `BazelDependencies` target.
+    /// objects used by the `BazelDependencies` target.
     ///
     /// - Parameters:
     ///   - platforms: The platforms that the project builds for.

--- a/tools/generators/pbxproj_prefix/src/Generator/PBXProjectBuildSettings.swift
+++ b/tools/generators/pbxproj_prefix/src/Generator/PBXProjectBuildSettings.swift
@@ -3,7 +3,7 @@ import PBXProj
 
 extension Generator {
     /// Calculates the `buildSettings` attribute of the `XCBuildConfiguration`
-    /// elements used by the `PBXProject` element.
+    /// objects used by the `PBXProject` element.
     ///
     /// - Parameters:
     ///   - buildMode: The `BuildMode`.

--- a/tools/generators/pbxproj_prefix/src/Generator/PBXProjectPrefixPartial.swift
+++ b/tools/generators/pbxproj_prefix/src/Generator/PBXProjectPrefixPartial.swift
@@ -49,7 +49,7 @@ extension Generator {
 
         // Final form
 
-        // This is a `PBXProj` partial for `PBXProject` related elements and
+        // This is a `PBXProj` partial for `PBXProject` related objects and
         // _part of_ the `PBXProject` element. Different generators will
         // generate the remaining parts of the `PBXProject` element. Because of
         // this, it's intentional that the element isn't terminated, and

--- a/tools/generators/pbxtargetdependencies/README.md
+++ b/tools/generators/pbxtargetdependencies/README.md
@@ -2,7 +2,7 @@
 
 The `pbxtargetdependencies` generator creates four+ files:
 
-- A `PBXProj` partial containing the `PBXTargetDependency` and `PBXContainerItemProxy` elements
+- A `PBXProj` partial containing the `PBXTargetDependency` and `PBXContainerItemProxy` objects
 - A `PBXProj` partial containing the `PBXProject.attributes.TargetAttributes` property
 - A `PBXProj` partial containing:
   - The `PBXProject.targets` property


### PR DESCRIPTION
“Elements” means file and group based objects. All other ones are just “objects”.