### PR TITLE
Clean up `filelists.write`

### DIFF
--- a/xcodeproj/internal/filelists.bzl
+++ b/xcodeproj/internal/filelists.bzl
@@ -2,17 +2,16 @@
 
 load(":memory_efficiency.bzl", "EMPTY_DEPSET")
 
-def _write(*, ctx, rule_name, name, files):
+def _write(*, actions, rule_name, name, files):
     if files == None:
         files = EMPTY_DEPSET
 
-    args = ctx.actions.args()
-    args.use_param_file("%s", use_always = True)
+    args = actions.args()
     args.set_param_file_format("multiline")
     args.add_all(files, expand_directories = False)
 
-    output = ctx.actions.declare_file("{}-{}.filelist".format(rule_name, name))
-    ctx.actions.write(output, args)
+    output = actions.declare_file("{}-{}.filelist".format(rule_name, name))
+    actions.write(output, args)
 
     return output
 

--- a/xcodeproj/internal/input_files.bzl
+++ b/xcodeproj/internal/input_files.bzl
@@ -648,7 +648,7 @@ def _collect_input_files(
         linking_output_group_name = "xl {}".format(id)
 
         indexstores_filelist = filelists.write(
-            ctx = ctx,
+            actions = ctx.actions,
             rule_name = ctx.rule.attr.name,
             name = "xi",
             files = indexstores_depset,

--- a/xcodeproj/internal/output_files.bzl
+++ b/xcodeproj/internal/output_files.bzl
@@ -118,7 +118,7 @@ def _create(
         products_output_group_name = "bp {}".format(direct_outputs.id)
 
         indexstores_filelist = filelists.write(
-            ctx = ctx,
+            actions = ctx.actions,
             rule_name = ctx.rule.attr.name,
             name = "bi",
             files = transitive_indexestores,


### PR DESCRIPTION
- Removes the use of `ctx`
- Prevents the creation of a params file when it’s not needed