### PR TITLE
Change “Command Line Tool” disambiguation to “Tool”

### DIFF
--- a/tools/generators/legacy/src/Extensions/PBXProductType+Extensions.swift
+++ b/tools/generators/legacy/src/Extensions/PBXProductType+Extensions.swift
@@ -219,7 +219,7 @@ extension PBXProductType {
         case .uiTestBundle: return "UI Tests"
         case .appExtension: return "App Extension"
         case .extensionKitExtension: return "ExtensionKit Extension"
-        case .commandLineTool: return "Command Line Tool"
+        case .commandLineTool: return "Tool"
         case .watchApp: return "watchOS 1.0 App"
         case .watch2App: return "App"
         case .watch2AppContainer: return "App Container"
@@ -281,7 +281,7 @@ extension PBXProductType {
     var isTopLevel: Bool {
         return isLaunchable || isTestBundle
     }
-    
+
     var sortOrder: Int {
         switch self {
         // Applications

--- a/tools/generators/pbxtargetdependencies/src/Generator/DisambiguateTargets.swift
+++ b/tools/generators/pbxtargetdependencies/src/Generator/DisambiguateTargets.swift
@@ -680,7 +680,7 @@ private extension PBXProductType {
         case .instrumentsPackage: return "Instruments Package"
         case .metalLibrary: return "Metal Library"
         case .systemExtension: return "System Extension"
-        case .commandLineTool: return "Command Line Tool"
+        case .commandLineTool: return "Tool"
         case .xpcService: return "XPC Service"
         }
     }


### PR DESCRIPTION
Doesn’t need to be as verbose.