### PR TITLE
Upgrade Stardoc to 0.6.1

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -40,7 +40,7 @@ bazel_dep(
 )
 bazel_dep(
     name = "stardoc",
-    version = "0.6.0",
+    version = "0.6.1",
     dev_dependency = True,
     repo_name = "io_bazel_stardoc",
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -66,10 +66,10 @@ buildifier_prebuilt_register_toolchains()
 
 http_archive(
     name = "io_bazel_stardoc",
-    sha256 = "4441a965c97f8364c8eb901f951ca9a15c6e2c29ee0f10b56bf8b563463752ea",
+    sha256 = "3082a199f39e1fd9ed608421516fdbe9e9af8eb34f52e46e9a8c4798c8e6bfad",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/stardoc/releases/download/0.6.0/stardoc-0.6.0.tar.gz",
-        "https://github.com/bazelbuild/stardoc/releases/download/0.6.0/stardoc-0.6.0.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/stardoc/releases/download/0.6.1/stardoc-0.6.1.tar.gz",
+        "https://github.com/bazelbuild/stardoc/releases/download/0.6.1/stardoc-0.6.1.tar.gz",
     ],
 )
 

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -57,7 +57,7 @@ x_templates:
     - &validate_integration "--output_base=bazel-output-base run --config=workflows --config=fixtures //test/fixtures:validate"
     - &build_all "--output_base=bazel-output-base build --config=workflows --config=fixtures --noexperimental_enable_bzlmod //..."
     - &test_all "--output_base=bazel-output-base test --config=workflows --noexperimental_enable_bzlmod //..."
-    - &bazel_5_test_all "--output_base=bazel-output-base test --config=workflows --noexperimental_enable_bzlmod --deleted_packages=//docs //..."
+    - &bazel_5_test_all "--output_base=bazel-output-base test --config=workflows --noexperimental_enable_bzlmod //..."
     - &bzlmod_generate_integration "--output_base=bazel-output-base run --config=workflows --config=fixtures //test/fixtures:update"
     - &bzlmod_build_all "--output_base=bazel-output-base build --config=workflows //..."
     - &bzlmod_test_all "--output_base=bazel-output-base test --config=workflows //test/..."


### PR DESCRIPTION
Brings back Bazel 5 support.