### PR TITLE
Make `defaultXcodeConfiguration` non-optional

### DIFF
--- a/test/internal/pbxproj_partials/write_pbxproj_prefix_tests.bzl
+++ b/test/internal/pbxproj_partials/write_pbxproj_prefix_tests.bzl
@@ -131,7 +131,7 @@ write_pbxproj_prefix_test = unittest.make(
         # Inputs
         "colorize": attr.bool(mandatory = True),
         "build_mode": attr.string(mandatory = True),
-        "default_xcode_configuration": attr.string(),
+        "default_xcode_configuration": attr.string(mandatory = True),
         "execution_root_file": attr.string(mandatory = True),
         "index_import": attr.string(mandatory = True),
         "minimum_xcode_version": attr.string(mandatory = True),
@@ -166,7 +166,7 @@ def write_pbxproj_prefix_test_suite(name):
             # Inputs
             build_mode,
             colorize = False,
-            default_xcode_configuration = None,
+            default_xcode_configuration,
             execution_root_file,
             index_import,
             minimum_xcode_version,
@@ -214,6 +214,7 @@ def write_pbxproj_prefix_test_suite(name):
 
         # Inputs
         build_mode = "xcode",
+        default_xcode_configuration = "Debug",
         execution_root_file = "an/execution/root/file",
         index_import = "some/path/to/index_import",
         minimum_xcode_version = "14.2.1",
@@ -250,6 +251,8 @@ def write_pbxproj_prefix_test_suite(name):
             "xcode",
             # minimumXcodeVersion
             "14.2.1",
+            # defaultXcodeConfiguration
+            "Debug",
             # developmentRegion
             "en",
             # platforms
@@ -271,7 +274,7 @@ def write_pbxproj_prefix_test_suite(name):
         # Inputs
         build_mode = "bazel",
         colorize = True,
-        default_xcode_configuration = "Debug",
+        default_xcode_configuration = "Release",
         execution_root_file = "an/execution/root/file",
         index_import = "some/path/to/index_import",
         platforms = [
@@ -311,6 +314,8 @@ def write_pbxproj_prefix_test_suite(name):
             "bazel",
             # minimumXcodeVersion
             "14.2.1",
+            # defaultXcodeConfiguration
+            "Release",
             # developmentRegion
             "enGB",
             # organizationName
@@ -323,9 +328,6 @@ def write_pbxproj_prefix_test_suite(name):
             # xcodeConfigurations
             "--xcode-configurations",
             "Release",
-            "Debug",
-            # defaultXcodeConfiguration
-            "--default-xcode-configuration",
             "Debug",
             # preBuildScript
             "--pre-build-script",

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -97,6 +97,8 @@ _SCHEMES = [
                 "bazel",
                 # minimumXcodeVersion
                 "14.0",
+                # defaultXcodeConfiguration
+                "Release",
                 # developmentRegion
                 "enGB",
                 # organizationName
@@ -109,9 +111,6 @@ _SCHEMES = [
                 # xcodeConfigurations
                 "--xcode-configurations",
                 "Debug",
-                "Release",
-                # defaultXcodeConfiguration
-                "--default-xcode-configuration",
                 "Release",
                 # preBuildScript
                 # postBuildScript

--- a/tools/generators/pbxproj_prefix/README.md
+++ b/tools/generators/pbxproj_prefix/README.md
@@ -18,11 +18,11 @@ The generator accepts the following command-line arguments (see
 - Positional `resolved-repositories-file`
 - Positional `build-mode`
 - Positional `minimum-xcode-version`
+- Positional `default-xcode-configuration`
 - Positional `development-region`
 - Optional option `--organization-name <organization-name>`
 - Option list `--platforms <platforms> ...`
 - Option list `--xcode-configurations <xcode-configurations> ...`
-- Optional option `--default-xcode-configuration <default-xcode-configuration>`
 - Optional option `--pre-build-script <pre-build-script>`
 - Optional option `--post-build-script <post-build-script>`
 - Flag `--colorize`
@@ -39,6 +39,7 @@ $ pbxproj_prefix \
     bazel-out/darwin_arm64-dbg/bin/external/_main~internal~rules_xcodeproj_generated/generator/tools/generators/xcodeproj/xcodeproj_pbxproj_partials/resolved_repositories \
     bazel \
     14.0 \
+    Release \
     enGB \
     --organization-name MobileNativeFoundation \
     --platforms \
@@ -48,7 +49,6 @@ $ pbxproj_prefix \
     --xcode-configurations \
     Debug \
     Release \
-    --default-xcode-configuration Release \
     --pre-build-script bazel-out/darwin_arm64-dbg/bin/external/_main~internal~rules_xcodeproj_generated/generator/tools/generators/xcodeproj/xcodeproj_pre_build_script
 ```
 

--- a/tools/generators/pbxproj_prefix/src/Generator/Arguments.swift
+++ b/tools/generators/pbxproj_prefix/src/Generator/Arguments.swift
@@ -47,6 +47,9 @@ Minimum Xcode version that the generated project supports.
 """)
         var minimumXcodeVersion: SemanticVersion
 
+        @Argument(help: "Name of the default Xcode configuration.")
+        var defaultXcodeConfiguration: String
+
         @Argument(help: "Development region for the project.")
         var developmentRegion: String
 
@@ -66,9 +69,6 @@ Populates the `ORGANIZATIONNAME` attribute for the project.
             help: "Names of the Xcode configurations the project is using."
         )
         var xcodeConfigurations: [String]
-
-        @Option(help: "Name of the default Xcode configuration.")
-        var defaultXcodeConfiguration: String?
 
         @Option(
             help: "Path to a file containing a pre-build script.",

--- a/tools/generators/pbxproj_prefix/src/Generator/BazelDependenciesPartial.swift
+++ b/tools/generators/pbxproj_prefix/src/Generator/BazelDependenciesPartial.swift
@@ -4,7 +4,7 @@ extension Generator {
     /// Calculates the BazelDependencies `PBXProj` partial.
     static func bazelDependenciesPartial(
         buildSettings: String,
-        defaultXcodeConfiguration: String?,
+        defaultXcodeConfiguration: String,
         postBuildRunScript: String?,
         preBuildRunScript: String?,
         xcodeConfigurations: [String]
@@ -84,11 +84,7 @@ extension Generator {
 
         // Build configurations
 
-        let sortedXcodeConfigurations = Set(xcodeConfigurations).sorted()
-        let defaultXcodeConfiguration = defaultXcodeConfiguration ??
-            sortedXcodeConfigurations.first!
-
-        let buildConfigurations =  sortedXcodeConfigurations
+        let buildConfigurations =  xcodeConfigurations
             .enumerated()
             .map { index, name in
                 let id = Identifiers.BazelDependencies

--- a/tools/generators/pbxproj_prefix/src/Generator/Environment.swift
+++ b/tools/generators/pbxproj_prefix/src/Generator/Environment.swift
@@ -15,7 +15,7 @@ extension Generator {
 
         let bazelDependenciesPartial: (
             _ buildConfigurationContent: String,
-            _ defaultXcodeConfiguration: String?,
+            _ defaultXcodeConfiguration: String,
             _ preBuildRunScript: String?,
             _ postBuildRunScript: String?,
             _ xcodeConfigurations: [String]
@@ -42,7 +42,7 @@ extension Generator {
         let pbxProjectPrefixPartial: (
             _ buildSettings: String,
             _ compatibilityVersion: String,
-            _ defaultXcodeConfiguration: String?,
+            _ defaultXcodeConfiguration: String,
             _ developmentRegion: String,
             _ organizationName: String?,
             _ projectDir: String,

--- a/tools/generators/pbxproj_prefix/src/Generator/PBXProjectPrefixPartial.swift
+++ b/tools/generators/pbxproj_prefix/src/Generator/PBXProjectPrefixPartial.swift
@@ -5,7 +5,7 @@ extension Generator {
     static func pbxProjectPrefixPartial(
         buildSettings: String,
         compatibilityVersion: String,
-        defaultXcodeConfiguration: String?,
+        defaultXcodeConfiguration: String,
         developmentRegion: String,
         organizationName: String?,
         projectDir: String,
@@ -26,11 +26,7 @@ extension Generator {
 
         // Build configurations
 
-        let sortedXcodeConfigurations = Set(xcodeConfigurations).sorted()
-        let defaultXcodeConfiguration = defaultXcodeConfiguration ??
-            sortedXcodeConfigurations.first!
-
-        let buildConfigurations =  sortedXcodeConfigurations
+        let buildConfigurations =  xcodeConfigurations
             .enumerated()
             .map { index, name in
                 let id = Identifiers.Project

--- a/tools/generators/pbxproj_prefix/test/BazelDependenciesPartialTests.swift
+++ b/tools/generators/pbxproj_prefix/test/BazelDependenciesPartialTests.swift
@@ -10,17 +10,18 @@ class BazelDependenciesPartialTests: XCTestCase {
         // Arrange
 
         let buildSettings = "{BUILD_SETTINGS_HERE}"
-        let defaultXcodeConfiguration: String? = nil
+        let defaultXcodeConfiguration = "Debug"
         let postBuildRunScript: String? = nil
         let preBuildRunScript: String? = nil
         let xcodeConfigurations = [
             "Release",
             "Profile",
-            "Release",
             "Debug",
         ]
 
-        // The tabs for indenting are intentional
+        // The tabs for indenting are intentional.
+        // Order of configurations is wrong, but shows that it doesn't do
+        // sorting (since they should be sorted coming in).
         let expectedBazelDependencies = #"""
 		FF0100000000000000000004 /* Bazel Build */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -59,27 +60,27 @@ class BazelDependenciesPartialTests: XCTestCase {
 			shellScript = "perl -pe '\n  # Replace \"__BAZEL_XCODE_DEVELOPER_DIR__\" with \"$(DEVELOPER_DIR)\"\n  s/__BAZEL_XCODE_DEVELOPER_DIR__/\\$(DEVELOPER_DIR)/g;\n\n  # Replace \"__BAZEL_XCODE_SDKROOT__\" with \"$(SDKROOT)\"\n  s/__BAZEL_XCODE_SDKROOT__/\\$(SDKROOT)/g;\n\n  # Replace build settings with their values\n  s/\n    \\$             # Match a dollar sign\n    (\\()?          # Optionally match an opening parenthesis and capture it\n    ([a-zA-Z_]\\w*) # Match a variable name and capture it\n    (?(1)\\))       # If an opening parenthesis was captured, match a closing parenthesis\n  /$ENV{$2}/gx;    # Replace the entire matched string with the value of the corresponding environment variable\n\n' \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
 			showEnvVarsInLog = 0;
 		};
-		FF0100000000000000000100 /* Debug */ = {
+		FF0100000000000000000100 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {BUILD_SETTINGS_HERE};
-			name = Debug;
+			name = Release;
 		};
 		FF0100000000000000000101 /* Profile */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {BUILD_SETTINGS_HERE};
 			name = Profile;
 		};
-		FF0100000000000000000102 /* Release */ = {
+		FF0100000000000000000102 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {BUILD_SETTINGS_HERE};
-			name = Release;
+			name = Debug;
 		};
 		FF0100000000000000000002 /* Build configuration list for PBXAggregateTarget "BazelDependencies" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				FF0100000000000000000100 /* Debug */,
+				FF0100000000000000000100 /* Release */,
 				FF0100000000000000000101 /* Profile */,
-				FF0100000000000000000102 /* Release */,
+				FF0100000000000000000102 /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
@@ -124,11 +125,12 @@ class BazelDependenciesPartialTests: XCTestCase {
         let xcodeConfigurations = [
             "Release",
             "Profile",
-            "Release",
             "Debug",
         ]
 
-        // The tabs for indenting are intentional
+        // The tabs for indenting are intentional.
+        // Order of configurations is wrong, but shows that it doesn't do
+        // sorting (since they should be sorted coming in).
         let expectedBazelDependencies = #"""
 		FF0100000000000000000004 /* Bazel Build */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -167,27 +169,27 @@ class BazelDependenciesPartialTests: XCTestCase {
 			shellScript = "perl -pe '\n  # Replace \"__BAZEL_XCODE_DEVELOPER_DIR__\" with \"$(DEVELOPER_DIR)\"\n  s/__BAZEL_XCODE_DEVELOPER_DIR__/\\$(DEVELOPER_DIR)/g;\n\n  # Replace \"__BAZEL_XCODE_SDKROOT__\" with \"$(SDKROOT)\"\n  s/__BAZEL_XCODE_SDKROOT__/\\$(SDKROOT)/g;\n\n  # Replace build settings with their values\n  s/\n    \\$             # Match a dollar sign\n    (\\()?          # Optionally match an opening parenthesis and capture it\n    ([a-zA-Z_]\\w*) # Match a variable name and capture it\n    (?(1)\\))       # If an opening parenthesis was captured, match a closing parenthesis\n  /$ENV{$2}/gx;    # Replace the entire matched string with the value of the corresponding environment variable\n\n' \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
 			showEnvVarsInLog = 0;
 		};
-		FF0100000000000000000100 /* Debug */ = {
+		FF0100000000000000000100 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {BUILD_SETTINGS_HERE};
-			name = Debug;
+			name = Release;
 		};
 		FF0100000000000000000101 /* Profile */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {BUILD_SETTINGS_HERE};
 			name = Profile;
 		};
-		FF0100000000000000000102 /* Release */ = {
+		FF0100000000000000000102 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {BUILD_SETTINGS_HERE};
-			name = Release;
+			name = Debug;
 		};
 		FF0100000000000000000002 /* Build configuration list for PBXAggregateTarget "BazelDependencies" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				FF0100000000000000000100 /* Debug */,
+				FF0100000000000000000100 /* Release */,
 				FF0100000000000000000101 /* Profile */,
-				FF0100000000000000000102 /* Release */,
+				FF0100000000000000000102 /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Profile;
@@ -226,17 +228,18 @@ class BazelDependenciesPartialTests: XCTestCase {
         // Arrange
 
         let buildSettings = "{BUILD_SETTINGS_HERE}"
-        let defaultXcodeConfiguration: String? = nil
+        let defaultXcodeConfiguration = "Debug"
         let postBuildRunScript = "{POST_BUILD_HERE}"
         let preBuildRunScript: String? = nil
         let xcodeConfigurations = [
             "Release",
             "Profile",
-            "Release",
             "Debug",
         ]
 
-        // The tabs for indenting are intentional
+        // The tabs for indenting are intentional.
+        // Order of configurations is wrong, but shows that it doesn't do
+        // sorting (since they should be sorted coming in).
         let expectedBazelDependencies = #"""
 		FF0100000000000000000004 /* Bazel Build */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -276,27 +279,27 @@ class BazelDependenciesPartialTests: XCTestCase {
 			showEnvVarsInLog = 0;
 		};
 		FF0100000000000000000006 /* Post-build Run Script */ = {POST_BUILD_HERE};
-		FF0100000000000000000100 /* Debug */ = {
+		FF0100000000000000000100 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {BUILD_SETTINGS_HERE};
-			name = Debug;
+			name = Release;
 		};
 		FF0100000000000000000101 /* Profile */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {BUILD_SETTINGS_HERE};
 			name = Profile;
 		};
-		FF0100000000000000000102 /* Release */ = {
+		FF0100000000000000000102 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {BUILD_SETTINGS_HERE};
-			name = Release;
+			name = Debug;
 		};
 		FF0100000000000000000002 /* Build configuration list for PBXAggregateTarget "BazelDependencies" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				FF0100000000000000000100 /* Debug */,
+				FF0100000000000000000100 /* Release */,
 				FF0100000000000000000101 /* Profile */,
-				FF0100000000000000000102 /* Release */,
+				FF0100000000000000000102 /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
@@ -336,17 +339,18 @@ class BazelDependenciesPartialTests: XCTestCase {
         // Arrange
 
         let buildSettings = "{BUILD_SETTINGS_HERE}"
-        let defaultXcodeConfiguration: String? = nil
+        let defaultXcodeConfiguration = "Debug"
         let postBuildRunScript: String? = nil
         let preBuildRunScript = "{PRE_BUILD_HERE}"
         let xcodeConfigurations = [
             "Release",
             "Profile",
-            "Release",
             "Debug",
         ]
 
-        // The tabs for indenting are intentional
+        // The tabs for indenting are intentional.
+        // Order of configurations is wrong, but shows that it doesn't do
+        // sorting (since they should be sorted coming in).
         let expectedBazelDependencies = #"""
 		FF0100000000000000000003 /* Pre-build Run Script */ = {PRE_BUILD_HERE};
 		FF0100000000000000000004 /* Bazel Build */ = {
@@ -386,27 +390,27 @@ class BazelDependenciesPartialTests: XCTestCase {
 			shellScript = "perl -pe '\n  # Replace \"__BAZEL_XCODE_DEVELOPER_DIR__\" with \"$(DEVELOPER_DIR)\"\n  s/__BAZEL_XCODE_DEVELOPER_DIR__/\\$(DEVELOPER_DIR)/g;\n\n  # Replace \"__BAZEL_XCODE_SDKROOT__\" with \"$(SDKROOT)\"\n  s/__BAZEL_XCODE_SDKROOT__/\\$(SDKROOT)/g;\n\n  # Replace build settings with their values\n  s/\n    \\$             # Match a dollar sign\n    (\\()?          # Optionally match an opening parenthesis and capture it\n    ([a-zA-Z_]\\w*) # Match a variable name and capture it\n    (?(1)\\))       # If an opening parenthesis was captured, match a closing parenthesis\n  /$ENV{$2}/gx;    # Replace the entire matched string with the value of the corresponding environment variable\n\n' \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
 			showEnvVarsInLog = 0;
 		};
-		FF0100000000000000000100 /* Debug */ = {
+		FF0100000000000000000100 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {BUILD_SETTINGS_HERE};
-			name = Debug;
+			name = Release;
 		};
 		FF0100000000000000000101 /* Profile */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {BUILD_SETTINGS_HERE};
 			name = Profile;
 		};
-		FF0100000000000000000102 /* Release */ = {
+		FF0100000000000000000102 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {BUILD_SETTINGS_HERE};
-			name = Release;
+			name = Debug;
 		};
 		FF0100000000000000000002 /* Build configuration list for PBXAggregateTarget "BazelDependencies" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				FF0100000000000000000100 /* Debug */,
+				FF0100000000000000000100 /* Release */,
 				FF0100000000000000000101 /* Profile */,
-				FF0100000000000000000102 /* Release */,
+				FF0100000000000000000102 /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/tools/generators/pbxproj_prefix/test/PBXProjectPrefixPartialTests.swift
+++ b/tools/generators/pbxproj_prefix/test/PBXProjectPrefixPartialTests.swift
@@ -19,33 +19,34 @@ class PBXProjectPrefixPartialTests: XCTestCase {
         let xcodeConfigurations = [
             "Release",
             "Profile",
-            "Release",
             "Debug",
         ]
 
-        // The tabs for indenting are intentional
+        // The tabs for indenting are intentional.
+        // Order of configurations is wrong, but shows that it doesn't do
+        // sorting (since they should be sorted coming in).
         let expectedPBXProjectPrefixPartial = #"""
-		FF0000000000000000000100 /* Debug */ = {
+		FF0000000000000000000100 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {BUILD_SETTINGS_HERE};
-			name = Debug;
+			name = Release;
 		};
 		FF0000000000000000000101 /* Profile */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {BUILD_SETTINGS_HERE};
 			name = Profile;
 		};
-		FF0000000000000000000102 /* Release */ = {
+		FF0000000000000000000102 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {BUILD_SETTINGS_HERE};
-			name = Release;
+			name = Debug;
 		};
 		FF0000000000000000000002 /* Build configuration list for PBXProject */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				FF0000000000000000000100 /* Debug */,
+				FF0000000000000000000100 /* Release */,
 				FF0000000000000000000101 /* Profile */,
-				FF0000000000000000000102 /* Release */,
+				FF0000000000000000000102 /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Profile;
@@ -93,7 +94,7 @@ class PBXProjectPrefixPartialTests: XCTestCase {
 
         let buildSettings = "{BUILD_SETTINGS_HERE}"
         let compatibilityVersion = "AppCode 42.7.4"
-        let defaultXcodeConfiguration: String? = nil
+        let defaultXcodeConfiguration = "Debug"
         let developmentRegion = "en-GB"
         let organizationName: String? = nil
         let projectDir = "/some/execution_root"
@@ -101,33 +102,34 @@ class PBXProjectPrefixPartialTests: XCTestCase {
         let xcodeConfigurations = [
             "Release",
             "Profile",
-            "Release",
             "Debug",
         ]
 
-        // The tabs for indenting are intentional
+        // The tabs for indenting are intentional.
+        // Order of configurations is wrong, but shows that it doesn't do
+        // sorting (since they should be sorted coming in).
         let expectedPBXProjectPrefixPartial = #"""
-		FF0000000000000000000100 /* Debug */ = {
+		FF0000000000000000000100 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {BUILD_SETTINGS_HERE};
-			name = Debug;
+			name = Release;
 		};
 		FF0000000000000000000101 /* Profile */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {BUILD_SETTINGS_HERE};
 			name = Profile;
 		};
-		FF0000000000000000000102 /* Release */ = {
+		FF0000000000000000000102 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {BUILD_SETTINGS_HERE};
-			name = Release;
+			name = Debug;
 		};
 		FF0000000000000000000002 /* Build configuration list for PBXProject */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				FF0000000000000000000100 /* Debug */,
+				FF0000000000000000000100 /* Release */,
 				FF0000000000000000000101 /* Profile */,
-				FF0000000000000000000102 /* Release */,
+				FF0000000000000000000102 /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
@@ -175,7 +177,7 @@ class PBXProjectPrefixPartialTests: XCTestCase {
 
         let buildSettings = "{BUILD_SETTINGS_HERE}"
         let compatibilityVersion = "AppCode 42.7.4"
-        let defaultXcodeConfiguration: String? = nil
+        let defaultXcodeConfiguration = "Debug"
         let developmentRegion = "enGB"
         let organizationName = "SingleWord"
         let projectDir = "/some/execution_root"
@@ -183,32 +185,34 @@ class PBXProjectPrefixPartialTests: XCTestCase {
         let xcodeConfigurations = [
             "Release",
             "Profile",
-            "Release",
             "Debug",
         ]
 
+        // The tabs for indenting are intentional.
+        // Order of configurations is wrong, but shows that it doesn't do
+        // sorting (since they should be sorted coming in).
         let expectedPBXProjectPrefixPartial = #"""
-		FF0000000000000000000100 /* Debug */ = {
+		FF0000000000000000000100 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {BUILD_SETTINGS_HERE};
-			name = Debug;
+			name = Release;
 		};
 		FF0000000000000000000101 /* Profile */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {BUILD_SETTINGS_HERE};
 			name = Profile;
 		};
-		FF0000000000000000000102 /* Release */ = {
+		FF0000000000000000000102 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {BUILD_SETTINGS_HERE};
-			name = Release;
+			name = Debug;
 		};
 		FF0000000000000000000002 /* Build configuration list for PBXProject */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				FF0000000000000000000100 /* Debug */,
+				FF0000000000000000000100 /* Release */,
 				FF0000000000000000000101 /* Profile */,
-				FF0000000000000000000102 /* Release */,
+				FF0000000000000000000102 /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
@@ -257,7 +261,7 @@ class PBXProjectPrefixPartialTests: XCTestCase {
 
         let buildSettings = "{BUILD_SETTINGS_HERE}"
         let compatibilityVersion = "AppCode 42.7.4"
-        let defaultXcodeConfiguration: String? = nil
+        let defaultXcodeConfiguration: String = "Debug"
         let developmentRegion = "enGB"
         let organizationName = "Multiple Words"
         let projectDir = "/some/execution_root"
@@ -265,32 +269,34 @@ class PBXProjectPrefixPartialTests: XCTestCase {
         let xcodeConfigurations = [
             "Release",
             "Profile",
-            "Release",
             "Debug",
         ]
 
+        // The tabs for indenting are intentional.
+        // Order of configurations is wrong, but shows that it doesn't do
+        // sorting (since they should be sorted coming in).
         let expectedPBXProjectPrefixPartial = #"""
-		FF0000000000000000000100 /* Debug */ = {
+		FF0000000000000000000100 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {BUILD_SETTINGS_HERE};
-			name = Debug;
+			name = Release;
 		};
 		FF0000000000000000000101 /* Profile */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {BUILD_SETTINGS_HERE};
 			name = Profile;
 		};
-		FF0000000000000000000102 /* Release */ = {
+		FF0000000000000000000102 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {BUILD_SETTINGS_HERE};
-			name = Release;
+			name = Debug;
 		};
 		FF0000000000000000000002 /* Build configuration list for PBXProject */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				FF0000000000000000000100 /* Debug */,
+				FF0000000000000000000100 /* Release */,
 				FF0000000000000000000101 /* Profile */,
-				FF0000000000000000000102 /* Release */,
+				FF0000000000000000000102 /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
@@ -339,7 +345,7 @@ class PBXProjectPrefixPartialTests: XCTestCase {
 
         let buildSettings = "{BUILD_SETTINGS_HERE}"
         let compatibilityVersion = "AppCode 42.7.4"
-        let defaultXcodeConfiguration: String? = nil
+        let defaultXcodeConfiguration: String = "Debug"
         let developmentRegion = "enGB"
         let organizationName = #"Go "Home""#
         let projectDir = "/some/execution_root"
@@ -347,32 +353,34 @@ class PBXProjectPrefixPartialTests: XCTestCase {
         let xcodeConfigurations = [
             "Release",
             "Profile",
-            "Release",
             "Debug",
         ]
 
+        // The tabs for indenting are intentional.
+        // Order of configurations is wrong, but shows that it doesn't do
+        // sorting (since they should be sorted coming in).
         let expectedPBXProjectPrefixPartial = #"""
-		FF0000000000000000000100 /* Debug */ = {
+		FF0000000000000000000100 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {BUILD_SETTINGS_HERE};
-			name = Debug;
+			name = Release;
 		};
 		FF0000000000000000000101 /* Profile */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {BUILD_SETTINGS_HERE};
 			name = Profile;
 		};
-		FF0000000000000000000102 /* Release */ = {
+		FF0000000000000000000102 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {BUILD_SETTINGS_HERE};
-			name = Release;
+			name = Debug;
 		};
 		FF0000000000000000000002 /* Build configuration list for PBXProject */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				FF0000000000000000000100 /* Debug */,
+				FF0000000000000000000100 /* Release */,
 				FF0000000000000000000101 /* Profile */,
-				FF0000000000000000000102 /* Release */,
+				FF0000000000000000000102 /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/xcodeproj/internal/pbxproj_partials.bzl
+++ b/xcodeproj/internal/pbxproj_partials.bzl
@@ -26,7 +26,6 @@ _flags = struct(
     colorize = "--colorize",
     compile_stub_needed = "--compile-stub-needed",
     consolidation_map_output_paths = "--consolidation-map-output-paths",
-    default_xcode_configuration = "--default-xcode-configuration",
     dependencies = "--dependencies",
     dependency_counts = "--dependency-counts",
     files_paths = "--file-paths",
@@ -227,10 +226,8 @@ def _write_pbxproj_prefix(
         apple_platform_to_platform_name: Exposed for testing. Don't set.
         build_mode: `xcodeproj.build_mode`.
         colorize: A `bool` indicating whether to colorize the output.
-        default_xcode_configuration: Optional. The name of the the Xcode
-            configuration to use when building, if not overridden by custom
-            schemes. If not set, the first Xcode configuration alphabetically
-            will be used.
+        default_xcode_configuration: The name of the the Xcode configuration to
+            use when building, if not overridden by custom schemes.
         execution_root_file: A `File` containing the absolute path to the Bazel
             execution root.
         generator_name: The name of the `xcodeproj` generator target.
@@ -249,7 +246,7 @@ def _write_pbxproj_prefix(
         tool: The executable that will generate the `PBXProj` partial.
         workspace_directory: The absolute path to the Bazel workspace
             directory.
-        xcode_configurations: A sequence of Xcode configuration names.
+        xcode_configurations: A sorted sequence of Xcode configuration names.
 
     Returns:
         The `File` for the `PBXProject` prefix `PBXProj` partial.
@@ -289,6 +286,9 @@ def _write_pbxproj_prefix(
     # minimumXcodeVersion
     args.add(minimum_xcode_version)
 
+    # defaultXcodeConfiguration
+    args.add(default_xcode_configuration)
+
     # developmentRegion
     args.add(project_options["development_region"])
 
@@ -306,13 +306,6 @@ def _write_pbxproj_prefix(
 
     # xcodeConfigurations
     args.add_all(_flags.xcode_configurations, xcode_configurations)
-
-    # defaultXcodeConfiguration
-    if default_xcode_configuration:
-        args.add(
-            _flags.default_xcode_configuration,
-            default_xcode_configuration,
-        )
 
     # preBuildScript
     if pre_build_script:


### PR DESCRIPTION
More than one generator will need to know what the default Xcode configuration, so we determine it in Starlark.