### PR TITLE
Change order of `files_and_groups` outputs

### DIFF
--- a/test/internal/pbxproj_partials/write_files_and_groups_tests.bzl
+++ b/test/internal/pbxproj_partials/write_files_and_groups_tests.bzl
@@ -18,8 +18,8 @@ def _write_files_and_groups_test_impl(ctx):
     actions = mock_actions.create()
 
     expected_declared_files = {
-        _KNOWN_REGIONS_DECLARED_FILE: None,
         _FILES_AND_GROUPS_DECLARED_FILE: None,
+        _KNOWN_REGIONS_DECLARED_FILE: None,
         _RESOLVED_REPOSITORIES_FILE_DECLARED_FILE: None,
     }
     expected_inputs = [

--- a/xcodeproj/internal/pbxproj_partials.bzl
+++ b/xcodeproj/internal/pbxproj_partials.bzl
@@ -182,8 +182,8 @@ def _write_files_and_groups(
             selected_model_versions_file,
         ],
         outputs = [
-            pbxproject_known_regions,
             files_and_groups,
+            pbxproject_known_regions,
             resolved_repositories_file,
         ],
         mnemonic = "WritePBXProjFileAndGroups",


### PR DESCRIPTION
This causes the params file to be named `files_and_groups.params` instead of `pbxproject_known_regions.params`, which is a lot less confusing.