### PR TITLE
Fix handling of unfocused `.xcdatamodel` bundles

### DIFF
--- a/tools/generators/legacy/src/Generator/CreateFilesAndGroups.swift
+++ b/tools/generators/legacy/src/Generator/CreateFilesAndGroups.swift
@@ -795,7 +795,7 @@ extension Generator {
                 // We can get `.xccurrentversion` files for `.xcdatamodel`
                 // bundles that are uncategorized (e.g.
                 // `rules_ios_apple_framework.resource_bundles`). If no
-                // downstream target is focused, we will won't have an
+                // downstream target is focused, we won't have an
                 // `xcVersionGroups` for this `xccurrentversion`. We can safely
                 // ignore these.
                 continue


### PR DESCRIPTION
Fixes #2464.

“Regressed” with b75ca4b2f9ce0ef8401a09e94c902499b8fd72d9.