### PR TITLE
Filter BwB dependencies in Starlark

### DIFF
--- a/examples/cc/test/fixtures/bwb_targets_spec.json
+++ b/examples/cc/test/fixtures/bwb_targets_spec.json
@@ -58,9 +58,6 @@
         },
         "8": "bazel-out/darwin_x86_64-dbg-STABLE-1/bin/lib/lib_defines.rules_xcodeproj.c.compile.params",
         "c": "darwin_x86_64-dbg-STABLE-1",
-        "d": [
-            "//lib/impl:lib_impl darwin_x86_64-dbg-STABLE-1"
-        ],
         "f": true,
         "i": {
             "s": [
@@ -90,11 +87,6 @@
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "tool_codesigned"
         },
         "c": "darwin_x86_64-dbg-STABLE-1",
-        "d": [
-            "//lib:lib_defines darwin_x86_64-dbg-STABLE-1",
-            "@examples_cc_external//:lib_impl darwin_x86_64-dbg-STABLE-1",
-            "//lib2:lib_impl darwin_x86_64-dbg-STABLE-1"
-        ],
         "f": true,
         "i": {
             "s": [

--- a/examples/integration/test/fixtures/bwb_targets_spec.json
+++ b/examples/integration/test/fixtures/bwb_targets_spec.json
@@ -41,9 +41,6 @@
             "TARGETED_DEVICE_FAMILY": "1"
         },
         "c": "applebin_ios-ios_arm64-dbg-STABLE-14",
-        "d": [
-            "//Lib:Lib ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4"
-        ],
         "i": {
             "r": [
                 "AppClip/PreviewContent/Preview Assets.xcassets",
@@ -117,9 +114,6 @@
             "TARGETED_DEVICE_FAMILY": "1"
         },
         "c": "applebin_ios-ios_arm64-opt-STABLE-16",
-        "d": [
-            "//Lib:Lib ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-10"
-        ],
         "i": {
             "r": [
                 "Lib/Resources/Assets.xcassets",
@@ -193,9 +187,6 @@
             "TARGETED_DEVICE_FAMILY": "1"
         },
         "c": "applebin_ios-ios_x86_64-dbg-STABLE-13",
-        "d": [
-            "//Lib:Lib ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1"
-        ],
         "i": {
             "r": [
                 "AppClip/PreviewContent/Preview Assets.xcassets",
@@ -268,9 +259,6 @@
             "TARGETED_DEVICE_FAMILY": "1"
         },
         "c": "applebin_ios-ios_x86_64-opt-STABLE-15",
-        "d": [
-            "//Lib:Lib ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-7"
-        ],
         "i": {
             "r": [
                 "Lib/Resources/Assets.xcassets",
@@ -430,9 +418,6 @@
             ]
         },
         "c": "applebin_macos-darwin_x86_64-dbg-STABLE-39",
-        "d": [
-            "//CommandLine/CommandLineToolLib:lib_swift macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33"
-        ],
         "f": true,
         "i": {
             "s": [
@@ -481,9 +466,6 @@
             ]
         },
         "c": "applebin_macos-darwin_x86_64-opt-STABLE-40",
-        "d": [
-            "//CommandLine/CommandLineToolLib:lib_swift macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36"
-        ],
         "f": true,
         "i": {
             "s": [
@@ -529,9 +511,6 @@
             "PRODUCT_MODULE_NAME": "CommandLine_CommandLineTool_tool_binary"
         },
         "c": "macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-34",
-        "d": [
-            "//CommandLine/CommandLineToolLib:lib_swift macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-34"
-        ],
         "f": true,
         "i": {
             "s": [
@@ -574,9 +553,6 @@
             "PRODUCT_MODULE_NAME": "CommandLine_CommandLineTool_tool_binary"
         },
         "c": "macos-arm64-min11.0-applebin_macos-darwin_arm64-opt-STABLE-37",
-        "d": [
-            "//CommandLine/CommandLineToolLib:lib_swift macos-arm64-min11.0-applebin_macos-darwin_arm64-opt-STABLE-37"
-        ],
         "f": true,
         "i": {
             "s": [
@@ -622,9 +598,6 @@
             "PRODUCT_MODULE_NAME": "CommandLine_CommandLineTool_tool_binary"
         },
         "c": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35",
-        "d": [
-            "//CommandLine/CommandLineToolLib:lib_swift macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35"
-        ],
         "f": true,
         "i": {
             "s": [
@@ -667,9 +640,6 @@
             "PRODUCT_MODULE_NAME": "CommandLine_CommandLineTool_tool_binary"
         },
         "c": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38",
-        "d": [
-            "//CommandLine/CommandLineToolLib:lib_swift macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38"
-        ],
         "f": true,
         "i": {
             "s": [
@@ -896,12 +866,6 @@
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "private/LibSwift-Swift.h"
         },
         "c": "macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-34",
-        "d": [
-            "//CommandLine/swift_c_module:c_lib macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-34",
-            "//CommandLine/CommandLineToolLib:lib_impl macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-34",
-            "//CommandLine/CommandLineToolLib:private_lib macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-34",
-            "//CommandLine/CommandLineToolLib:private_swift_lib macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-34"
-        ],
         "i": {
             "s": [
                 "CommandLine/CommandLineToolLib/lib.swift"
@@ -940,12 +904,6 @@
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "private/LibSwift-Swift.h"
         },
         "c": "macos-arm64-min11.0-applebin_macos-darwin_arm64-opt-STABLE-37",
-        "d": [
-            "//CommandLine/swift_c_module:c_lib macos-arm64-min11.0-applebin_macos-darwin_arm64-opt-STABLE-37",
-            "//CommandLine/CommandLineToolLib:lib_impl macos-arm64-min11.0-applebin_macos-darwin_arm64-opt-STABLE-37",
-            "//CommandLine/CommandLineToolLib:private_lib macos-arm64-min11.0-applebin_macos-darwin_arm64-opt-STABLE-37",
-            "//CommandLine/CommandLineToolLib:private_swift_lib macos-arm64-min11.0-applebin_macos-darwin_arm64-opt-STABLE-37"
-        ],
         "i": {
             "s": [
                 "CommandLine/CommandLineToolLib/lib.swift"
@@ -986,12 +944,6 @@
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "private/LibSwift-Swift.h"
         },
         "c": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35",
-        "d": [
-            "//CommandLine/swift_c_module:c_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35",
-            "//CommandLine/CommandLineToolLib:lib_impl macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35",
-            "//CommandLine/CommandLineToolLib:private_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35",
-            "//CommandLine/CommandLineToolLib:private_swift_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-35"
-        ],
         "i": {
             "s": [
                 "CommandLine/CommandLineToolLib/lib.swift"
@@ -1029,12 +981,6 @@
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "private/LibSwift-Swift.h"
         },
         "c": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33",
-        "d": [
-            "//CommandLine/swift_c_module:c_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33",
-            "//CommandLine/CommandLineToolLib:lib_impl macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33",
-            "//CommandLine/CommandLineToolLib:private_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33",
-            "//CommandLine/CommandLineToolLib:private_swift_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33"
-        ],
         "i": {
             "s": [
                 "CommandLine/CommandLineToolLib/lib.swift"
@@ -1073,12 +1019,6 @@
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "private/LibSwift-Swift.h"
         },
         "c": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38",
-        "d": [
-            "//CommandLine/swift_c_module:c_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38",
-            "//CommandLine/CommandLineToolLib:lib_impl macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38",
-            "//CommandLine/CommandLineToolLib:private_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38",
-            "//CommandLine/CommandLineToolLib:private_swift_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-38"
-        ],
         "i": {
             "s": [
                 "CommandLine/CommandLineToolLib/lib.swift"
@@ -1120,12 +1060,6 @@
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "private/LibSwift-Swift.h"
         },
         "c": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36",
-        "d": [
-            "//CommandLine/swift_c_module:c_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36",
-            "//CommandLine/CommandLineToolLib:lib_impl macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36",
-            "//CommandLine/CommandLineToolLib:private_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36",
-            "//CommandLine/CommandLineToolLib:private_swift_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36"
-        ],
         "i": {
             "s": [
                 "CommandLine/CommandLineToolLib/lib.swift"
@@ -1638,9 +1572,6 @@
             "PRODUCT_MODULE_NAME": "CommandLineToolTests"
         },
         "c": "applebin_macos-darwin_x86_64-dbg-STABLE-39",
-        "d": [
-            "//CommandLine/CommandLineToolLib:lib_swift macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-33"
-        ],
         "i": {
             "s": [
                 "CommandLine/Tests/BasicTests.swift",
@@ -1700,9 +1631,6 @@
             "SWIFT_COMPILATION_MODE": "wholemodule"
         },
         "c": "applebin_macos-darwin_x86_64-opt-STABLE-40",
-        "d": [
-            "//CommandLine/CommandLineToolLib:lib_swift macos-x86_64-min11.0-applebin_macos-darwin_x86_64-opt-STABLE-36"
-        ],
         "i": {
             "s": [
                 "CommandLine/Tests/BasicTests.swift",
@@ -1930,9 +1858,6 @@
             "TARGETED_DEVICE_FAMILY": "1"
         },
         "c": "applebin_ios-ios_arm64-dbg-STABLE-14",
-        "d": [
-            "//Lib:Lib ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4"
-        ],
         "i": {
             "r": [
                 "Lib/Resources/Assets.xcassets"
@@ -1979,9 +1904,6 @@
             "TARGETED_DEVICE_FAMILY": "1"
         },
         "c": "applebin_ios-ios_arm64-opt-STABLE-16",
-        "d": [
-            "//Lib:Lib ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-10"
-        ],
         "i": {
             "r": [
                 "Lib/Resources/Assets.xcassets"
@@ -2031,9 +1953,6 @@
             "TARGETED_DEVICE_FAMILY": "1"
         },
         "c": "applebin_ios-ios_x86_64-dbg-STABLE-13",
-        "d": [
-            "//Lib:Lib ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1"
-        ],
         "i": {
             "r": [
                 "Lib/Resources/Assets.xcassets"
@@ -2080,9 +1999,6 @@
             "TARGETED_DEVICE_FAMILY": "1"
         },
         "c": "applebin_ios-ios_x86_64-opt-STABLE-15",
-        "d": [
-            "//Lib:Lib ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-7"
-        ],
         "i": {
             "r": [
                 "Lib/Resources/Assets.xcassets"
@@ -2131,9 +2047,6 @@
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.LibFramework"
         },
         "c": "applebin_tvos-tvos_arm64-dbg-STABLE-26",
-        "d": [
-            "//Lib:Lib tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-6"
-        ],
         "i": {
             "r": [
                 "Lib/Resources/Assets.xcassets"
@@ -2179,9 +2092,6 @@
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.LibFramework"
         },
         "c": "applebin_tvos-tvos_arm64-opt-STABLE-28",
-        "d": [
-            "//Lib:Lib tvos-arm64-min15.0-applebin_tvos-tvos_arm64-opt-STABLE-12"
-        ],
         "i": {
             "r": [
                 "Lib/Resources/Assets.xcassets"
@@ -2230,9 +2140,6 @@
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.LibFramework"
         },
         "c": "applebin_tvos-tvos_x86_64-dbg-STABLE-25",
-        "d": [
-            "//Lib:Lib tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3"
-        ],
         "i": {
             "r": [
                 "Lib/Resources/Assets.xcassets"
@@ -2278,9 +2185,6 @@
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.LibFramework"
         },
         "c": "applebin_tvos-tvos_x86_64-opt-STABLE-27",
-        "d": [
-            "//Lib:Lib tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-opt-STABLE-9"
-        ],
         "i": {
             "r": [
                 "Lib/Resources/Assets.xcassets"
@@ -2329,9 +2233,6 @@
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.LibFramework"
         },
         "c": "applebin_watchos-watchos_arm64_32-dbg-STABLE-18",
-        "d": [
-            "//Lib:Lib watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-5"
-        ],
         "i": {
             "r": [
                 "Lib/Resources/Assets.xcassets"
@@ -2377,9 +2278,6 @@
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.LibFramework"
         },
         "c": "applebin_watchos-watchos_arm64_32-opt-STABLE-20",
-        "d": [
-            "//Lib:Lib watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-opt-STABLE-11"
-        ],
         "i": {
             "r": [
                 "Lib/Resources/Assets.xcassets"
@@ -2428,9 +2326,6 @@
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.LibFramework"
         },
         "c": "applebin_watchos-watchos_x86_64-dbg-STABLE-17",
-        "d": [
-            "//Lib:Lib watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2"
-        ],
         "i": {
             "r": [
                 "Lib/Resources/Assets.xcassets"
@@ -2476,9 +2371,6 @@
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.LibFramework"
         },
         "c": "applebin_watchos-watchos_x86_64-opt-STABLE-19",
-        "d": [
-            "//Lib:Lib watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-opt-STABLE-8"
-        ],
         "i": {
             "r": [
                 "Lib/Resources/Assets.xcassets"
@@ -2986,9 +2878,6 @@
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.LibFramework"
         },
         "c": "applebin_tvos-tvos_arm64-dbg-STABLE-26",
-        "d": [
-            "//Lib:Lib tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-6"
-        ],
         "i": {
             "r": [
                 "Lib/Resources/Assets.xcassets"
@@ -3037,9 +2926,6 @@
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.LibFramework"
         },
         "c": "applebin_tvos-tvos_arm64-opt-STABLE-28",
-        "d": [
-            "//Lib:Lib tvos-arm64-min15.0-applebin_tvos-tvos_arm64-opt-STABLE-12"
-        ],
         "i": {
             "r": [
                 "Lib/Resources/Assets.xcassets"
@@ -3091,9 +2977,6 @@
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.LibFramework"
         },
         "c": "applebin_tvos-tvos_x86_64-dbg-STABLE-25",
-        "d": [
-            "//Lib:Lib tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3"
-        ],
         "i": {
             "r": [
                 "Lib/Resources/Assets.xcassets"
@@ -3142,9 +3025,6 @@
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.LibFramework"
         },
         "c": "applebin_tvos-tvos_x86_64-opt-STABLE-27",
-        "d": [
-            "//Lib:Lib tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-opt-STABLE-9"
-        ],
         "i": {
             "r": [
                 "Lib/Resources/Assets.xcassets"
@@ -3196,9 +3076,6 @@
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.LibFramework"
         },
         "c": "applebin_watchos-watchos_arm64_32-dbg-STABLE-18",
-        "d": [
-            "//Lib:Lib watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-5"
-        ],
         "i": {
             "r": [
                 "Lib/Resources/Assets.xcassets"
@@ -3247,9 +3124,6 @@
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.LibFramework"
         },
         "c": "applebin_watchos-watchos_arm64_32-opt-STABLE-20",
-        "d": [
-            "//Lib:Lib watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-opt-STABLE-11"
-        ],
         "i": {
             "r": [
                 "Lib/Resources/Assets.xcassets"
@@ -3301,9 +3175,6 @@
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.LibFramework"
         },
         "c": "applebin_watchos-watchos_x86_64-dbg-STABLE-17",
-        "d": [
-            "//Lib:Lib watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2"
-        ],
         "i": {
             "r": [
                 "Lib/Resources/Assets.xcassets"
@@ -3352,9 +3223,6 @@
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.LibFramework"
         },
         "c": "applebin_watchos-watchos_x86_64-opt-STABLE-19",
-        "d": [
-            "//Lib:Lib watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-opt-STABLE-8"
-        ],
         "i": {
             "r": [
                 "Lib/Resources/Assets.xcassets"
@@ -3422,9 +3290,6 @@
             "TARGETED_DEVICE_FAMILY": "1"
         },
         "c": "applebin_ios-ios_arm64-dbg-STABLE-14",
-        "d": [
-            "//Lib:Lib ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4"
-        ],
         "i": {
             "h": [
                 "UI/UI.h"
@@ -3500,9 +3365,6 @@
             "TARGETED_DEVICE_FAMILY": "1"
         },
         "c": "applebin_ios-ios_arm64-opt-STABLE-16",
-        "d": [
-            "//Lib:Lib ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-10"
-        ],
         "i": {
             "h": [
                 "UI/UI.h"
@@ -3580,9 +3442,6 @@
             "TARGETED_DEVICE_FAMILY": "1"
         },
         "c": "applebin_ios-ios_x86_64-dbg-STABLE-13",
-        "d": [
-            "//Lib:Lib ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1"
-        ],
         "i": {
             "h": [
                 "UI/UI.h"
@@ -3658,9 +3517,6 @@
             "TARGETED_DEVICE_FAMILY": "1"
         },
         "c": "applebin_ios-ios_x86_64-opt-STABLE-15",
-        "d": [
-            "//Lib:Lib ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-7"
-        ],
         "i": {
             "h": [
                 "UI/UI.h"
@@ -3740,10 +3596,6 @@
             "PRODUCT_MODULE_NAME": "UI"
         },
         "c": "applebin_tvos-tvos_arm64-dbg-STABLE-26",
-        "d": [
-            "//Lib:LibFramework.tvOS applebin_tvos-tvos_arm64-dbg-STABLE-26",
-            "//Lib:Lib tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-6"
-        ],
         "i": {
             "s": [
                 "UI/ContentView.swift"
@@ -3818,10 +3670,6 @@
             "SWIFT_COMPILATION_MODE": "wholemodule"
         },
         "c": "applebin_tvos-tvos_arm64-opt-STABLE-28",
-        "d": [
-            "//Lib:LibFramework.tvOS applebin_tvos-tvos_arm64-opt-STABLE-28",
-            "//Lib:Lib tvos-arm64-min15.0-applebin_tvos-tvos_arm64-opt-STABLE-12"
-        ],
         "i": {
             "s": [
                 "UI/ContentView.swift"
@@ -3898,10 +3746,6 @@
             "PRODUCT_MODULE_NAME": "UI"
         },
         "c": "applebin_tvos-tvos_x86_64-dbg-STABLE-25",
-        "d": [
-            "//Lib:LibFramework.tvOS applebin_tvos-tvos_x86_64-dbg-STABLE-25",
-            "//Lib:Lib tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3"
-        ],
         "i": {
             "s": [
                 "UI/ContentView.swift"
@@ -3976,10 +3820,6 @@
             "SWIFT_COMPILATION_MODE": "wholemodule"
         },
         "c": "applebin_tvos-tvos_x86_64-opt-STABLE-27",
-        "d": [
-            "//Lib:LibFramework.tvOS applebin_tvos-tvos_x86_64-opt-STABLE-27",
-            "//Lib:Lib tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-opt-STABLE-9"
-        ],
         "i": {
             "s": [
                 "UI/ContentView.swift"
@@ -4056,10 +3896,6 @@
             "PRODUCT_MODULE_NAME": "UI"
         },
         "c": "applebin_watchos-watchos_arm64_32-dbg-STABLE-18",
-        "d": [
-            "//Lib:LibFramework.watchOS applebin_watchos-watchos_arm64_32-dbg-STABLE-18",
-            "//Lib:Lib watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-5"
-        ],
         "i": {
             "s": [
                 "UI/ContentView.swift"
@@ -4134,10 +3970,6 @@
             "SWIFT_COMPILATION_MODE": "wholemodule"
         },
         "c": "applebin_watchos-watchos_arm64_32-opt-STABLE-20",
-        "d": [
-            "//Lib:LibFramework.watchOS applebin_watchos-watchos_arm64_32-opt-STABLE-20",
-            "//Lib:Lib watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-opt-STABLE-11"
-        ],
         "i": {
             "s": [
                 "UI/ContentView.swift"
@@ -4214,10 +4046,6 @@
             "PRODUCT_MODULE_NAME": "UI"
         },
         "c": "applebin_watchos-watchos_x86_64-dbg-STABLE-17",
-        "d": [
-            "//Lib:LibFramework.watchOS applebin_watchos-watchos_x86_64-dbg-STABLE-17",
-            "//Lib:Lib watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2"
-        ],
         "i": {
             "s": [
                 "UI/ContentView.swift"
@@ -4292,10 +4120,6 @@
             "SWIFT_COMPILATION_MODE": "wholemodule"
         },
         "c": "applebin_watchos-watchos_x86_64-opt-STABLE-19",
-        "d": [
-            "//Lib:LibFramework.watchOS applebin_watchos-watchos_x86_64-opt-STABLE-19",
-            "//Lib:Lib watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-opt-STABLE-8"
-        ],
         "i": {
             "s": [
                 "UI/ContentView.swift"
@@ -4365,9 +4189,6 @@
             "TARGETED_DEVICE_FAMILY": "1"
         },
         "c": "applebin_ios-ios_arm64-dbg-STABLE-14",
-        "d": [
-            "//Lib:Lib ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4"
-        ],
         "i": {
             "r": [
                 "Lib/Resources/Assets.xcassets",
@@ -4439,9 +4260,6 @@
             "TARGETED_DEVICE_FAMILY": "1"
         },
         "c": "applebin_ios-ios_arm64-opt-STABLE-16",
-        "d": [
-            "//Lib:Lib ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-10"
-        ],
         "i": {
             "r": [
                 "Lib/Resources/Assets.xcassets",
@@ -4514,9 +4332,6 @@
             "TARGETED_DEVICE_FAMILY": "1"
         },
         "c": "applebin_ios-ios_x86_64-dbg-STABLE-13",
-        "d": [
-            "//Lib:Lib ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1"
-        ],
         "i": {
             "r": [
                 "Lib/Resources/Assets.xcassets",
@@ -4587,9 +4402,6 @@
             "TARGETED_DEVICE_FAMILY": "1"
         },
         "c": "applebin_ios-ios_x86_64-opt-STABLE-15",
-        "d": [
-            "//Lib:Lib ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-7"
-        ],
         "i": {
             "r": [
                 "Lib/Resources/Assets.xcassets",
@@ -4641,9 +4453,6 @@
             "TARGETED_DEVICE_FAMILY": "1"
         },
         "c": "applebin_ios-ios_x86_64-dbg-STABLE-13",
-        "d": [
-            "//iMessageApp:iMessageAppExtension applebin_ios-ios_x86_64-dbg-STABLE-13"
-        ],
         "e": [
             "//iMessageApp:iMessageAppExtension applebin_ios-ios_x86_64-dbg-STABLE-13"
         ],
@@ -4681,9 +4490,6 @@
             "TARGETED_DEVICE_FAMILY": "1"
         },
         "c": "applebin_ios-ios_x86_64-opt-STABLE-15",
-        "d": [
-            "//iMessageApp:iMessageAppExtension applebin_ios-ios_x86_64-opt-STABLE-15"
-        ],
         "e": [
             "//iMessageApp:iMessageAppExtension applebin_ios-ios_x86_64-opt-STABLE-15"
         ],
@@ -4745,9 +4551,6 @@
             "TARGETED_DEVICE_FAMILY": "1"
         },
         "c": "applebin_ios-ios_x86_64-dbg-STABLE-13",
-        "d": [
-            "//Lib:Lib ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1"
-        ],
         "i": {
             "r": [
                 "iMessageApp/ExtensionAssets.xcassets",
@@ -4818,9 +4621,6 @@
             "TARGETED_DEVICE_FAMILY": "1"
         },
         "c": "applebin_ios-ios_x86_64-opt-STABLE-15",
-        "d": [
-            "//Lib:Lib ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-7"
-        ],
         "i": {
             "r": [
                 "iMessageApp/ExtensionAssets.xcassets",
@@ -4866,9 +4666,6 @@
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym"
         },
         "c": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4",
-        "d": [
-            "//iOSApp/Source/CoreUtilsMixed/MixedAnswer:MixedAnswerLib_Swift ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4"
-        ],
         "f": true,
         "i": {
             "s": [
@@ -4896,9 +4693,6 @@
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym"
         },
         "c": "ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-10",
-        "d": [
-            "//iOSApp/Source/CoreUtilsMixed/MixedAnswer:MixedAnswerLib_Swift ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-10"
-        ],
         "f": true,
         "i": {
             "s": [
@@ -4929,9 +4723,6 @@
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym"
         },
         "c": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-        "d": [
-            "//iOSApp/Source/CoreUtilsMixed/MixedAnswer:MixedAnswerLib_Swift ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1"
-        ],
         "f": true,
         "i": {
             "s": [
@@ -4959,9 +4750,6 @@
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym"
         },
         "c": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-7",
-        "d": [
-            "//iOSApp/Source/CoreUtilsMixed/MixedAnswer:MixedAnswerLib_Swift ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-7"
-        ],
         "f": true,
         "i": {
             "s": [
@@ -5379,10 +5167,6 @@
             "PRODUCT_MODULE_NAME": "Utils"
         },
         "c": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-        "d": [
-            "//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC applebin_ios-ios_x86_64-dbg-STABLE-13",
-            "@FXPageControl//:FXPageControl ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1"
-        ],
         "f": true,
         "i": {
             "s": [
@@ -5412,10 +5196,6 @@
             "PRODUCT_MODULE_NAME": "Utils"
         },
         "c": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-7",
-        "d": [
-            "//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC applebin_ios-ios_x86_64-opt-STABLE-15",
-            "@FXPageControl//:FXPageControl ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-7"
-        ],
         "f": true,
         "i": {
             "s": [
@@ -5496,16 +5276,6 @@
             "TARGETED_DEVICE_FAMILY": "1"
         },
         "c": "applebin_ios-ios_arm64-dbg-STABLE-14",
-        "d": [
-            "//AppClip:AppClip applebin_ios-ios_arm64-dbg-STABLE-14",
-            "//WidgetExtension:WidgetExtension applebin_ios-ios_arm64-dbg-STABLE-14",
-            "//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC applebin_ios-ios_arm64-dbg-STABLE-14",
-            "//UI:UIFramework.iOS applebin_ios-ios_arm64-dbg-STABLE-14",
-            "//watchOSApp:watchOSApp applebin_watchos-watchos_arm64_32-dbg-STABLE-22",
-            "//UI:UIFramework.iOS applebin_ios-ios_arm64-dbg-STABLE-14",
-            "//iOSApp/Source/CoreUtilsMixed/MixedAnswer:MixedAnswer ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4",
-            "//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC applebin_ios-ios_arm64-dbg-STABLE-14"
-        ],
         "e": [
             "//WidgetExtension:WidgetExtension applebin_ios-ios_arm64-dbg-STABLE-14"
         ],
@@ -5614,16 +5384,6 @@
             "TARGETED_DEVICE_FAMILY": "1"
         },
         "c": "applebin_ios-ios_arm64-opt-STABLE-16",
-        "d": [
-            "//AppClip:AppClip applebin_ios-ios_arm64-opt-STABLE-16",
-            "//WidgetExtension:WidgetExtension applebin_ios-ios_arm64-opt-STABLE-16",
-            "//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC applebin_ios-ios_arm64-opt-STABLE-16",
-            "//UI:UIFramework.iOS applebin_ios-ios_arm64-opt-STABLE-16",
-            "//watchOSApp:watchOSApp applebin_watchos-watchos_arm64_32-opt-STABLE-24",
-            "//UI:UIFramework.iOS applebin_ios-ios_arm64-opt-STABLE-16",
-            "//iOSApp/Source/CoreUtilsMixed/MixedAnswer:MixedAnswer ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-10",
-            "//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC applebin_ios-ios_arm64-opt-STABLE-16"
-        ],
         "e": [
             "//WidgetExtension:WidgetExtension applebin_ios-ios_arm64-opt-STABLE-16"
         ],
@@ -5732,16 +5492,6 @@
             "TARGETED_DEVICE_FAMILY": "1"
         },
         "c": "applebin_ios-ios_x86_64-dbg-STABLE-13",
-        "d": [
-            "//AppClip:AppClip applebin_ios-ios_x86_64-dbg-STABLE-13",
-            "//WidgetExtension:WidgetExtension applebin_ios-ios_x86_64-dbg-STABLE-13",
-            "//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC applebin_ios-ios_x86_64-dbg-STABLE-13",
-            "//UI:UIFramework.iOS applebin_ios-ios_x86_64-dbg-STABLE-13",
-            "//watchOSApp:watchOSApp applebin_watchos-watchos_x86_64-dbg-STABLE-21",
-            "//UI:UIFramework.iOS applebin_ios-ios_x86_64-dbg-STABLE-13",
-            "//iOSApp/Source/CoreUtilsMixed/MixedAnswer:MixedAnswer ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-            "//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC applebin_ios-ios_x86_64-dbg-STABLE-13"
-        ],
         "e": [
             "//WidgetExtension:WidgetExtension applebin_ios-ios_x86_64-dbg-STABLE-13"
         ],
@@ -5849,16 +5599,6 @@
             "TARGETED_DEVICE_FAMILY": "1"
         },
         "c": "applebin_ios-ios_x86_64-opt-STABLE-15",
-        "d": [
-            "//AppClip:AppClip applebin_ios-ios_x86_64-opt-STABLE-15",
-            "//WidgetExtension:WidgetExtension applebin_ios-ios_x86_64-opt-STABLE-15",
-            "//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC applebin_ios-ios_x86_64-opt-STABLE-15",
-            "//UI:UIFramework.iOS applebin_ios-ios_x86_64-opt-STABLE-15",
-            "//watchOSApp:watchOSApp applebin_watchos-watchos_x86_64-opt-STABLE-23",
-            "//UI:UIFramework.iOS applebin_ios-ios_x86_64-opt-STABLE-15",
-            "//iOSApp/Source/CoreUtilsMixed/MixedAnswer:MixedAnswer ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-7",
-            "//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC applebin_ios-ios_x86_64-opt-STABLE-15"
-        ],
         "e": [
             "//WidgetExtension:WidgetExtension applebin_ios-ios_x86_64-opt-STABLE-15"
         ],
@@ -5962,10 +5702,7 @@
         },
         "c": "applebin_ios-ios_x86_64-dbg-STABLE-13",
         "d": [
-            "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-dbg-STABLE-13",
-            "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-dbg-STABLE-13",
-            "//iOSApp/Source/Utils:Utils ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-            "//iOSApp/Test/TestingUtils:TestingUtils ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1"
+            "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-dbg-STABLE-13"
         ],
         "f": true,
         "h": "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-dbg-STABLE-13",
@@ -6046,10 +5783,7 @@
         },
         "c": "applebin_ios-ios_x86_64-opt-STABLE-15",
         "d": [
-            "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-opt-STABLE-15",
-            "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-opt-STABLE-15",
-            "//iOSApp/Source/Utils:Utils ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-7",
-            "//iOSApp/Test/TestingUtils:TestingUtils ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-7"
+            "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-opt-STABLE-15"
         ],
         "f": true,
         "h": "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-opt-STABLE-15",
@@ -6133,10 +5867,7 @@
         },
         "c": "applebin_ios-ios_x86_64-dbg-STABLE-13",
         "d": [
-            "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-dbg-STABLE-13",
-            "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-dbg-STABLE-13",
-            "//iOSApp/Source/Utils:Utils ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-            "//iOSApp/Test/TestingUtils:TestingUtils ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1"
+            "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-dbg-STABLE-13"
         ],
         "f": true,
         "h": "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-dbg-STABLE-13",
@@ -6217,10 +5948,7 @@
         },
         "c": "applebin_ios-ios_x86_64-opt-STABLE-15",
         "d": [
-            "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-opt-STABLE-15",
-            "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-opt-STABLE-15",
-            "//iOSApp/Source/Utils:Utils ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-7",
-            "//iOSApp/Test/TestingUtils:TestingUtils ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-7"
+            "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-opt-STABLE-15"
         ],
         "f": true,
         "h": "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-opt-STABLE-15",
@@ -6307,10 +6035,7 @@
         },
         "c": "applebin_ios-ios_x86_64-dbg-STABLE-13",
         "d": [
-            "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-dbg-STABLE-13",
-            "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-dbg-STABLE-13",
-            "//iOSApp/Source/Utils:Utils ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-            "//iOSApp/Test/TestingUtils:TestingUtils ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1"
+            "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-dbg-STABLE-13"
         ],
         "h": "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-dbg-STABLE-13",
         "i": {
@@ -6403,10 +6128,7 @@
         },
         "c": "applebin_ios-ios_x86_64-opt-STABLE-15",
         "d": [
-            "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-opt-STABLE-15",
-            "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-opt-STABLE-15",
-            "//iOSApp/Source/Utils:Utils ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-7",
-            "//iOSApp/Test/TestingUtils:TestingUtils ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-7"
+            "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-opt-STABLE-15"
         ],
         "h": "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-opt-STABLE-15",
         "i": {
@@ -6501,10 +6223,7 @@
         },
         "c": "applebin_ios-ios_x86_64-dbg-STABLE-13",
         "d": [
-            "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-dbg-STABLE-13",
-            "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-dbg-STABLE-13",
-            "//iOSApp/Source/Utils:Utils ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-            "//iOSApp/Test/TestingUtils:TestingUtils ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1"
+            "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-dbg-STABLE-13"
         ],
         "h": "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-dbg-STABLE-13",
         "i": {
@@ -6597,10 +6316,7 @@
         },
         "c": "applebin_ios-ios_x86_64-opt-STABLE-15",
         "d": [
-            "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-opt-STABLE-15",
-            "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-opt-STABLE-15",
-            "//iOSApp/Source/Utils:Utils ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-7",
-            "//iOSApp/Test/TestingUtils:TestingUtils ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-7"
+            "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-opt-STABLE-15"
         ],
         "h": "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-opt-STABLE-15",
         "i": {
@@ -7376,10 +7092,6 @@
             "PRODUCT_MODULE_NAME": "tvOSApp"
         },
         "c": "applebin_tvos-tvos_arm64-dbg-STABLE-26",
-        "d": [
-            "//UI:UIFramework.tvOS applebin_tvos-tvos_arm64-dbg-STABLE-26",
-            "//UI:UIFramework.tvOS applebin_tvos-tvos_arm64-dbg-STABLE-26"
-        ],
         "i": {
             "r": [
                 "tvOSApp/Resources/PreviewContent/Preview Assets.xcassets",
@@ -7456,10 +7168,6 @@
             "SWIFT_COMPILATION_MODE": "wholemodule"
         },
         "c": "applebin_tvos-tvos_arm64-opt-STABLE-28",
-        "d": [
-            "//UI:UIFramework.tvOS applebin_tvos-tvos_arm64-opt-STABLE-28",
-            "//UI:UIFramework.tvOS applebin_tvos-tvos_arm64-opt-STABLE-28"
-        ],
         "i": {
             "r": [
                 "tvOSApp/Resources/Assets.xcassets"
@@ -7536,10 +7244,6 @@
             "PRODUCT_MODULE_NAME": "tvOSApp"
         },
         "c": "applebin_tvos-tvos_x86_64-dbg-STABLE-25",
-        "d": [
-            "//UI:UIFramework.tvOS applebin_tvos-tvos_x86_64-dbg-STABLE-25",
-            "//UI:UIFramework.tvOS applebin_tvos-tvos_x86_64-dbg-STABLE-25"
-        ],
         "i": {
             "r": [
                 "tvOSApp/Resources/PreviewContent/Preview Assets.xcassets",
@@ -7615,10 +7319,6 @@
             "SWIFT_COMPILATION_MODE": "wholemodule"
         },
         "c": "applebin_tvos-tvos_x86_64-opt-STABLE-27",
-        "d": [
-            "//UI:UIFramework.tvOS applebin_tvos-tvos_x86_64-opt-STABLE-27",
-            "//UI:UIFramework.tvOS applebin_tvos-tvos_x86_64-opt-STABLE-27"
-        ],
         "i": {
             "r": [
                 "tvOSApp/Resources/Assets.xcassets"
@@ -7824,7 +7524,6 @@
         },
         "c": "applebin_tvos-tvos_x86_64-dbg-STABLE-25",
         "d": [
-            "//tvOSApp/Source:tvOSApp applebin_tvos-tvos_x86_64-dbg-STABLE-25",
             "//tvOSApp/Source:tvOSApp applebin_tvos-tvos_x86_64-dbg-STABLE-25"
         ],
         "h": "//tvOSApp/Source:tvOSApp applebin_tvos-tvos_x86_64-dbg-STABLE-25",
@@ -7902,7 +7601,6 @@
         },
         "c": "applebin_tvos-tvos_x86_64-opt-STABLE-27",
         "d": [
-            "//tvOSApp/Source:tvOSApp applebin_tvos-tvos_x86_64-opt-STABLE-27",
             "//tvOSApp/Source:tvOSApp applebin_tvos-tvos_x86_64-opt-STABLE-27"
         ],
         "h": "//tvOSApp/Source:tvOSApp applebin_tvos-tvos_x86_64-opt-STABLE-27",
@@ -8283,10 +7981,6 @@
             "PRODUCT_MODULE_NAME": "watchOSAppExtensionUnitTestsLibrary"
         },
         "c": "applebin_watchos-watchos_x86_64-dbg-STABLE-17",
-        "d": [
-            "//UI:UIFramework.watchOS applebin_watchos-watchos_x86_64-dbg-STABLE-17",
-            "//UI:UIFramework.watchOS applebin_watchos-watchos_x86_64-dbg-STABLE-17"
-        ],
         "i": {
             "s": [
                 "watchOSAppExtension/Test/UnitTests/WatchOSAppExtensionTests.swift"
@@ -8356,10 +8050,6 @@
             "SWIFT_COMPILATION_MODE": "wholemodule"
         },
         "c": "applebin_watchos-watchos_x86_64-opt-STABLE-19",
-        "d": [
-            "//UI:UIFramework.watchOS applebin_watchos-watchos_x86_64-opt-STABLE-19",
-            "//UI:UIFramework.watchOS applebin_watchos-watchos_x86_64-opt-STABLE-19"
-        ],
         "i": {
             "s": [
                 "watchOSAppExtension/Test/UnitTests/WatchOSAppExtensionTests.swift"
@@ -8431,10 +8121,6 @@
             "PRODUCT_MODULE_NAME": "watchOSAppExtension"
         },
         "c": "applebin_watchos-watchos_arm64_32-dbg-STABLE-18",
-        "d": [
-            "//UI:UIFramework.watchOS applebin_watchos-watchos_arm64_32-dbg-STABLE-18",
-            "//UI:UIFramework.watchOS applebin_watchos-watchos_arm64_32-dbg-STABLE-18"
-        ],
         "i": {
             "r": [
                 "watchOSAppExtension/Assets.xcassets"
@@ -8507,10 +8193,6 @@
             "SWIFT_COMPILATION_MODE": "wholemodule"
         },
         "c": "applebin_watchos-watchos_arm64_32-opt-STABLE-20",
-        "d": [
-            "//UI:UIFramework.watchOS applebin_watchos-watchos_arm64_32-opt-STABLE-20",
-            "//UI:UIFramework.watchOS applebin_watchos-watchos_arm64_32-opt-STABLE-20"
-        ],
         "i": {
             "r": [
                 "watchOSAppExtension/Assets.xcassets"
@@ -8584,10 +8266,6 @@
             "PRODUCT_MODULE_NAME": "watchOSAppExtension"
         },
         "c": "applebin_watchos-watchos_x86_64-dbg-STABLE-17",
-        "d": [
-            "//UI:UIFramework.watchOS applebin_watchos-watchos_x86_64-dbg-STABLE-17",
-            "//UI:UIFramework.watchOS applebin_watchos-watchos_x86_64-dbg-STABLE-17"
-        ],
         "i": {
             "r": [
                 "watchOSAppExtension/Assets.xcassets"
@@ -8659,10 +8337,6 @@
             "SWIFT_COMPILATION_MODE": "wholemodule"
         },
         "c": "applebin_watchos-watchos_x86_64-opt-STABLE-19",
-        "d": [
-            "//UI:UIFramework.watchOS applebin_watchos-watchos_x86_64-opt-STABLE-19",
-            "//UI:UIFramework.watchOS applebin_watchos-watchos_x86_64-opt-STABLE-19"
-        ],
         "i": {
             "r": [
                 "watchOSAppExtension/Assets.xcassets"

--- a/examples/rules_ios/test/fixtures/bwb_targets_spec.json
+++ b/examples/rules_ios/test/fixtures/bwb_targets_spec.json
@@ -14,9 +14,6 @@
             "PRODUCT_MODULE_NAME": "Lib_Lib"
         },
         "c": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-2",
-        "d": [
-            "//Lib:Lib_swift ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-2"
-        ],
         "l": "//Lib:Lib",
         "n": "Lib",
         "o": {
@@ -47,9 +44,6 @@
             "PRODUCT_MODULE_NAME": "Lib_Lib"
         },
         "c": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-        "d": [
-            "//Lib:Lib_swift ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1"
-        ],
         "l": "//Lib:Lib",
         "n": "Lib",
         "o": {
@@ -82,9 +76,6 @@
             "PRODUCT_MODULE_NAME": "Lib_LibDynamic"
         },
         "c": "applebin_ios-ios_arm64-dbg-STABLE-4",
-        "d": [
-            "//Lib:Lib ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-2"
-        ],
         "l": "//Lib:LibDynamic",
         "n": "LibDynamic",
         "p": {
@@ -115,9 +106,6 @@
             "PRODUCT_MODULE_NAME": "Lib_LibDynamic"
         },
         "c": "applebin_ios-ios_x86_64-dbg-STABLE-3",
-        "d": [
-            "//Lib:Lib ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1"
-        ],
         "l": "//Lib:LibDynamic",
         "n": "LibDynamic",
         "p": {
@@ -215,10 +203,6 @@
             "PRODUCT_MODULE_NAME": "UI_UI"
         },
         "c": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-2",
-        "d": [
-            "//Lib:Lib ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-2",
-            "//UI:UI_swift ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-2"
-        ],
         "l": "//UI:UI",
         "n": "UI",
         "o": {
@@ -248,10 +232,6 @@
             "PRODUCT_MODULE_NAME": "UI_UI"
         },
         "c": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-        "d": [
-            "//Lib:Lib ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-            "//UI:UI_swift ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1"
-        ],
         "l": "//UI:UI",
         "n": "UI",
         "o": {
@@ -282,9 +262,6 @@
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "UI-Swift.h"
         },
         "c": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-2",
-        "d": [
-            "//Lib:Lib ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-2"
-        ],
         "i": {
             "s": [
                 "UI/ContentView.swift"
@@ -320,9 +297,6 @@
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "UI-Swift.h"
         },
         "c": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-        "d": [
-            "//Lib:Lib ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1"
-        ],
         "i": {
             "s": [
                 "UI/ContentView.swift"
@@ -363,9 +337,6 @@
             "TARGETED_DEVICE_FAMILY": "1"
         },
         "c": "applebin_ios-ios_arm64-dbg-STABLE-4",
-        "d": [
-            "//WidgetExtension:WidgetExtension.library ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-2"
-        ],
         "i": {
             "r": [
                 "WidgetExtension/Assets.xcassets",
@@ -401,9 +372,6 @@
             "TARGETED_DEVICE_FAMILY": "1"
         },
         "c": "applebin_ios-ios_x86_64-dbg-STABLE-3",
-        "d": [
-            "//WidgetExtension:WidgetExtension.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1"
-        ],
         "i": {
             "r": [
                 "WidgetExtension/Assets.xcassets",
@@ -443,9 +411,6 @@
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "WidgetExtension-Swift.h"
         },
         "c": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-2",
-        "d": [
-            "//Lib:Lib ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-2"
-        ],
         "i": {
             "s": [
                 "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-2/bin/WidgetExtension/Intents.Intent.output.swift",
@@ -494,9 +459,6 @@
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "WidgetExtension-Swift.h"
         },
         "c": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-        "d": [
-            "//Lib:Lib ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1"
-        ],
         "i": {
             "s": [
                 "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/WidgetExtension/Intents.Intent.output.swift",
@@ -537,10 +499,6 @@
             "PRODUCT_MODULE_NAME": "iOSApp_Source_CoreUtilsMixed_MixedAnswer_MixedAnswer"
         },
         "c": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-2",
-        "d": [
-            "//iOSApp/Source/CoreUtilsMixed/MixedAnswer:MixedAnswer_swift ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-2",
-            "//iOSApp/Source/CoreUtilsMixed/MixedAnswer:MixedAnswer_objc ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-2"
-        ],
         "l": "//iOSApp/Source/CoreUtilsMixed/MixedAnswer:MixedAnswer",
         "n": "MixedAnswer",
         "o": {
@@ -571,10 +529,6 @@
             "PRODUCT_MODULE_NAME": "iOSApp_Source_CoreUtilsMixed_MixedAnswer_MixedAnswer"
         },
         "c": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-        "d": [
-            "//iOSApp/Source/CoreUtilsMixed/MixedAnswer:MixedAnswer_swift ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-            "//iOSApp/Source/CoreUtilsMixed/MixedAnswer:MixedAnswer_objc ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1"
-        ],
         "l": "//iOSApp/Source/CoreUtilsMixed/MixedAnswer:MixedAnswer",
         "n": "MixedAnswer",
         "o": {
@@ -603,9 +557,6 @@
             "GCC_PREFIX_HEADER": "$(BAZEL_EXTERNAL)/build_bazel_rules_ios/rules/library/common.pch"
         },
         "c": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-2",
-        "d": [
-            "//iOSApp/Source/CoreUtilsMixed/MixedAnswer:MixedAnswer_swift ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-2"
-        ],
         "f": true,
         "i": {
             "s": [
@@ -633,9 +584,6 @@
             "GCC_PREFIX_HEADER": "$(BAZEL_EXTERNAL)/build_bazel_rules_ios/rules/library/common.pch"
         },
         "c": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-        "d": [
-            "//iOSApp/Source/CoreUtilsMixed/MixedAnswer:MixedAnswer_swift ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1"
-        ],
         "f": true,
         "i": {
             "s": [
@@ -735,9 +683,6 @@
             "PRODUCT_MODULE_NAME": "iOSApp_Source_CoreUtilsObjC_CoreUtilsObjC"
         },
         "c": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-2",
-        "d": [
-            "//iOSApp/Source/CoreUtilsObjC:CoreUtilsObjC_objc ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-2"
-        ],
         "l": "//iOSApp/Source/CoreUtilsObjC:CoreUtilsObjC",
         "n": "CoreUtilsObjC",
         "p": {
@@ -763,9 +708,6 @@
             "PRODUCT_MODULE_NAME": "iOSApp_Source_CoreUtilsObjC_CoreUtilsObjC"
         },
         "c": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-        "d": [
-            "//iOSApp/Source/CoreUtilsObjC:CoreUtilsObjC_objc ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1"
-        ],
         "l": "//iOSApp/Source/CoreUtilsObjC:CoreUtilsObjC",
         "n": "CoreUtilsObjC",
         "p": {
@@ -846,9 +788,6 @@
             "PRODUCT_MODULE_NAME": "iOSApp_Source_Utils_Utils"
         },
         "c": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-        "d": [
-            "//iOSApp/Source/Utils:Utils_objc ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1"
-        ],
         "l": "//iOSApp/Source/Utils:Utils",
         "n": "Utils",
         "p": {
@@ -872,9 +811,6 @@
             "GCC_PREFIX_HEADER": "$(BAZEL_EXTERNAL)/build_bazel_rules_ios/rules/library/common.pch"
         },
         "c": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-        "d": [
-            "//iOSApp/Source/CoreUtilsObjC:CoreUtilsObjC ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1"
-        ],
         "f": true,
         "i": {
             "s": [
@@ -913,12 +849,6 @@
             "TARGETED_DEVICE_FAMILY": "1"
         },
         "c": "applebin_ios-ios_arm64-dbg-STABLE-4",
-        "d": [
-            "//iOSApp/Source:iOSApp.library ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-2",
-            "//UI:UI ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-2",
-            "//iOSApp/Source/CoreUtilsObjC:CoreUtilsObjC ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-2",
-            "//WidgetExtension:WidgetExtension applebin_ios-ios_arm64-dbg-STABLE-4"
-        ],
         "e": [
             "//WidgetExtension:WidgetExtension applebin_ios-ios_arm64-dbg-STABLE-4"
         ],
@@ -967,12 +897,6 @@
             "TARGETED_DEVICE_FAMILY": "1"
         },
         "c": "applebin_ios-ios_x86_64-dbg-STABLE-3",
-        "d": [
-            "//iOSApp/Source:iOSApp.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-            "//UI:UI ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-            "//iOSApp/Source/CoreUtilsObjC:CoreUtilsObjC ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-            "//WidgetExtension:WidgetExtension applebin_ios-ios_x86_64-dbg-STABLE-3"
-        ],
         "e": [
             "//WidgetExtension:WidgetExtension applebin_ios-ios_x86_64-dbg-STABLE-3"
         ],
@@ -1021,11 +945,6 @@
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "iOSApp-Swift.h"
         },
         "c": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-2",
-        "d": [
-            "//UI:UI ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-2",
-            "//iOSApp/Source/CoreUtilsMixed/MixedAnswer:MixedAnswer ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-2",
-            "//iOSApp/Source/CoreUtilsObjC:CoreUtilsObjC ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-2"
-        ],
         "i": {
             "s": [
                 "iOSApp/Source/iOSApp.swift"
@@ -1073,11 +992,6 @@
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "iOSApp-Swift.h"
         },
         "c": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-        "d": [
-            "//UI:UI ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-            "//iOSApp/Source/CoreUtilsMixed/MixedAnswer:MixedAnswer ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-            "//iOSApp/Source/CoreUtilsObjC:CoreUtilsObjC ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1"
-        ],
         "i": {
             "s": [
                 "iOSApp/Source/iOSApp.swift"
@@ -1144,8 +1058,6 @@
         },
         "c": "applebin_ios-ios_x86_64-dbg-STABLE-3",
         "d": [
-            "//iOSApp/Source:iOSApp.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-            "//iOSApp/Source/Utils:Utils ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
             "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-dbg-STABLE-3"
         ],
         "f": true,
@@ -1207,8 +1119,6 @@
         },
         "c": "applebin_ios-ios_x86_64-dbg-STABLE-3",
         "d": [
-            "//iOSApp/Source:iOSApp.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-            "//iOSApp/Source/Utils:Utils ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
             "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-dbg-STABLE-3"
         ],
         "f": true,
@@ -1262,8 +1172,6 @@
         },
         "c": "applebin_ios-ios_x86_64-dbg-STABLE-3",
         "d": [
-            "//iOSApp/Source:iOSApp.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-            "//iOSApp/Source/Utils:Utils ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
             "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-dbg-STABLE-3"
         ],
         "f": true,
@@ -1317,8 +1225,6 @@
         },
         "c": "applebin_ios-ios_x86_64-dbg-STABLE-3",
         "d": [
-            "//iOSApp/Source:iOSApp.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-            "//iOSApp/Source/Utils:Utils ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
             "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-dbg-STABLE-3"
         ],
         "f": true,
@@ -1372,8 +1278,6 @@
         },
         "c": "applebin_ios-ios_x86_64-dbg-STABLE-3",
         "d": [
-            "//iOSApp/Source:iOSApp.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-            "//iOSApp/Source/Utils:Utils ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
             "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-dbg-STABLE-3"
         ],
         "f": true,
@@ -1427,8 +1331,6 @@
         },
         "c": "applebin_ios-ios_x86_64-dbg-STABLE-3",
         "d": [
-            "//iOSApp/Source:iOSApp.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-            "//iOSApp/Source/Utils:Utils ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
             "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-dbg-STABLE-3"
         ],
         "f": true,
@@ -1487,8 +1389,6 @@
         },
         "c": "applebin_ios-ios_x86_64-dbg-STABLE-3",
         "d": [
-            "//iOSApp/Source:iOSApp.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-            "//iOSApp/Source/Utils:Utils ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
             "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-dbg-STABLE-3"
         ],
         "h": "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-dbg-STABLE-3",
@@ -1552,8 +1452,6 @@
         },
         "c": "applebin_ios-ios_x86_64-dbg-STABLE-3",
         "d": [
-            "//iOSApp/Source:iOSApp.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-            "//iOSApp/Source/Utils:Utils ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
             "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-dbg-STABLE-3"
         ],
         "h": "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-dbg-STABLE-3",

--- a/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
@@ -22,22 +22,21 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
-		03416C5B570486FEDD4437D9 /* CreateProjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 923AF33D912B04AC283BF4BB /* CreateProjectTests.swift */; };
 		0455C142CD9D26A84CA2E13F /* ArgumentHelp.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD87EF40B153D049E7495479 /* ArgumentHelp.swift */; };
 		04B698A2272DBDCBF8E0F4E9 /* _HashTable+CustomStringConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = E66A1C3F2E30D98458407796 /* _HashTable+CustomStringConvertible.swift */; };
 		050445C6BF629B87B70E4BD9 /* XCScheme+LocationScenarioReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B9EE1950B6ED6178BCABC07 /* XCScheme+LocationScenarioReference.swift */; };
-		06C242CB0FC1647D23E5CC54 /* CreateCustomXCSchemesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0EF3CEC5B326041C5DCAC7C /* CreateCustomXCSchemesTests.swift */; };
+		06F6CCF518F94F29FC28B537 /* BuildSettingConditionalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ECF7D1F9A353FED519E08C1 /* BuildSettingConditionalTests.swift */; };
 		074234ADCE2421EC7B297782 /* ParsableCommand+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C88CDFBE298CE4246EDCF65 /* ParsableCommand+Extensions.swift */; };
 		082AEC14E80DEE1A5C16D674 /* OrderedDictionary+Partial RangeReplaceableCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5735A36C579FBC574BE77EE0 /* OrderedDictionary+Partial RangeReplaceableCollection.swift */; };
+		0865944F5F1B07E3BB7C8807 /* SetTargetDependenciesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FBABC6E30E2C6DCC523F190 /* SetTargetDependenciesTests.swift */; };
 		08D0D2F90B76B03CED46FBAE /* PBXBuildRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 793BCDB3D93B087C19673CB2 /* PBXBuildRule.swift */; };
 		0984BEFB2CC925BFEDD53E55 /* PBXObjectReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4D11997D2B16524A880BC9F /* PBXObjectReference.swift */; };
 		09D170246DCF41369D284DEE /* StringExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 971D60FC57CA36A0F4D81843 /* StringExtensions.swift */; };
 		0A77469F07E6DC1DAA0F6F85 /* XCSchemeManagement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 546B3741F154A09AE65A46C4 /* XCSchemeManagement.swift */; };
+		0B281555742C6F8C6EBF0FBE /* TargetIDConsolidatedTargetKeyDictionary+ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2C17B6B53A88AC72F96CE27 /* TargetIDConsolidatedTargetKeyDictionary+ExtensionsTests.swift */; };
 		0B4469624B56DA4953088D95 /* OrderedDictionary+Values.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB2E3201F630521CA0B28B14 /* OrderedDictionary+Values.swift */; };
-		0B4E35D4EB957952588C1423 /* CreateXCUserDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB3FF798D71A31AAE9690F88 /* CreateXCUserDataTests.swift */; };
-		0BF9C67DD986906F3AE15784 /* XCSchemeInfo+HostInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB9FD956FD80453BF9B1BDA7 /* XCSchemeInfo+HostInfoTests.swift */; };
 		0C02E43166F6835CCCC49A2D /* CreateXCUserData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A8DC8CC910A9778FCAADD5D /* CreateXCUserData.swift */; };
-		0D0588E5D7507DA45D6DE2D7 /* CreateFilesAndGroupsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F96FE230883F3D7F990DFE9B /* CreateFilesAndGroupsTests.swift */; };
+		0CB991EA4563DABD4049576B /* PBXProductTypeExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 803399FC4252CE057DBC30BD /* PBXProductTypeExtensionsTests.swift */; };
 		0D3FFA6E37591D066D2E84F5 /* XCScheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C5E16F38026EE59A0E7C695 /* XCScheme.swift */; };
 		0D9203E3FEDF14A6B9F7C6BC /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8AB0BC12F8507E59068989F /* Logger.swift */; };
 		0DAB38A0245A8A172824EB09 /* PathKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BDBBE8451AEEFF47570DECC /* PathKit.swift */; };
@@ -45,26 +44,28 @@
 		0DFCC8FA442D176113B60162 /* MessageInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374D7C5B851F26CF005224BF /* MessageInfo.swift */; };
 		0EF3948F5027DFFBE4807877 /* XCScheme+BuildAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE2F53D433491DD8A63759EF /* XCScheme+BuildAction.swift */; };
 		0F232DEBCD2FE4FD8DC74022 /* _HashTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28E71CBA2C89431345B1797E /* _HashTable.swift */; };
-		10C66F27D038A118CCABE0F3 /* SetTargetDependenciesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FBABC6E30E2C6DCC523F190 /* SetTargetDependenciesTests.swift */; };
+		0F486596F7688856F9B9E3CC /* Array+ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7F9BDF86C2A6BB71927E17D /* Array+ExtensionsTests.swift */; };
 		11510746C86AAEEBEE30F6EC /* _HashTable+Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 927194992F298C79462A7EA2 /* _HashTable+Constants.swift */; };
+		126DC6EA1323478BE8A0BC26 /* CreateProductsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA624D3E5B594905293DD60C /* CreateProductsTest.swift */; };
 		12A173B63A1903BF38FFB001 /* Unordered.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A64691F9E08CF48FAE969DD /* Unordered.swift */; };
-		13673DB7CBFBA4795F6512F1 /* AddTargetsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D9780A462599256657D870D /* AddTargetsTests.swift */; };
 		1413F2C15F76E26AD24BDD71 /* HelpCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC6DE0D2EB08C4AD710C4424 /* HelpCommand.swift */; };
 		14455140F16D5245AFDE355E /* TargetID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46CE806C1960DB541A12968C /* TargetID.swift */; };
 		14843911F52A52FC2C7F6EE6 /* Target.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38815BD649A6C0E1A9F7E7E7 /* Target.swift */; };
 		14944FAD1D8421CF96EAB3F4 /* XCScheme+TestPlanReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 533ABB8646E73C47BF808999 /* XCScheme+TestPlanReference.swift */; };
 		15175D0D669FD8D1B7E6F145 /* String+Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F1B6A25F58F192264CBF34 /* String+Utils.swift */; };
+		15FE35D9681C4F4ED15E1A26 /* XCSchemeInfo+LaunchActionInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C5B95390F1F4F1BB0AE7787 /* XCSchemeInfo+LaunchActionInfoTests.swift */; };
 		18991DB1CC72376B2C785B18 /* Flag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F7B8B37B95720D23BC819BA /* Flag.swift */; };
 		18DD7BAC85D582B036AE2207 /* SetTargetConfigurations.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1BCF1F208925EA2E19ED05B /* SetTargetConfigurations.swift */; };
 		1A878FB05DFE6B904AB012C4 /* XCWorkspaceDataElementLocationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 410DAFF236D0BF9F0382E239 /* XCWorkspaceDataElementLocationType.swift */; };
+		1B052790107B8EADD7C73FA9 /* ConsolidatedTargetExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0476FAE400008FA0690CBDD5 /* ConsolidatedTargetExtensionsTests.swift */; };
 		1BD25D154234A489921A40F2 /* UserNotifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A03F2100ED2A0B1E4CABDD3 /* UserNotifications.swift */; };
 		1C6F1BBA52B2BE5533401B9C /* XcodeScheme+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9481E86328952F03D5AFC61C /* XcodeScheme+Extensions.swift */; };
-		1D5502EDA1C64C69FEAF796E /* ConsolidatedTargetExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0476FAE400008FA0690CBDD5 /* ConsolidatedTargetExtensionsTests.swift */; };
 		1DDC6B04E5E3CBB4CD0CE3F7 /* XCWorkspaceDataGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DB2C9086DD87FA16ED7E250 /* XCWorkspaceDataGroup.swift */; };
 		1DFA0D6803FBBEDD8572255F /* ArgumentSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4425FBACAEE73F6BE098752C /* ArgumentSet.swift */; };
 		1E1FCC658303A7ABEA644223 /* AEXML+XcodeFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C648D63207BCA6CB6EEEEA /* AEXML+XcodeFormat.swift */; };
 		1F10E793C76FD43596272C24 /* CalculateXcodeGeneratedFiles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B3507EEAD58F9F13BF4947 /* CalculateXcodeGeneratedFiles.swift */; };
 		1F3D82B6BD4C9D725CCE678E /* Path+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 183888B2FF0D977B9E25A0C5 /* Path+Extras.swift */; };
+		20CA514B9BC2A26A0906C561 /* CreateXCSharedDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 002DED77E7361AE266EDCEDA /* CreateXCSharedDataTests.swift */; };
 		20E18192D56898A7A98D0F8B /* XCSchemeEnvironmentVariables+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F02D02B4A12496FAF44C69 /* XCSchemeEnvironmentVariables+Extensions.swift */; };
 		232AAAF7C994B8D78FB5694F /* XCVersionGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 457E4F02FE952FFC72E9E42C /* XCVersionGroup.swift */; };
 		23479CFC98820672D4779864 /* BuildSettingsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = F175C5105656B0FE5711E54C /* BuildSettingsProvider.swift */; };
@@ -80,62 +81,52 @@
 		2D067425CC4F6E8801E2E375 /* XCScheme+ProfileAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29E2DA1D45F723ECBAAC8E10 /* XCScheme+ProfileAction.swift */; };
 		2D146B46BCE2EE46605E1E98 /* BuildSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67089F980716FCDF835D2731 /* BuildSettings.swift */; };
 		2F75B36FA1FB56988604D305 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34F9044C94AF3C2BD45C6FC3 /* main.swift */; };
-		30FF4F30CCA0229707503CC1 /* XcodeScheme+ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5E5E615A113FFB8B140036C /* XcodeScheme+ExtensionsTests.swift */; };
 		312BABBD457AFB2C0549266A /* PBXProject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48CDD39F7A904677DEAAC1C7 /* PBXProject.swift */; };
 		3162AA0DD15534F6880F0B8D /* CreateCustomXCSchemes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E1E914E465528F95447E0D2 /* CreateCustomXCSchemes.swift */; };
-		31E93E5AB4ABAB06534B6AFD /* Platform+ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A4924FE926E9BEAADE9F74B /* Platform+ExtensionsTests.swift */; };
 		336B42C5A2B6ADAFF6AD35CA /* XCDebugger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75B30EFE0183B8D7DA0EEC4B /* XCDebugger.swift */; };
-		338A1BC7C5850B7FADFAC91F /* XcodeSchemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8628BAAFC23DB1FB2F99F192 /* XcodeSchemeTests.swift */; };
+		33CC8E47DE7A7730E395C386 /* SetTargetConfigurationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3929AF90EB332967FFDF6C6D /* SetTargetConfigurationsTests.swift */; };
+		34BA592214CFDF935F31EB55 /* Platform+ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A4924FE926E9BEAADE9F74B /* Platform+ExtensionsTests.swift */; };
 		35B11AE1095B5B3216906D0D /* XCUserData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07A7F5735BBF0937CCB34B74 /* XCUserData.swift */; };
 		3635CDA6766D531B6617CA2A /* XCWorkspaceDataElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = C77483031BF239504F305D93 /* XCWorkspaceDataElement.swift */; };
+		368E7AB1F5DD66541ED65FA3 /* XCSchemeInfo+PrePostActionInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C8322799EAAE41C1833E5D8 /* XCSchemeInfo+PrePostActionInfoTests.swift */; };
 		36E94F07A9F68E7E61170C2C /* OrderedDictionary+Deprecations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62A27B46C4FC033CAAE7A0B2 /* OrderedDictionary+Deprecations.swift */; };
+		378D57513B4A7DC2895B50B7 /* XCSchemeInfo+BuildActionInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D707A379373ABF6913737C92 /* XCSchemeInfo+BuildActionInfoTests.swift */; };
 		37ED9378C56817A8468BE8B0 /* OrderedSet+Partial SetAlgebra+Basics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FF60B4EE41AA39BF8BE4AA3 /* OrderedSet+Partial SetAlgebra+Basics.swift */; };
-		3891829A66D8108CE81570D6 /* PBXProj+Testing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4458CEBDA3C4FD40FF360E7E /* PBXProj+Testing.swift */; };
-		3929E9E8AE690E4F6AA32C25 /* Optional+ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF8A4999C790B01B02BFF3D6 /* Optional+ExtensionsTests.swift */; };
 		39FE8D6098E291F1E003ED19 /* OrderedDictionary+Codable.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDB00AEB74C1EBA77CB5A346 /* OrderedDictionary+Codable.swift */; };
 		3ABAC9D6BBC6012C1B94F255 /* PBXBatchUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A1ED07486D10DDAA9F681F7 /* PBXBatchUpdater.swift */; };
+		3B267216E076CF5A2E84FB0D /* XcodeScheme+ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5E5E615A113FFB8B140036C /* XcodeScheme+ExtensionsTests.swift */; };
 		3CFDABB5BECD7DFCC386F79F /* OrderedSet+UnorderedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12E9F366756D2F90DB8EA58C /* OrderedSet+UnorderedView.swift */; };
 		3D0634EAE7D894FD0D4B04AA /* PBXProductType+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10A093241387A049621EF0A8 /* PBXProductType+Extensions.swift */; };
 		3D960F091B3C378AD19971F4 /* OrderedSet+ExpressibleByArrayLiteral.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28C1C02F6539D5429492028 /* OrderedSet+ExpressibleByArrayLiteral.swift */; };
+		3E2E98C4E36B791F3878DD6F /* Fixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC351AAD5976C7516B75C330 /* Fixtures.swift */; };
 		3E54D16F38E6B8046E5440DF /* Main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D9A2FF9299708990D216849 /* Main.swift */; };
 		3EE801C86E4315C14C6EDC19 /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E3410784B3DCFECBA6F4ADD /* String.swift */; };
-		4017497FA71F745C88BAB4B1 /* XCSchemeInfo+BuildActionInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D707A379373ABF6913737C92 /* XCSchemeInfo+BuildActionInfoTests.swift */; };
-		410CC6B7DB3511BD39FF1752 /* XCSchemeInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A29B3E9211815B1576208716 /* XCSchemeInfoTests.swift */; };
-		41578E99F673783F8B2AFC86 /* ConsolidateTargetsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9585A860897E21F841443E57 /* ConsolidateTargetsTests.swift */; };
 		4205D8169B745E194D3F9B7E /* PBXFileElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79635341E1D4711836249329 /* PBXFileElement.swift */; };
 		426BDD5BA5ECCE96EAC03184 /* OrderedSet+Initializers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02303D78B9A2B3A3BEEC055C /* OrderedSet+Initializers.swift */; };
 		428996F06DD5289E7BE01B56 /* PBXCopyFilesBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E3216CC232BADA4DD21C08F /* PBXCopyFilesBuildPhase.swift */; };
 		43174BC6C787D599A2DEFBD8 /* XCScheme+BuildableReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8319AE5C0A6E40DC06DE42B8 /* XCScheme+BuildableReference.swift */; };
 		431FDBAFC4E38625714B44B7 /* PBXGroup+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEDDD15FC6C873F6EE65ECE3 /* PBXGroup+Extensions.swift */; };
-		440BB9EE0DD26F1EA1328EA7 /* TargetIDTargetDictionary+ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F30B98D650DBB52F06D31885 /* TargetIDTargetDictionary+ExtensionsTests.swift */; };
-		4451386AB0E2F65BCB20EE55 /* PBXProductTypeExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 803399FC4252CE057DBC30BD /* PBXProductTypeExtensionsTests.swift */; };
 		44B8F6662DB679E207CC3149 /* XCScheme+BuildableProductRunnable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7906D48BABCF9BD75AFB3C2C /* XCScheme+BuildableProductRunnable.swift */; };
-		451E14EDFD86EE2A635537BB /* CreateProjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 923AF33D912B04AC283BF4BB /* CreateProjectTests.swift */; };
 		45740E9078C83151988B7FB1 /* PBXContainerItemProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87AE89B89AD33F52B8289D56 /* PBXContainerItemProxy.swift */; };
-		47AE14B2FCDCA1D66DFAA3BF /* TargetIDConsolidatedTargetKeyDictionary+ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2C17B6B53A88AC72F96CE27 /* TargetIDConsolidatedTargetKeyDictionary+ExtensionsTests.swift */; };
+		46266870EC4CF96FE881625A /* PBXProj+Testing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4458CEBDA3C4FD40FF360E7E /* PBXProj+Testing.swift */; };
 		49267699896430024EF88F92 /* Xcode.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDA3D3ED9E77789A81EB0858 /* Xcode.swift */; };
-		497360214F6E631F1F3867CD /* BazelLabel+TestExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D38932B464EC5D386812A550 /* BazelLabel+TestExtensions.swift */; };
 		4A70ACB74773BBDB28515F91 /* Argument.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA7F56A6F52E5E4A95671B6F /* Argument.swift */; };
 		4B110B493639BF1B6963ECA2 /* XCScheme+TestAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4328278DD4D7309B9B2D7A77 /* XCScheme+TestAction.swift */; };
-		4B27712B5700EAED713F3BB2 /* XCSchemeInfo+BuildActionInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D707A379373ABF6913737C92 /* XCSchemeInfo+BuildActionInfoTests.swift */; };
 		4BC3442D9DA9220F3C58A85C /* Equality.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81A12C76034EA334B582EB28 /* Equality.generated.swift */; };
 		4BC8DA04570520951C9A0059 /* ArgumentDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = F17A484BA32D4C9CD6FB4678 /* ArgumentDecoder.swift */; };
-		4CFA7835DB277BA2AF2DE3AC /* CreateXcodeProjTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9412FD5ABF1BB294A8DA48D /* CreateXcodeProjTests.swift */; };
 		4DE287E416E0D31372FBB704 /* OrderedSet+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24DF495CC1D6BC20F4F31C56 /* OrderedSet+Equatable.swift */; };
 		4F5895E4F5B75DB24A9F3809 /* FishCompletionsGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17BA3FC6452EFABAD0213FD4 /* FishCompletionsGenerator.swift */; };
 		4F59F9503226777C61F34605 /* Dump.swift in Sources */ = {isa = PBXBuildFile; fileRef = 355D3852EBC28DB906DECBA5 /* Dump.swift */; };
 		4FA3C97CB9E24A252364BBCF /* OrderedSet+CustomStringConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4571EBCBE529D1092CE07F0F /* OrderedSet+CustomStringConvertible.swift */; };
-		4FAF39013EEE169D4BD611B3 /* XCSchemeInfo+PrePostActionInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C8322799EAAE41C1833E5D8 /* XCSchemeInfo+PrePostActionInfoTests.swift */; };
 		502551F488D5A386A35B3BCF /* CommentedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B414E2D9DC7C38D7FA4A1E9 /* CommentedString.swift */; };
 		52278C014D007807AC088CEA /* XCWorkspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47EF7AD14396F267B8DD40D4 /* XCWorkspace.swift */; };
-		53102E6881AB59008DC74EAF /* Fixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC351AAD5976C7516B75C330 /* Fixtures.swift */; };
-		53C2D694F0A99BA6F5897D49 /* TargetIDTargetDictionary+ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F30B98D650DBB52F06D31885 /* TargetIDTargetDictionary+ExtensionsTests.swift */; };
-		5417FEC528A0CA447C2E3937 /* Target+Testing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 089203287CD3B51EA341E13A /* Target+Testing.swift */; };
+		5431E3884ABC775C789D38E2 /* CreateAutogeneratedXCSchemesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31C36193F884D8B5CA900ED2 /* CreateAutogeneratedXCSchemesTests.swift */; };
 		556FE0FF675703C69BF85DCE /* Option.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1EF55A00478BD2592B6E39D /* Option.swift */; };
 		55A1251FAB1E8B279F0B4377 /* XcodeProj.swift in Sources */ = {isa = PBXBuildFile; fileRef = E03B795C7F5111B156BDD48C /* XcodeProj.swift */; };
 		55A333F7CF62A1223068E232 /* PBXTarget+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 850D940E7AAE468F040AFC73 /* PBXTarget+Extensions.swift */; };
 		55EA8B6C84FE1B33ED4653F6 /* PBXTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDE15F06C413D5F5DE67A541 /* PBXTarget.swift */; };
 		5644250367D7D28A74DEDC46 /* PBXHeadersBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FC32D82BA9F766FD3ECC2E7 /* PBXHeadersBuildPhase.swift */; };
+		5658F45404CE0842C937C042 /* CreateXCUserDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB3FF798D71A31AAE9690F88 /* CreateXCUserDataTests.swift */; };
 		56C8ED2B80DE2441296F861F /* XCSchemeInfo+TestActionInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC67D2A23DA0579FD33B70C /* XCSchemeInfo+TestActionInfo.swift */; };
 		58027D3575A187C714F5DECB /* XCScheme+SerialAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 772A4F322021DF772649C5D2 /* XCScheme+SerialAction.swift */; };
 		58C69072F53B575E5F6D8A55 /* GameKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87C288E8B505CBC743498DFE /* GameKit.swift */; };
@@ -148,13 +139,11 @@
 		5AAF2D46681920BD01FAC6AE /* OrderedDictionary+Partial MutableCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = F94627455FFA7FCCA735F33B /* OrderedDictionary+Partial MutableCollection.swift */; };
 		5B7D275B99E7B3BC126EBB74 /* PBXFileReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = C08F83573E75B0A81D02E452 /* PBXFileReference.swift */; };
 		5CCDAE9815B52D4BCC8E686A /* CoreMotion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D93C8FAE38FC6163A79D679 /* CoreMotion.swift */; };
-		5F3DDFEA3E9151D8589BCD8D /* PBXTarget+ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04FB1C1818CB43F134D2BDD3 /* PBXTarget+ExtensionsTests.swift */; };
-		602CAD18311C1CC452A8B3B7 /* XCSchemeInfo+TestActionInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A952722F65B7419585B1B350 /* XCSchemeInfo+TestActionInfoTests.swift */; };
 		6041FB45497D25D0F455619C /* Path+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C531C7B894375B09CFECC678 /* Path+Extensions.swift */; };
 		6049CE2E129A66635A503EDC /* RandomAccessCollection+Offsets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 333F375C875241DA03ABBB16 /* RandomAccessCollection+Offsets.swift */; };
 		606999E3FA6765E28DF1330D /* CustomDumpRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3ECFC487FD7A61242A9A577 /* CustomDumpRepresentable.swift */; };
+		616823ED96158871734EC7E7 /* ConsolidateTargetsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9585A860897E21F841443E57 /* ConsolidateTargetsTests.swift */; };
 		628549310A673C6CFB0CAFCB /* OrderedSet+CustomDebugStringConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DE3346822D6A291178332B8 /* OrderedSet+CustomDebugStringConvertible.swift */; };
-		62A0CBA0774481AB886F4868 /* XCSchemeInfo+LaunchActionInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C5B95390F1F4F1BB0AE7787 /* XCSchemeInfo+LaunchActionInfoTests.swift */; };
 		633EF35D16A9F325041323E5 /* JSONDecoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF5848041FB2388D015D915 /* JSONDecoding.swift */; };
 		63900E87E85E95B2C9046989 /* CoreImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01587D56EDD0EF0F572BBEA6 /* CoreImage.swift */; };
 		63FB339F227DF2FAD0155D1A /* CustomDumpStringConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EB188B7E5168DDC740E3836 /* CustomDumpStringConvertible.swift */; };
@@ -163,25 +152,17 @@
 		65B35912635F233CF8EE2383 /* BuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E11CEE7C8D4EC4E2A57791E /* BuildPhase.swift */; };
 		65B92836BFA6477991CE6850 /* EnumerableFlag.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8511A1F2E56E9F9D58C4E5E /* EnumerableFlag.swift */; };
 		65DE23788CD6E6BC6793BD8D /* Name.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8B479936248BB7B1E6853BA /* Name.swift */; };
-		6647B037B4F6B6639FCE0255 /* BazelLabelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DD1CFC2C244CE1BCF2EFBEE /* BazelLabelTests.swift */; };
-		665CC039AE8F014CF0037D09 /* SetTargetDependenciesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FBABC6E30E2C6DCC523F190 /* SetTargetDependenciesTests.swift */; };
-		6737CFDC50ED3CF0E6CD0D82 /* CreateProductsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA624D3E5B594905293DD60C /* CreateProductsTest.swift */; };
-		6766FD137C3A8812D583F21A /* DisambiguateTargetsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29187B7B91F51C6C267E9D39 /* DisambiguateTargetsTests.swift */; };
 		6844017F50EA4A8677BC6F04 /* OrderedSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D7021024F27F269D7A8691 /* OrderedSet.swift */; };
 		68A45865199284D5597A6BBF /* SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9737B85BF6317C682E8597A3 /* SwiftUI.swift */; };
-		6915F69F36EEF9AD28ECDD73 /* BazelLabel+TestExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D38932B464EC5D386812A550 /* BazelLabel+TestExtensions.swift */; };
-		6957A8090F71A97C66C31B16 /* BazelLabelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DD1CFC2C244CE1BCF2EFBEE /* BazelLabelTests.swift */; };
+		6920C4E11D16C63A0A539636 /* XcodeSchemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8628BAAFC23DB1FB2F99F192 /* XcodeSchemeTests.swift */; };
 		69ED784A058F0C64D3AAA433 /* OrderedDictionary+Invariants.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD5409ECB7AD799A19F8BD03 /* OrderedDictionary+Invariants.swift */; };
 		6A4ACC9419CB3961CF3DF733 /* Platform.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA823FB63040E3B95F398281 /* Platform.swift */; };
-		6AD8A3F1432E501376A90831 /* CreateXCSharedDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 002DED77E7361AE266EDCEDA /* CreateXCSharedDataTests.swift */; };
 		6C58B25548E64962BAEC6D29 /* Project.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA27470FB01722B89D109F56 /* Project.swift */; };
 		6D848DB7F08B072A6088811A /* OrderedSet+UnstableInternals.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5FF557B7B1D208E940BC8CE /* OrderedSet+UnstableInternals.swift */; };
 		6E760B074583038B1B2E3DD5 /* PBXReferenceProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = F191467990E7C675CA282A26 /* PBXReferenceProxy.swift */; };
 		6E7B20C7957B27D818D27ED2 /* ZippyJSONDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79D84F6718222FA7C662ED56 /* ZippyJSONDecoder.swift */; };
 		6EB7774B7BB14E70D8D263D8 /* PBXRezBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8A3E5A993AEE45CE7217367 /* PBXRezBuildPhase.swift */; };
-		6F352F13B291659C236B5FA6 /* CreateAutogeneratedXCSchemesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31C36193F884D8B5CA900ED2 /* CreateAutogeneratedXCSchemesTests.swift */; };
-		70387B1E48C2965836EF186A /* XCSchemeEnvironmentVariablesExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14E2BB4F5DEC9797A241E041 /* XCSchemeEnvironmentVariablesExtensionsTests.swift */; };
-		70492AA4724E71202A1C300D /* DirectoriesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7A9A1CA4B76989D3D96B70D /* DirectoriesTests.swift */; };
+		701FB39843ECA095DCA151D1 /* CreateProjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 923AF33D912B04AC283BF4BB /* CreateProjectTests.swift */; };
 		70DED6F14CE030549D5543A8 /* OrderedDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6629B43106377EA0D88F5E3 /* OrderedDictionary.swift */; };
 		71B39134D8B7E8F561920AB6 /* KeyPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B1EED3630789FEA1A31DA13 /* KeyPath.swift */; };
 		72D5B42A9C023EC1622BD86B /* ArgumentVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 761F6999B4C3D56519CE85FE /* ArgumentVisibility.swift */; };
@@ -189,70 +170,54 @@
 		72F52A4E9DCDD227C3B2E67E /* PBXObjects.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F54CAA13BAE72E18E91440 /* PBXObjects.swift */; };
 		732ADC43ABD44D8EDC2F878C /* XCSchemeInfo+ProfileActionInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56CECFE349799F37E952F266 /* XCSchemeInfo+ProfileActionInfo.swift */; };
 		735BEC9BDB8D1BDEE79378B2 /* Dictionary+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B26DC537FDC1D77B606CEF3 /* Dictionary+Extras.swift */; };
-		745699294D7E0C6500A7C69D /* XCSchemeInfo+TargetInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54E0D35563D6173B30B12BCB /* XCSchemeInfo+TargetInfoTests.swift */; };
-		747F317E25DA762448FFBBC7 /* TargetIDConsolidatedTargetKeyDictionary+ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2C17B6B53A88AC72F96CE27 /* TargetIDConsolidatedTargetKeyDictionary+ExtensionsTests.swift */; };
 		74F84D13681D2E5051836186 /* PBXVariantGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0314B9F1B691771DC543F8A /* PBXVariantGroup.swift */; };
 		752B6561B5B4D8F03E13CA1F /* CompletionsGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 488C1FE4FA3657705703CD19 /* CompletionsGenerator.swift */; };
 		75B0B442C7E9EF2B8424C740 /* XCWorkspaceDataFileRef.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7A0B1FD74B7719CE5808DBA /* XCWorkspaceDataFileRef.swift */; };
+		75B6D016F0844FA4F96DB047 /* XCSchemeInfo+BuildTargetInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16ADAFFC466896D163F74D22 /* XCSchemeInfo+BuildTargetInfoTests.swift */; };
 		75BECF5D69ED32D23D97F539 /* Sorting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39C87CA00B7DC860C70F60A1 /* Sorting.swift */; };
 		763BD38172FA4042F9AAE048 /* OrderedDictionary+ExpressibleByDictionaryLiteral.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FE9BDF9FA947B41DF5EDC57 /* OrderedDictionary+ExpressibleByDictionaryLiteral.swift */; };
+		764D00E02A1135C735045C33 /* XCSchemeInfo+TargetInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54E0D35563D6173B30B12BCB /* XCSchemeInfo+TargetInfoTests.swift */; };
 		77B281CD3F4F3F4C34C4D7A7 /* OrderedDictionary+CustomDebugStringConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F4EF889B94BDAAA60458FC0 /* OrderedDictionary+CustomDebugStringConvertible.swift */; };
 		77C4E2252EA5FD48D120898B /* BazelLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68A3590C7B9B4FFBF56C0AB3 /* BazelLabel.swift */; };
 		77EFE44BF3B17AD960D4201F /* ParsedValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = 793EECD7DC5512261AEB0C03 /* ParsedValues.swift */; };
-		7829FB2A71031BFE5C916156 /* Array+ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7F9BDF86C2A6BB71927E17D /* Array+ExtensionsTests.swift */; };
-		797768A32A4A028AEA052B9F /* XcodeScheme+BuildForTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C1D1EC065B5A867A43419E8 /* XcodeScheme+BuildForTests.swift */; };
-		798CDEAFF42E17EEE2A046E3 /* Dictionary+ExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C07E4B4AB850F09438EFDFCD /* Dictionary+ExtensionTests.swift */; };
 		7A497A17695CC25196C084CF /* Mirror.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EFAFE544A0DDD36579388A4 /* Mirror.swift */; };
 		7A6EEB5EEA98ADA75EB272B1 /* XCConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD7319AF3B1B1F41DB40845D /* XCConfig.swift */; };
 		7AE99E7DCA8F50FFAB73EEF2 /* CollectionExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DA2BF94565D94AEA2D4127C /* CollectionExtensions.swift */; };
 		7B3666637325D2186FDEAE87 /* PBXProj.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6528033D7641101DC177616A /* PBXProj.swift */; };
-		7B4C90F96F06083E8AA08DDA /* XcodeProj+CustomDump.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE23484580120E99275637EC /* XcodeProj+CustomDump.swift */; };
 		7B4E017E8AA3A327198F5589 /* XCScheme+AditionalOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AA8E3DFBF88D478DA744D47 /* XCScheme+AditionalOption.swift */; };
 		7B6370652C27D3DC996A2984 /* OrderedDictionary+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6696B7215C4E28CB3E0B03CB /* OrderedDictionary+Equatable.swift */; };
 		7BCC3242C4E220B3D67B1DBE /* _HashTable+Testing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9688BD6C1EA3B2E2C399BBB4 /* _HashTable+Testing.swift */; };
-		7C0C13C8E651DF61FCE1F447 /* CreateCustomXCSchemesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0EF3CEC5B326041C5DCAC7C /* CreateCustomXCSchemesTests.swift */; };
 		7CAA8C33447B52355E7D8A8A /* OrderedSet+Diffing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3588873E14F2C20F8AF16402 /* OrderedSet+Diffing.swift */; };
 		7D76D7605D4013BEF6D8BB46 /* BuildSettingConditional.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F87609D7B124FFBA586ACB9 /* BuildSettingConditional.swift */; };
 		7E504B67BF699AA7CC52A95E /* Outputs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29A9F1CF5849C4454C67F239 /* Outputs.swift */; };
-		7E5146DB1C449A171E464CA1 /* PopulateMainGroupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79B8165ED5AAA24EE1D3B08A /* PopulateMainGroupTests.swift */; };
 		7EBA862872B67F32D6ABAC1A /* Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 586ED36454533572CDC157DB /* Foundation.swift */; };
-		7F62DA1396B4FF7AE2FCF664 /* PBXProj+Testing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4458CEBDA3C4FD40FF360E7E /* PBXProj+Testing.swift */; };
 		800F0D47F5E3A2F557C611CA /* XCScheme+CommandLineArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4490F64144050A8E9D55B02C /* XCScheme+CommandLineArguments.swift */; };
 		80A2456A22344964E5A88AAF /* ParsableCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CB8A57C9965E092474B4118 /* ParsableCommand.swift */; };
 		810140893DA16A9F0AEC5D2E /* XCConfigurationList.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA28E80CF39FAEAA5B563182 /* XCConfigurationList.swift */; };
-		8103A33664910626BC07F42C /* Fixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC351AAD5976C7516B75C330 /* Fixtures.swift */; };
-		81D957300C6CC1793147859A /* Target+Testing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 089203287CD3B51EA341E13A /* Target+Testing.swift */; };
+		81DDEF3F103D85F3821A269F /* DisambiguateTargetsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29187B7B91F51C6C267E9D39 /* DisambiguateTargetsTests.swift */; };
 		81E6F3BAEA84EB26E0C5B7A9 /* CreateXCSharedData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A8069A80346FF5F19F34C53 /* CreateXCSharedData.swift */; };
 		82496FED336DD60B9CC9B23A /* OrderedSet+RandomAccessCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B56CCE10C77FF94DF5E34F2 /* OrderedSet+RandomAccessCollection.swift */; };
 		83BE81C6EC2B61C4006D829C /* PBXShellScriptBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF6A598E6BD4D6632DD9A22A /* PBXShellScriptBuildPhase.swift */; };
 		85BCCA168DC69F15359EE331 /* XCScheme+Runnable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93637B9256E4CB6F83F9828D /* XCScheme+Runnable.swift */; };
 		863ED3A71D675E209D13491E /* OrderedSet+Partial SetAlgebra+Operations.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5D650F25B90824B86103C0B /* OrderedSet+Partial SetAlgebra+Operations.swift */; };
 		864A251191C06BD50CCF260C /* ZshCompletionsGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDCCB92DEEE4808854471EC3 /* ZshCompletionsGenerator.swift */; };
-		8828380D2578793029A79CED /* CreateAutogeneratedXCSchemesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31C36193F884D8B5CA900ED2 /* CreateAutogeneratedXCSchemesTests.swift */; };
-		882B96A89C012056D68045F2 /* XCSchemeInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A29B3E9211815B1576208716 /* XCSchemeInfoTests.swift */; };
 		884C4B38CAD4DC04BB61BA4D /* CommandConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6D6513973B1A3CC262398A9 /* CommandConfiguration.swift */; };
 		89C3B63D51282D017AA752F5 /* CreateAutogeneratedXCSchemes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E9F89AD7C2C4A1C284617AC /* CreateAutogeneratedXCSchemes.swift */; };
 		89E321764618F3E3897C3562 /* CommandParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13B42DF631EF9EC2BCF95288 /* CommandParser.swift */; };
 		8A0EEAB6BEE80EF9007250CE /* CoreLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7224E567F903C4F23FAE8B82 /* CoreLocation.swift */; };
 		8A14E9AED9EE5BDA8678B657 /* OrderedDictionary+CustomReflectable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F454DD7F11FBF23F982A2C9F /* OrderedDictionary+CustomReflectable.swift */; };
-		8A2F4E6A1AD63F891833A479 /* BuildSettingConditionalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ECF7D1F9A353FED519E08C1 /* BuildSettingConditionalTests.swift */; };
-		8CA9B2943580024FF4259E7E /* XcodeSchemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8628BAAFC23DB1FB2F99F192 /* XcodeSchemeTests.swift */; };
-		8D26F5BA444E8CDF4B381437 /* CreateXCSharedDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 002DED77E7361AE266EDCEDA /* CreateXCSharedDataTests.swift */; };
+		8B3DF51C4C38D9B6036E0572 /* GeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C75EC7D65EA2A54A35AB675 /* GeneratorTests.swift */; };
 		8D7567C0B46AC6B91D674AB0 /* XCSwiftPackageProductDependency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11A8B37EF038ED90548A0FC6 /* XCSwiftPackageProductDependency.swift */; };
-		8F228311B799EC2D5B9AA796 /* Dictionary+ExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C07E4B4AB850F09438EFDFCD /* Dictionary+ExtensionTests.swift */; };
+		8E5E957E506A144AE260C58D /* XCScheme+ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606B3822A50B70DF9C2CE47B /* XCScheme+ExtensionsTests.swift */; };
 		8F62B53445119233B1F53667 /* XCSchemeInfo+OtherActionInfos.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE2CA7C7FA38C5200C0A6782 /* XCSchemeInfo+OtherActionInfos.swift */; };
 		9096973E9B841486B9DD1314 /* OrderedSet+SubSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C374430F99E68760A341633 /* OrderedSet+SubSequence.swift */; };
-		9153DEDFAF55DEB2B0B775B2 /* ConsolidateTargetsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9585A860897E21F841443E57 /* ConsolidateTargetsTests.swift */; };
 		91A256F0FB9528ED62CA6F4E /* XCSchemeInfo+PrePostActionInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55662A74CC29AD983C76154C /* XCSchemeInfo+PrePostActionInfo.swift */; };
-		93389D53F1A887D731D4DDC7 /* PopulateMainGroupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79B8165ED5AAA24EE1D3B08A /* PopulateMainGroupTests.swift */; };
-		936C164B3CA38CC7A7BF43D5 /* PBXTarget+ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04FB1C1818CB43F134D2BDD3 /* PBXTarget+ExtensionsTests.swift */; };
-		947D744BB29BC53AB4E1A212 /* XCSchemeInfo+ProfileActionInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C5BCF503E86E1057907F6B1 /* XCSchemeInfo+ProfileActionInfoTests.swift */; };
-		94B87D5DA7CD19C3D11DC5B6 /* XCSchemeInfo+HostInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB9FD956FD80453BF9B1BDA7 /* XCSchemeInfo+HostInfoTests.swift */; };
-		94CAEBC6B8D71F6283810CD7 /* XCSchemeInfo+PrePostActionInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C8322799EAAE41C1833E5D8 /* XCSchemeInfo+PrePostActionInfoTests.swift */; };
+		946270B0C8AB7E8F3FDEAC3E /* PBXTarget+ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04FB1C1818CB43F134D2BDD3 /* PBXTarget+ExtensionsTests.swift */; };
 		95683BA42259537DF95E2F6A /* XCScheme+LaunchAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 073BB17EC8CABF50DF30156E /* XCScheme+LaunchAction.swift */; };
 		959C5FB24E5CAF5F6350F909 /* Writable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C85D8A360FE21C368AACFAA /* Writable.swift */; };
 		95D116BA4BCE26707EFD5A6B /* ExpressibleByArgument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7969903C72DFBC0F866B3AAE /* ExpressibleByArgument.swift */; };
 		96276AE6EE8E3D20E04E1477 /* XCScheme+StoreKitConfigurationFileReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE4383A055B5E97237A7A674 /* XCScheme+StoreKitConfigurationFileReference.swift */; };
+		9738C1D899A60E429CFDC3F8 /* PopulateMainGroupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79B8165ED5AAA24EE1D3B08A /* PopulateMainGroupTests.swift */; };
 		978309A3646CD8CA26F86114 /* XCRemoteSwiftPackageReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = D893B5D58BCA16EF15776B38 /* XCRemoteSwiftPackageReference.swift */; };
 		97F7DDE8945731A4370B1DCA /* XCSchemeInfo+LaunchActionInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF7A6CF5D7D2E306BFFE089F /* XCSchemeInfo+LaunchActionInfo.swift */; };
 		97F8827CFA23BC282E958023 /* ExtensionPointIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B2299E669E8F0C19F4A75D0 /* ExtensionPointIdentifier.swift */; };
@@ -262,85 +227,78 @@
 		9AD49E625626277D24916966 /* AddTargets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83377D07D40A8D2E09612FDF /* AddTargets.swift */; };
 		9D586840B937528BC20FF0E5 /* HelpGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17EA79830990A030060CFF9B /* HelpGenerator.swift */; };
 		9FBB68CA7094687A260AD8CF /* PBXProductType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8B90AAAA114E7F2FE052C4C /* PBXProductType.swift */; };
+		A111F59488F9290F4992D287 /* CreateCustomXCSchemesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0EF3CEC5B326041C5DCAC7C /* CreateCustomXCSchemesTests.swift */; };
 		A1179C9E9C85C73BAAD76071 /* WorkspaceSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAFC608E30F1111807F87301 /* WorkspaceSettings.swift */; };
-		A15641EE8EB25CA9241647F9 /* XcodeScheme+ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5E5E615A113FFB8B140036C /* XcodeScheme+ExtensionsTests.swift */; };
+		A14EF748493E541008CB597D /* BazelLabel+TestExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D38932B464EC5D386812A550 /* BazelLabel+TestExtensions.swift */; };
 		A165B2D04B2A7463A67FCB4A /* SequenceExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 869D3DCE7B9FA553FEBD6FB6 /* SequenceExtensions.swift */; };
 		A1F060D310AFFBB3A5ACF87A /* UIKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA9CE11F8F678BC0F32079F /* UIKit.swift */; };
-		A236EEEDB201ED1A20140CEE /* XCSchemeInfo+TargetInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54E0D35563D6173B30B12BCB /* XCSchemeInfo+TargetInfoTests.swift */; };
 		A271753D3741A1BE34C76BAB /* String+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16B5551ACB57DD727C445292 /* String+Extensions.swift */; };
 		A2E977A592686E5F78AA477E /* Speech.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C25318055B336CC879911EE /* Speech.swift */; };
 		A2F8BDBE4BAD3E10DB856D5C /* Photos.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AFDD1D3888277A88F131B1C /* Photos.swift */; };
-		A48498BE5D24D05361FE50E9 /* XCScheme+ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606B3822A50B70DF9C2CE47B /* XCScheme+ExtensionsTests.swift */; };
-		A5025FE07C7A75004EFC62FE /* ConsolidatedTargetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D36460C06F55AFFFE025AC6 /* ConsolidatedTargetTests.swift */; };
+		A4023F544AD63539C5860EEF /* Target+Testing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 089203287CD3B51EA341E13A /* Target+Testing.swift */; };
 		A572953FB931E704D85D7ED9 /* localtime.c in Sources */ = {isa = PBXBuildFile; fileRef = A2F3DECD44D6641668E3EEC0 /* localtime.c */; };
-		A58203E13F0FAAB40B743997 /* ConsolidatedTargetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D36460C06F55AFFFE025AC6 /* ConsolidatedTargetTests.swift */; };
 		A5E6FC3AC95C231BB3E334BD /* XCTFail.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDE65353927BFFF510C83E7D /* XCTFail.swift */; };
 		A6AA8F8AF82C423A93B3E70A /* PBXObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBD34CB454099AB03FFCB8E8 /* PBXObject.swift */; };
 		A7228706FEF94AE65BF2B7D6 /* PBXResourcesBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = D964D0013E3290129AEF8690 /* PBXResourcesBuildPhase.swift */; };
-		A79F22633FBD54A436E411DF /* CreateProductsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA624D3E5B594905293DD60C /* CreateProductsTest.swift */; };
 		A83D07E81DD9AE67AA78D7CF /* PBXSourcesBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C21635338F05FE80B0F7353 /* PBXSourcesBuildPhase.swift */; };
 		A8486A201346EB70E4F0BB1C /* OrderedSet+Testing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AF01DF630E8A334C4073CC0 /* OrderedSet+Testing.swift */; };
 		A8A4C5F7543156D55D779DDD /* PBXContainerItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C00D6F380848DF275B9724C /* PBXContainerItem.swift */; };
 		A8B10BC54AE20BDFABA83242 /* PBXAggregateTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 463A34E839973731BB7CF8C2 /* PBXAggregateTarget.swift */; };
+		A8B8E29B9FA72D53BB350DF5 /* XCSchemeInfo+TestActionInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A952722F65B7419585B1B350 /* XCSchemeInfo+TestActionInfoTests.swift */; };
 		A8DE72CE323AB81C25A57576 /* XCSchemeInfo+HostInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1F61D495C7A669F4434EBC7 /* XCSchemeInfo+HostInfo.swift */; };
-		AC4EB13BA6E28AF768BE455B /* AddTargetsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D9780A462599256657D870D /* AddTargetsTests.swift */; };
-		AD2E9548FAE6EC1F868C6336 /* XCSchemeEnvironmentVariablesExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14E2BB4F5DEC9797A241E041 /* XCSchemeEnvironmentVariablesExtensionsTests.swift */; };
 		AD557C7FF3DF13823FDD2C5F /* PBXBuildFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E91956C75F600669E2E3AC1 /* PBXBuildFile.swift */; };
 		ADE4C46D93F45DFBB898E840 /* OrderedSet+Hashable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96A443E2CB3B251BE7642FE8 /* OrderedSet+Hashable.swift */; };
 		ADE514DCA432EC0708670CE0 /* Decoders.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C9496B535BA4AB43380B0A6 /* Decoders.swift */; };
-		AFFEB830DDC7930847F1505E /* XCSchemeInfo+BuildTargetInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16ADAFFC466896D163F74D22 /* XCSchemeInfo+BuildTargetInfoTests.swift */; };
+		B024664FE747C83FCFC10839 /* DirectoriesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7A9A1CA4B76989D3D96B70D /* DirectoriesTests.swift */; };
 		B048880109442AAD846972C3 /* XcodeScheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8A6DACA1C2105871343B97A /* XcodeScheme.swift */; };
 		B09C55419C4DE6A45829ADB1 /* InputOrigin.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD43EF72553E17DC15060055 /* InputOrigin.swift */; };
+		B109AC3FE27A37ECD7E860E0 /* BazelLabelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DD1CFC2C244CE1BCF2EFBEE /* BazelLabelTests.swift */; };
 		B24DB5FBBD2AFC2DB596E703 /* XCSchemeInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54A85F1835F8789D5446908F /* XCSchemeInfo.swift */; };
-		B2A6DDB3BE75E56F9359D96B /* XCSchemeInfo+LaunchActionInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C5B95390F1F4F1BB0AE7787 /* XCSchemeInfo+LaunchActionInfoTests.swift */; };
 		B327B6C11045126CC340C8F3 /* CreateFilesAndGroups.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6D710B77ED53606C74E2AC1 /* CreateFilesAndGroups.swift */; };
 		B33C5E9B2F5478A3C454EF18 /* Array+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A40371FFE13CF1F5B19D9B7E /* Array+Extensions.swift */; };
-		B417A9D850EC57984725D40F /* GeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C75EC7D65EA2A54A35AB675 /* GeneratorTests.swift */; };
 		B42CD4C6B2D4B2C06916A8D0 /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1474C970002013B71121354 /* Environment.swift */; };
 		B45CC89DCE0C9A0312A0E2D2 /* BuildMode+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC77BC005E1DFD635B7822CB /* BuildMode+Extensions.swift */; };
-		B47F89E7BC0ED2084B312556 /* CreateFilesAndGroupsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F96FE230883F3D7F990DFE9B /* CreateFilesAndGroupsTests.swift */; };
 		B4CB163E7433F842CAA02C49 /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 433B0DD20641F3F31FBF91A9 /* Errors.swift */; };
-		B5355BDBCB77D7AFBB91CD96 /* XcodeScheme+BuildForTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C1D1EC065B5A867A43419E8 /* XcodeScheme+BuildForTests.swift */; };
 		B5A5E5A2FF34C2DD84FD8F0D /* PBXBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 978F7F054BF49766F7437276 /* PBXBuildPhase.swift */; };
-		B5F50442313214636BF1FFE2 /* DirectoriesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7A9A1CA4B76989D3D96B70D /* DirectoriesTests.swift */; };
 		B61E5C2ED38E265578D80F01 /* ParsableArgumentsValidation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E481CA13AB4E7024659B4124 /* ParsableArgumentsValidation.swift */; };
 		B693199A75F3735251066FF3 /* CreateProducts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01DA728F3C1EFAD8ED0D07B4 /* CreateProducts.swift */; };
+		B6DB7A585B57EA98AAD94F25 /* Optional+ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF8A4999C790B01B02BFF3D6 /* Optional+ExtensionsTests.swift */; };
+		B6EED570E552C9301BDF03AA /* XCSchemeInfo+ProfileActionInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C5BCF503E86E1057907F6B1 /* XCSchemeInfo+ProfileActionInfoTests.swift */; };
 		B70D5054A074BC3B28DB5C6E /* PBXObjectParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17C22B6C06CF33C672BD9C93 /* PBXObjectParser.swift */; };
 		B772146682A8443A9AE3AAB5 /* Diff.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66E9C7856FD3FE8245FED498 /* Diff.swift */; };
 		B89A79A29728E7F7F5B76B66 /* UserNotificationsUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C291CB7BF8C483F7F9F466C /* UserNotificationsUI.swift */; };
-		B8EBCDB822E3973C723B89DD /* XcodeProj+CustomDump.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE23484580120E99275637EC /* XcodeProj+CustomDump.swift */; };
 		B95357286669CF7CCC3B79D6 /* BashCompletionsGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F62FCC1F2DB0D9D6EF1F73C /* BashCompletionsGenerator.swift */; };
 		BA0D4EB05B56CE4F143732B0 /* CustomDumpReflectable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40EFE745D5B917E54F5078AC /* CustomDumpReflectable.swift */; };
-		BA21181403143AE7C8C728F4 /* CreateXCUserDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB3FF798D71A31AAE9690F88 /* CreateXCUserDataTests.swift */; };
 		BA391B7003B9142BEAEB7C31 /* LinkerInputs.swift in Sources */ = {isa = PBXBuildFile; fileRef = A76E1356130C12728BF65E31 /* LinkerInputs.swift */; };
 		BA4EFFA978E478A3BC07C794 /* XCBreakpointList.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFE3F0F986AB17A8E2C68DC7 /* XCBreakpointList.swift */; };
 		BA9BAF805C79B490F731BC2D /* Box.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1819CEC3382AC3F2E30ED6C2 /* Box.swift */; };
 		BC6E75F478CF9BC40F41ECAD /* PBXNativeTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13178D86152EA5DB53397E9B /* PBXNativeTarget.swift */; };
 		BD1C284E67F3F8B479A179AB /* FilePath.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4C459433715D3B1678DDF92 /* FilePath.swift */; };
 		BD823759B857BD48BAF4E88E /* CreateXcodeProj.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9560F91C427FC8AB8F13746D /* CreateXcodeProj.swift */; };
+		BDAD54CAD85BF764668F2AF1 /* XcodeProj+CustomDump.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE23484580120E99275637EC /* XcodeProj+CustomDump.swift */; };
 		BECD01BA300E00331FACF49C /* _Hashtable+Header.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11A5223CE3ED58001C49FE15 /* _Hashtable+Header.swift */; };
 		BFCCE08B291B40F8BCD53410 /* JSONSerialization.mm in Sources */ = {isa = PBXBuildFile; fileRef = 26A9188E264AA8D418D49A8D /* JSONSerialization.mm */; };
+		C052A4DEE3BBAB283679B3AB /* Dictionary+ExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C07E4B4AB850F09438EFDFCD /* Dictionary+ExtensionTests.swift */; };
 		C1DE8943E7FC998C78D0A772 /* DumpHelpGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BBF131A64FA3CB9131B6D2B /* DumpHelpGenerator.swift */; };
 		C2463C4E5A0C1AAA08A6C655 /* UsageGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19FC3F0D80FFE06A907A44CB /* UsageGenerator.swift */; };
-		C385B5936D628317D3417C63 /* XCSchemeInfo+TestActionInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A952722F65B7419585B1B350 /* XCSchemeInfo+TestActionInfoTests.swift */; };
-		C409D512E7B1F17321B9F341 /* DisambiguateTargetsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29187B7B91F51C6C267E9D39 /* DisambiguateTargetsTests.swift */; };
 		C54F51257C269D0EF20B8E8E /* XCSchemeInfo+DiagnosticsInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 833171C1EDC6EBB3CCA85376 /* XCSchemeInfo+DiagnosticsInfo.swift */; };
 		C630AC1CE42326DFD13073CE /* XCSchemeInfo+BuildTargetInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = E05F6909FBEF82026AFB48BD /* XCSchemeInfo+BuildTargetInfo.swift */; };
 		C6E6C91B5F999E68FBCF59D6 /* OrderedSet+Invariants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AB38800E4A200B1E17E4D0D /* OrderedSet+Invariants.swift */; };
-		C70C0BBAF9D7D987A1AEACE4 /* ConsolidatedTargetExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0476FAE400008FA0690CBDD5 /* ConsolidatedTargetExtensionsTests.swift */; };
 		C80F872CBC095567B40255FE /* OrderedDictionary+Initializers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C506D05B9D41B6C5CACF18 /* OrderedDictionary+Initializers.swift */; };
 		C95F17DF8353920CE9157D61 /* AnyType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D001630B87073043235A25E4 /* AnyType.swift */; };
+		CA5DEFB1A09A9DEF9F8BEB43 /* XCSchemeEnvironmentVariablesExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14E2BB4F5DEC9797A241E041 /* XCSchemeEnvironmentVariablesExtensionsTests.swift */; };
+		CBD9FCEFCC64EF3B071B5D89 /* CreateFilesAndGroupsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F96FE230883F3D7F990DFE9B /* CreateFilesAndGroupsTests.swift */; };
 		CC06878F812F34F2BD8F6CCE /* Tree.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01DC8627718DF349F374BB5E /* Tree.swift */; };
 		CD1A84DD6CE77DB8815E9C7F /* _HashTable+BucketIterator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F558BB6C4380840D87F54534 /* _HashTable+BucketIterator.swift */; };
 		CDC3A08A0669D21FDFFD4BEF /* SemanticVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC16336BF07B2135FCA1211E /* SemanticVersion.swift */; };
 		CE45F5EEC1DE0D5C0A49EE87 /* OptionGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EF79C50E3605BB0B10C6D70 /* OptionGroup.swift */; };
 		CE4940AA213768EF34A86EFA /* OrderedDictionary+Hashable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A3550D3F2C2092F487BF147 /* OrderedDictionary+Hashable.swift */; };
 		CF7BB50C87C2D679ABFC2E1D /* Platform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54940DA0C8C626AAC0F4FBBD /* Platform.swift */; };
+		D0406CB515045CFAB4A58F5F /* XCSchemeInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A29B3E9211815B1576208716 /* XCSchemeInfoTests.swift */; };
 		D2724D0F064ABD5223BDB721 /* BuildMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A1439FC22CCDA9976E0DF37 /* BuildMode.swift */; };
 		D30A34DEB48628BA8047F7FD /* XCScheme+AnalyzeAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D39F2E9D0D5C195F8CC97F0 /* XCScheme+AnalyzeAction.swift */; };
 		D312AE23ECE209B26DCD4A27 /* PBXFrameworksBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A5E0E6975E53653E044530D /* PBXFrameworksBuildPhase.swift */; };
-		D31A161CA3A1C1C652ACF61F /* XCScheme+ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606B3822A50B70DF9C2CE47B /* XCScheme+ExtensionsTests.swift */; };
-		D33C1E07A0C8EEAA72922450 /* Optional+ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF8A4999C790B01B02BFF3D6 /* Optional+ExtensionsTests.swift */; };
+		D36EEFF1AE688B4759BBE3E4 /* CreateXcodeProjTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9412FD5ABF1BB294A8DA48D /* CreateXcodeProjTests.swift */; };
 		D3EAC85759B77F71C8CF887C /* TargetIDConsolidatedTargetKeyDictionary+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DA5935CC8E23ECD176597CE /* TargetIDConsolidatedTargetKeyDictionary+Extensions.swift */; };
 		D3EBFEA1C22CA0BCBD118178 /* StoreKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57624F4631BF968191310D43 /* StoreKit.swift */; };
 		D402F5C1972B4ED90D3F5F62 /* CollectionDifference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8510B7DF8BEE35BC28007991 /* CollectionDifference.swift */; };
@@ -351,7 +309,9 @@
 		D6965EBDA5827BC2180BAFB2 /* PopulateMainGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DE83B7525CCEFED91CE9FC6 /* PopulateMainGroup.swift */; };
 		D6A0061EE198AFE4F5B22950 /* Bool+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFA334991264419E3F932300 /* Bool+Extras.swift */; };
 		D6EB9BD42C6538FD9C0C1853 /* NameSpecification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 323036055376CF2404EA0141 /* NameSpecification.swift */; };
+		D70303129773031075AE1D97 /* AddTargetsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D9780A462599256657D870D /* AddTargetsTests.swift */; };
 		D74D5794AB88DEA904F4B580 /* Optional+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4523BADA4513D7DFA01E38E3 /* Optional+Extensions.swift */; };
+		D773FA4AB7E2A2EAE79C48D7 /* TargetIDTargetDictionary+ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F30B98D650DBB52F06D31885 /* TargetIDTargetDictionary+ExtensionsTests.swift */; };
 		D7D4867EA7581CADAB5ED4B0 /* NSRecursiveLock+Sync.swift in Sources */ = {isa = PBXBuildFile; fileRef = F45A31D8C35D47F65B20BB5D /* NSRecursiveLock+Sync.swift */; };
 		D86A8E08A70E0EB7D9D2760C /* XCSchemeInfo+BuildActionInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCE1D41692794D2864474176 /* XCSchemeInfo+BuildActionInfo.swift */; };
 		D872C88048A08DC4AD2A6C79 /* OrderedSet+Insertions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCBCEC06A11D323D9F962649 /* OrderedSet+Insertions.swift */; };
@@ -367,33 +327,29 @@
 		DD5C64EBCA0ADB9866C4D949 /* AddBazelDependenciesTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7A313B4FE7B03BFC26AF135 /* AddBazelDependenciesTarget.swift */; };
 		DDCD1DD7B5DDB1FB5F22A15B /* Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C444E7A8335DC87D024459E /* Swift.swift */; };
 		DE7C529AECC0336B227421CE /* _UnsafeBitset.swift in Sources */ = {isa = PBXBuildFile; fileRef = D99E1A2E41892C7D98CE6F55 /* _UnsafeBitset.swift */; };
-		DFC56ABCEDD4AD5A55ACD7C4 /* GeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C75EC7D65EA2A54A35AB675 /* GeneratorTests.swift */; };
 		E064128085E59EC3F1BAC0F6 /* XCScheme+TestableReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6E582D5C01224A3FA34D482 /* XCScheme+TestableReference.swift */; };
 		E0BB1D3F2EE09F68B0AAE7C2 /* XCSchemeInfo+TargetInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FD9DB25E4C15855BEF92EB9 /* XCSchemeInfo+TargetInfo.swift */; };
 		E0F3F7A57908416B83813BFF /* InputKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91288FF463FA34A3DE91B9A5 /* InputKey.swift */; };
 		E2A5E9AF9662D2E3D119B8A3 /* OrderedSet+CustomReflectable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67114B201AF823E1DED89ABC /* OrderedSet+CustomReflectable.swift */; };
+		E34F7DD822715F0557CD6EC9 /* ConsolidatedTargetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D36460C06F55AFFFE025AC6 /* ConsolidatedTargetTests.swift */; };
 		E3B88250EA5B2BE1A23CA100 /* OrderedDictionary+Elements+SubSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84D452BFAB122FF57D4E1899 /* OrderedDictionary+Elements+SubSequence.swift */; };
 		E40EE69A3F79F0B83748DEDB /* CompletionKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E07915AE73CE68D030DD0D4 /* CompletionKind.swift */; };
-		E42E4D14D08DEF1CBC91E235 /* SetTargetConfigurationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3929AF90EB332967FFDF6C6D /* SetTargetConfigurationsTests.swift */; };
 		E50DECE57978DCE854017409 /* AsyncParsableCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C790CC5BDD33E58B68388C3 /* AsyncParsableCommand.swift */; };
 		E593980D1C8703D8EC6ACDA3 /* Directories.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15B7A1639E07CB1F0E3985A6 /* Directories.swift */; };
 		E6A8DD5B0CDBBB6684DF0B07 /* TargetIDTargetDictionary+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32CA3824FEFCDB4D73C0764C /* TargetIDTargetDictionary+Extensions.swift */; };
 		E6ADB26ABC74EB1D263F05D1 /* XCScheme+EnvironmentVariable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65123348DC3959E1D008FBA5 /* XCScheme+EnvironmentVariable.swift */; };
-		E871B6F3ABCE1C15709244DF /* CreateXcodeProjTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9412FD5ABF1BB294A8DA48D /* CreateXcodeProjTests.swift */; };
-		E878DF62DF7E8E9A3A17E0E8 /* XCSchemeInfo+BuildTargetInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16ADAFFC466896D163F74D22 /* XCSchemeInfo+BuildTargetInfoTests.swift */; };
 		E88056113DFB19CB1774A2BC /* PlistValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F4336885822E8CDC294B591 /* PlistValue.swift */; };
 		E8BF45B891266C2493484CCA /* KeyedDecodingContainer+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A444EA1D327BCC04F2AAD191 /* KeyedDecodingContainer+Additions.swift */; };
 		E9D7770FE1B31401B5A04D1D /* XCWorkspaceData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 882129C20926E28E123BFD52 /* XCWorkspaceData.swift */; };
-		E9ED9FB37F81E1642B3ADD16 /* XCSchemeInfo+ProfileActionInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C5BCF503E86E1057907F6B1 /* XCSchemeInfo+ProfileActionInfoTests.swift */; };
 		EA97EFC56C308946AF8B0676 /* ReferenceGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A61F49C0EE9330580BB0169B /* ReferenceGenerator.swift */; };
 		EB108E14748C1CC55CFB0E45 /* XCScheme+ExecutionAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = E695AC95B4B49EBF7552E066 /* XCScheme+ExecutionAction.swift */; };
 		EB682C15ACB5CE22FF03796D /* Sourcery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FFC8DAC0FE0E6407C9EE9A4 /* Sourcery.swift */; };
 		EC6A5FA6123A1D41CF710B54 /* JJLISO8601DateFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 74CF0A550656F1051BA752DF /* JJLISO8601DateFormatter.m */; };
-		ED56DCBC446E584F48EFD121 /* SetTargetConfigurationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3929AF90EB332967FFDF6C6D /* SetTargetConfigurationsTests.swift */; };
 		EE508541AE5A43FF0E8D7AB6 /* XCScheme+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BC3D5D825E94EA3DAE05A05 /* XCScheme+Extensions.swift */; };
+		EED9347A12E5203D2BFF549A /* XCSchemeInfo+HostInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB9FD956FD80453BF9B1BDA7 /* XCSchemeInfo+HostInfoTests.swift */; };
 		EF4A7672F8F298BBC29EE1C8 /* XcodeScheme+BuildFor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66EAD228333BAA0784A39747 /* XcodeScheme+BuildFor.swift */; };
-		F144C2F1E08395AF734D2126 /* Array+ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7F9BDF86C2A6BB71927E17D /* Array+ExtensionsTests.swift */; };
 		F49A1762852D0DD9188C0571 /* _HashTable+UnsafeHandle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 519971073A0ACA8CE08DFD87 /* _HashTable+UnsafeHandle.swift */; };
+		F4C7BD2388A4D2AED049E3B3 /* XcodeScheme+BuildForTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C1D1EC065B5A867A43419E8 /* XcodeScheme+BuildForTests.swift */; };
 		F6C5626DBC93EA604CD0CCF6 /* ParsableArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = C932CDFFDD047DBDF9E9175C /* ParsableArguments.swift */; };
 		F6E2FB7958A5A9B63763A4FB /* PBXProjEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33482B174F64C397A60B883B /* PBXProjEncoder.swift */; };
 		F7EDEF86AAA56CE9C291A1EE /* XCBuildConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EBAD4F9B14CE3A55275BA5F /* XCBuildConfiguration.swift */; };
@@ -402,12 +358,9 @@
 		F84ED38073DD26C835E91A52 /* XCTAssertNoDifference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A8CB22CD9B34AD0D1F64F10 /* XCTAssertNoDifference.swift */; };
 		F8A53C7B67C6BD6CD1044755 /* SetTargetDependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF3C5D2611EAC0E3D36F4BCB /* SetTargetDependencies.swift */; };
 		F8DB53EED19FEA99DB332E8B /* SetAdditionalProjectConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 300026D87363E2BAA90DF560 /* SetAdditionalProjectConfiguration.swift */; };
-		F9EEAE6231468E31203BDF17 /* Platform+ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A4924FE926E9BEAADE9F74B /* Platform+ExtensionsTests.swift */; };
-		F9FF65FE76842C2D711468C6 /* PBXProductTypeExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 803399FC4252CE057DBC30BD /* PBXProductTypeExtensionsTests.swift */; };
 		FA4D65FB4BC915465105803B /* OrderedSet+Codable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FD015138C774BA78C918B3A /* OrderedSet+Codable.swift */; };
 		FBE4D2FB351DB334D795F7FE /* XCScheme+ArchiveAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4B3F8DE870566A864516956 /* XCScheme+ArchiveAction.swift */; };
 		FDA1B2D3D0A7AF488C034A11 /* CreateProject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C8E82530C8B936EDB53948 /* CreateProject.swift */; };
-		FDF6ABB962723AA68B66D721 /* BuildSettingConditionalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ECF7D1F9A353FED519E08C1 /* BuildSettingConditionalTests.swift */; };
 		FE3A8E7CD4824E922FCAEE6A /* JJLInternal.c in Sources */ = {isa = PBXBuildFile; fileRef = 019728E8A962D708ACD64B2C /* JJLInternal.c */; };
 		FEB0E7910F6DC6767B9C4E90 /* ConsolidateTargets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B57DC445D96B2E69D9D64F1 /* ConsolidateTargets.swift */; };
 		FEC99386E94D7B827A1329BF /* PBXLegacyTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 725608DA06CCB3F85EC4096A /* PBXLegacyTarget.swift */; };
@@ -415,6 +368,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		1B37F14BCD93FD7AB94FD7E0 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 7E7D155EBCA520F35DEA3571;
+			remoteInfo = BazelDependencies;
+		};
 		2407B459161512A6CE879D08 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
@@ -437,20 +397,6 @@
 			remoteInfo = BazelDependencies;
 		};
 		6BA13D7167A2D734540FB39B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 0805833D09730531AD081697 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 7E7D155EBCA520F35DEA3571;
-			remoteInfo = BazelDependencies;
-		};
-		7A43F01DAA6648FE0AAB9328 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 0805833D09730531AD081697 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 7E7D155EBCA520F35DEA3571;
-			remoteInfo = BazelDependencies;
-		};
-		8A919CC0D2E51B1967384D12 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
 			proxyType = 1;
@@ -664,7 +610,6 @@
 		4D1F6FDE4EC715876791C2AF /* Errors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Errors.swift; sourceTree = "<group>"; };
 		4D9780A462599256657D870D /* AddTargetsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTargetsTests.swift; sourceTree = "<group>"; };
 		4E11CEE7C8D4EC4E2A57791E /* BuildPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildPhase.swift; sourceTree = "<group>"; };
-		4E2CAA3026B6E805F87EC0FF /* tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		4F7B8B37B95720D23BC819BA /* Flag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Flag.swift; sourceTree = "<group>"; };
 		4FFC8DAC0FE0E6407C9EE9A4 /* Sourcery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sourcery.swift; sourceTree = "<group>"; };
 		519971073A0ACA8CE08DFD87 /* _HashTable+UnsafeHandle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "_HashTable+UnsafeHandle.swift"; sourceTree = "<group>"; };
@@ -1772,7 +1717,6 @@
 				923CC205DC8CF8935A4DB70A /* libZippyJSONCFamily.a */,
 				98CA01BCABAF4205F1E15E97 /* swiftc */,
 				785842ACBE603D5767FBE10B /* tests.xctest */,
-				4E2CAA3026B6E805F87EC0FF /* tests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -2519,44 +2463,6 @@
 			productName = OrderedCollections;
 			productType = "com.apple.product-type.library.static";
 		};
-		1F8ACFD448DBFCE4D2BCD6CD /* tests (Debug) */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 06784B7CB7AE20060EA8A240 /* Build configuration list for PBXNativeTarget "tests (Debug)" */;
-			buildPhases = (
-				1216D012EDF62F133AE09713 /* Copy Bazel Outputs / Generate Bazel Dependencies (Index Build) */,
-				175714035435C3A100C1805E /* Create Compile Dependencies */,
-				80A93513DF7CEBEE8636666F /* Create Link Dependencies */,
-				D2FE7AB6AB128B8DFB0FBE8E /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				3E56C8DFA5E97BC3DBDF764D /* PBXTargetDependency */,
-			);
-			name = "tests (Debug)";
-			productName = tests;
-			productReference = 785842ACBE603D5767FBE10B /* tests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
-		};
-		27F2BB3A75802147ED1E07C2 /* tests (Profile, Release) */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 9695454E652B6441B25CFA8A /* Build configuration list for PBXNativeTarget "tests (Profile, Release)" */;
-			buildPhases = (
-				3B69525A99D7973C7C9E91C3 /* Copy Bazel Outputs / Generate Bazel Dependencies (Index Build) */,
-				EAE4753EF316F3DEFEA48A40 /* Create Compile Dependencies */,
-				4B4D6864571B02B21CCDDA3C /* Create Link Dependencies */,
-				0D91AB843433159BC7B10434 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				2379B8BCAE7FC7A3A4ADC589 /* PBXTargetDependency */,
-			);
-			name = "tests (Profile, Release)";
-			productName = tests;
-			productReference = 4E2CAA3026B6E805F87EC0FF /* tests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
-		};
 		2CF4E33AE578202202C2EC87 /* swiftc */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = AC0536A4C7A1B96FDA8E9898 /* Build configuration list for PBXNativeTarget "swiftc" */;
@@ -2713,6 +2619,25 @@
 			productName = ArgumentParserToolInfo;
 			productType = "com.apple.product-type.library.static";
 		};
+		979D12680661F4B864602CE6 /* tests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 2AE3F241DE7B5C62A4FBFD3F /* Build configuration list for PBXNativeTarget "tests" */;
+			buildPhases = (
+				E7EE4017A96AB14B369E11DC /* Copy Bazel Outputs / Generate Bazel Dependencies (Index Build) */,
+				45252266CA422101456457E5 /* Create Compile Dependencies */,
+				E9D591E2EC3F3D9E20B4A56C /* Create Link Dependencies */,
+				90B131D058F213F9EE1D4E2A /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				02991226505D2F59EC54038D /* PBXTargetDependency */,
+			);
+			name = tests;
+			productName = tests;
+			productReference = 785842ACBE603D5767FBE10B /* tests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		9DF90F35406923EA23C68CFC /* XCTestDynamicOverlay */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 6151A35A4285123290BF712B /* Build configuration list for PBXNativeTarget "XCTestDynamicOverlay" */;
@@ -2795,14 +2720,6 @@
 						CreatedOnToolsVersion = 13.0.0;
 						LastSwiftMigration = 9999;
 					};
-					1F8ACFD448DBFCE4D2BCD6CD = {
-						CreatedOnToolsVersion = 13.0.0;
-						LastSwiftMigration = 9999;
-					};
-					27F2BB3A75802147ED1E07C2 = {
-						CreatedOnToolsVersion = 13.0.0;
-						LastSwiftMigration = 9999;
-					};
 					2CF4E33AE578202202C2EC87 = {
 						CreatedOnToolsVersion = 13.0.0;
 						LastSwiftMigration = 9999;
@@ -2841,6 +2758,10 @@
 					};
 					7E7D155EBCA520F35DEA3571 = {
 						CreatedOnToolsVersion = 13.0.0;
+					};
+					979D12680661F4B864602CE6 = {
+						CreatedOnToolsVersion = 13.0.0;
+						LastSwiftMigration = 9999;
 					};
 					9DF90F35406923EA23C68CFC = {
 						CreatedOnToolsVersion = 13.0.0;
@@ -2884,8 +2805,7 @@
 				023B2C041CD79AF5B2FDAFE1 /* OrderedCollections */,
 				4A2EC1B2D6969F717CB890DE /* PathKit */,
 				2CF4E33AE578202202C2EC87 /* swiftc */,
-				1F8ACFD448DBFCE4D2BCD6CD /* tests (Debug) */,
-				27F2BB3A75802147ED1E07C2 /* tests (Profile, Release) */,
+				979D12680661F4B864602CE6 /* tests */,
 				A09CE18EBBDAC65CD0C6B7D1 /* XcodeProj */,
 				9DF90F35406923EA23C68CFC /* XCTestDynamicOverlay */,
 				C1C9A1EA5F7FD851D082A6A2 /* ZippyJSON */,
@@ -2895,23 +2815,6 @@
 /* End PBXProject section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		1216D012EDF62F133AE09713 /* Copy Bazel Outputs / Generate Bazel Dependencies (Index Build) */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
-			);
-			name = "Copy Bazel Outputs / Generate Bazel Dependencies (Index Build)";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -euo pipefail\n\nif [[ \"$ACTION\" == \"indexbuild\" ]]; then\n  cd \"$SRCROOT\"\n\n  \"$BAZEL_INTEGRATION_DIR/generate_index_build_bazel_dependencies.sh\"\nelse\n  \"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n    \"_BazelForcedCompile_.swift\" \\\n    \"$BAZEL_INTEGRATION_DIR/xctest.exclude.rsynclist\"\nfi\n";
-			showEnvVarsInLog = 0;
-		};
 		1325E7FCD2DBC02BBE324390 /* Copy Bazel Outputs / Generate Bazel Dependencies (Index Build) */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -2926,23 +2829,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -euo pipefail\n\nif [[ \"$ACTION\" == \"indexbuild\" ]]; then\n  cd \"$SRCROOT\"\n\n  \"$BAZEL_INTEGRATION_DIR/generate_index_build_bazel_dependencies.sh\"\nelse\n  \"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n    \"_BazelForcedCompile_.swift\" \\\n    \"\"\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		175714035435C3A100C1805E /* Create Compile Dependencies */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(SWIFT_PARAMS_FILE)",
-			);
-			name = "Create Compile Dependencies";
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/swift.compile.params",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -euo pipefail\n\nperl -pe '\n  s/__BAZEL_XCODE_DEVELOPER_DIR__/\\$(DEVELOPER_DIR)/g;\n  s/__BAZEL_XCODE_SDKROOT__/\\$(SDKROOT)/g;\n  s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/gx;\n' \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
 			showEnvVarsInLog = 0;
 		};
 		1879C052522978F4334BB93C /* Copy Bazel Outputs / Generate Bazel Dependencies (Index Build) */ = {
@@ -3082,23 +2968,6 @@
 			shellScript = "set -euo pipefail\n\nperl -pe '\n  s/__BAZEL_XCODE_DEVELOPER_DIR__/\\$(DEVELOPER_DIR)/g;\n  s/__BAZEL_XCODE_SDKROOT__/\\$(SDKROOT)/g;\n  s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/gx;\n' \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
 			showEnvVarsInLog = 0;
 		};
-		3B69525A99D7973C7C9E91C3 /* Copy Bazel Outputs / Generate Bazel Dependencies (Index Build) */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
-			);
-			name = "Copy Bazel Outputs / Generate Bazel Dependencies (Index Build)";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -euo pipefail\n\nif [[ \"$ACTION\" == \"indexbuild\" ]]; then\n  cd \"$SRCROOT\"\n\n  \"$BAZEL_INTEGRATION_DIR/generate_index_build_bazel_dependencies.sh\"\nelse\n  \"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n    \"_BazelForcedCompile_.swift\" \\\n    \"$BAZEL_INTEGRATION_DIR/xctest.exclude.rsynclist\"\nfi\n";
-			showEnvVarsInLog = 0;
-		};
 		3F981DB634F31B2A6974E69A /* Copy Bazel Outputs / Generate Bazel Dependencies (Index Build) */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -3113,6 +2982,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -euo pipefail\n\nif [[ \"$ACTION\" == \"indexbuild\" ]]; then\n  cd \"$SRCROOT\"\n\n  \"$BAZEL_INTEGRATION_DIR/generate_index_build_bazel_dependencies.sh\"\nelse\n  \"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n    \"_BazelForcedCompile_.swift\" \\\n    \"\"\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		45252266CA422101456457E5 /* Create Compile Dependencies */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SWIFT_PARAMS_FILE)",
+			);
+			name = "Create Compile Dependencies";
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/swift.compile.params",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -euo pipefail\n\nperl -pe '\n  s/__BAZEL_XCODE_DEVELOPER_DIR__/\\$(DEVELOPER_DIR)/g;\n  s/__BAZEL_XCODE_SDKROOT__/\\$(SDKROOT)/g;\n  s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/gx;\n' \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
 			showEnvVarsInLog = 0;
 		};
 		4A4F32F7CE87A9DAAC6C2DCC /* Create Compile Dependencies */ = {
@@ -3130,23 +3016,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -euo pipefail\n\nperl -pe '\n  s/__BAZEL_XCODE_DEVELOPER_DIR__/\\$(DEVELOPER_DIR)/g;\n  s/__BAZEL_XCODE_SDKROOT__/\\$(SDKROOT)/g;\n  s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/gx;\n' \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
-			showEnvVarsInLog = 0;
-		};
-		4B4D6864571B02B21CCDDA3C /* Create Link Dependencies */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(LINK_PARAMS_FILE)",
-			);
-			name = "Create Link Dependencies";
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/link.params",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -euo pipefail\n\nif [[ \"${ENABLE_PREVIEWS:-}\" == \"YES\" ]]; then\nperl -pe 's/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\nelse\n  touch \"$SCRIPT_OUTPUT_FILE_0\"\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		53CB049B744C287401CD9071 /* Copy Bazel Outputs / Generate Bazel Dependencies (Index Build) */ = {
@@ -3246,23 +3115,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -euo pipefail\n\nif [[ \"$ACTION\" == \"indexbuild\" ]]; then\n  cd \"$SRCROOT\"\n\n  \"$BAZEL_INTEGRATION_DIR/generate_index_build_bazel_dependencies.sh\"\nelse\n  \"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n    \"_BazelForcedCompile_.swift\" \\\n    \"\"\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		80A93513DF7CEBEE8636666F /* Create Link Dependencies */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(LINK_PARAMS_FILE)",
-			);
-			name = "Create Link Dependencies";
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/link.params",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -euo pipefail\n\nif [[ \"${ENABLE_PREVIEWS:-}\" == \"YES\" ]]; then\nperl -pe 's/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\nelse\n  touch \"$SCRIPT_OUTPUT_FILE_0\"\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		8F559B3ABC2BCE58495A9E05 /* Copy Bazel Outputs / Generate Bazel Dependencies (Index Build) */ = {
@@ -3464,21 +3316,38 @@
 			shellScript = "set -euo pipefail\n\nperl -pe '\n  s/__BAZEL_XCODE_DEVELOPER_DIR__/\\$(DEVELOPER_DIR)/g;\n  s/__BAZEL_XCODE_SDKROOT__/\\$(SDKROOT)/g;\n  s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/gx;\n' \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
 			showEnvVarsInLog = 0;
 		};
-		EAE4753EF316F3DEFEA48A40 /* Create Compile Dependencies */ = {
+		E7EE4017A96AB14B369E11DC /* Copy Bazel Outputs / Generate Bazel Dependencies (Index Build) */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
+			);
+			name = "Copy Bazel Outputs / Generate Bazel Dependencies (Index Build)";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -euo pipefail\n\nif [[ \"$ACTION\" == \"indexbuild\" ]]; then\n  cd \"$SRCROOT\"\n\n  \"$BAZEL_INTEGRATION_DIR/generate_index_build_bazel_dependencies.sh\"\nelse\n  \"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n    \"_BazelForcedCompile_.swift\" \\\n    \"$BAZEL_INTEGRATION_DIR/xctest.exclude.rsynclist\"\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		E9D591E2EC3F3D9E20B4A56C /* Create Link Dependencies */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
-				"$(SWIFT_PARAMS_FILE)",
+				"$(LINK_PARAMS_FILE)",
 			);
-			name = "Create Compile Dependencies";
+			name = "Create Link Dependencies";
 			outputPaths = (
-				"$(DERIVED_FILE_DIR)/swift.compile.params",
+				"$(DERIVED_FILE_DIR)/link.params",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -euo pipefail\n\nperl -pe '\n  s/__BAZEL_XCODE_DEVELOPER_DIR__/\\$(DEVELOPER_DIR)/g;\n  s/__BAZEL_XCODE_SDKROOT__/\\$(SDKROOT)/g;\n  s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/gx;\n' \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
+			shellScript = "set -euo pipefail\n\nif [[ \"${ENABLE_PREVIEWS:-}\" == \"YES\" ]]; then\nperl -pe 's/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\nelse\n  touch \"$SCRIPT_OUTPUT_FILE_0\"\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		F9354BE60F470BEFDFE341BC /* Create Compile Dependencies */ = {
@@ -3562,60 +3431,6 @@
 				A165B2D04B2A7463A67FCB4A /* SequenceExtensions.swift in Sources */,
 				09D170246DCF41369D284DEE /* StringExtensions.swift in Sources */,
 				CC06878F812F34F2BD8F6CCE /* Tree.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		0D91AB843433159BC7B10434 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				AC4EB13BA6E28AF768BE455B /* AddTargetsTests.swift in Sources */,
-				7829FB2A71031BFE5C916156 /* Array+ExtensionsTests.swift in Sources */,
-				497360214F6E631F1F3867CD /* BazelLabel+TestExtensions.swift in Sources */,
-				6647B037B4F6B6639FCE0255 /* BazelLabelTests.swift in Sources */,
-				8A2F4E6A1AD63F891833A479 /* BuildSettingConditionalTests.swift in Sources */,
-				41578E99F673783F8B2AFC86 /* ConsolidateTargetsTests.swift in Sources */,
-				1D5502EDA1C64C69FEAF796E /* ConsolidatedTargetExtensionsTests.swift in Sources */,
-				A5025FE07C7A75004EFC62FE /* ConsolidatedTargetTests.swift in Sources */,
-				8828380D2578793029A79CED /* CreateAutogeneratedXCSchemesTests.swift in Sources */,
-				7C0C13C8E651DF61FCE1F447 /* CreateCustomXCSchemesTests.swift in Sources */,
-				B47F89E7BC0ED2084B312556 /* CreateFilesAndGroupsTests.swift in Sources */,
-				6737CFDC50ED3CF0E6CD0D82 /* CreateProductsTest.swift in Sources */,
-				03416C5B570486FEDD4437D9 /* CreateProjectTests.swift in Sources */,
-				8D26F5BA444E8CDF4B381437 /* CreateXCSharedDataTests.swift in Sources */,
-				BA21181403143AE7C8C728F4 /* CreateXCUserDataTests.swift in Sources */,
-				4CFA7835DB277BA2AF2DE3AC /* CreateXcodeProjTests.swift in Sources */,
-				8F228311B799EC2D5B9AA796 /* Dictionary+ExtensionTests.swift in Sources */,
-				B5F50442313214636BF1FFE2 /* DirectoriesTests.swift in Sources */,
-				C409D512E7B1F17321B9F341 /* DisambiguateTargetsTests.swift in Sources */,
-				8103A33664910626BC07F42C /* Fixtures.swift in Sources */,
-				B417A9D850EC57984725D40F /* GeneratorTests.swift in Sources */,
-				D33C1E07A0C8EEAA72922450 /* Optional+ExtensionsTests.swift in Sources */,
-				4451386AB0E2F65BCB20EE55 /* PBXProductTypeExtensionsTests.swift in Sources */,
-				3891829A66D8108CE81570D6 /* PBXProj+Testing.swift in Sources */,
-				936C164B3CA38CC7A7BF43D5 /* PBXTarget+ExtensionsTests.swift in Sources */,
-				31E93E5AB4ABAB06534B6AFD /* Platform+ExtensionsTests.swift in Sources */,
-				93389D53F1A887D731D4DDC7 /* PopulateMainGroupTests.swift in Sources */,
-				ED56DCBC446E584F48EFD121 /* SetTargetConfigurationsTests.swift in Sources */,
-				665CC039AE8F014CF0037D09 /* SetTargetDependenciesTests.swift in Sources */,
-				5417FEC528A0CA447C2E3937 /* Target+Testing.swift in Sources */,
-				747F317E25DA762448FFBBC7 /* TargetIDConsolidatedTargetKeyDictionary+ExtensionsTests.swift in Sources */,
-				440BB9EE0DD26F1EA1328EA7 /* TargetIDTargetDictionary+ExtensionsTests.swift in Sources */,
-				A48498BE5D24D05361FE50E9 /* XCScheme+ExtensionsTests.swift in Sources */,
-				AD2E9548FAE6EC1F868C6336 /* XCSchemeEnvironmentVariablesExtensionsTests.swift in Sources */,
-				4017497FA71F745C88BAB4B1 /* XCSchemeInfo+BuildActionInfoTests.swift in Sources */,
-				AFFEB830DDC7930847F1505E /* XCSchemeInfo+BuildTargetInfoTests.swift in Sources */,
-				0BF9C67DD986906F3AE15784 /* XCSchemeInfo+HostInfoTests.swift in Sources */,
-				62A0CBA0774481AB886F4868 /* XCSchemeInfo+LaunchActionInfoTests.swift in Sources */,
-				94CAEBC6B8D71F6283810CD7 /* XCSchemeInfo+PrePostActionInfoTests.swift in Sources */,
-				E9ED9FB37F81E1642B3ADD16 /* XCSchemeInfo+ProfileActionInfoTests.swift in Sources */,
-				A236EEEDB201ED1A20140CEE /* XCSchemeInfo+TargetInfoTests.swift in Sources */,
-				C385B5936D628317D3417C63 /* XCSchemeInfo+TestActionInfoTests.swift in Sources */,
-				882B96A89C012056D68045F2 /* XCSchemeInfoTests.swift in Sources */,
-				7B4C90F96F06083E8AA08DDA /* XcodeProj+CustomDump.swift in Sources */,
-				797768A32A4A028AEA052B9F /* XcodeScheme+BuildForTests.swift in Sources */,
-				30FF4F30CCA0229707503CC1 /* XcodeScheme+ExtensionsTests.swift in Sources */,
-				338A1BC7C5850B7FADFAC91F /* XcodeSchemeTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3747,6 +3562,60 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		90B131D058F213F9EE1D4E2A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D70303129773031075AE1D97 /* AddTargetsTests.swift in Sources */,
+				0F486596F7688856F9B9E3CC /* Array+ExtensionsTests.swift in Sources */,
+				A14EF748493E541008CB597D /* BazelLabel+TestExtensions.swift in Sources */,
+				B109AC3FE27A37ECD7E860E0 /* BazelLabelTests.swift in Sources */,
+				06F6CCF518F94F29FC28B537 /* BuildSettingConditionalTests.swift in Sources */,
+				616823ED96158871734EC7E7 /* ConsolidateTargetsTests.swift in Sources */,
+				1B052790107B8EADD7C73FA9 /* ConsolidatedTargetExtensionsTests.swift in Sources */,
+				E34F7DD822715F0557CD6EC9 /* ConsolidatedTargetTests.swift in Sources */,
+				5431E3884ABC775C789D38E2 /* CreateAutogeneratedXCSchemesTests.swift in Sources */,
+				A111F59488F9290F4992D287 /* CreateCustomXCSchemesTests.swift in Sources */,
+				CBD9FCEFCC64EF3B071B5D89 /* CreateFilesAndGroupsTests.swift in Sources */,
+				126DC6EA1323478BE8A0BC26 /* CreateProductsTest.swift in Sources */,
+				701FB39843ECA095DCA151D1 /* CreateProjectTests.swift in Sources */,
+				20CA514B9BC2A26A0906C561 /* CreateXCSharedDataTests.swift in Sources */,
+				5658F45404CE0842C937C042 /* CreateXCUserDataTests.swift in Sources */,
+				D36EEFF1AE688B4759BBE3E4 /* CreateXcodeProjTests.swift in Sources */,
+				C052A4DEE3BBAB283679B3AB /* Dictionary+ExtensionTests.swift in Sources */,
+				B024664FE747C83FCFC10839 /* DirectoriesTests.swift in Sources */,
+				81DDEF3F103D85F3821A269F /* DisambiguateTargetsTests.swift in Sources */,
+				3E2E98C4E36B791F3878DD6F /* Fixtures.swift in Sources */,
+				8B3DF51C4C38D9B6036E0572 /* GeneratorTests.swift in Sources */,
+				B6DB7A585B57EA98AAD94F25 /* Optional+ExtensionsTests.swift in Sources */,
+				0CB991EA4563DABD4049576B /* PBXProductTypeExtensionsTests.swift in Sources */,
+				46266870EC4CF96FE881625A /* PBXProj+Testing.swift in Sources */,
+				946270B0C8AB7E8F3FDEAC3E /* PBXTarget+ExtensionsTests.swift in Sources */,
+				34BA592214CFDF935F31EB55 /* Platform+ExtensionsTests.swift in Sources */,
+				9738C1D899A60E429CFDC3F8 /* PopulateMainGroupTests.swift in Sources */,
+				33CC8E47DE7A7730E395C386 /* SetTargetConfigurationsTests.swift in Sources */,
+				0865944F5F1B07E3BB7C8807 /* SetTargetDependenciesTests.swift in Sources */,
+				A4023F544AD63539C5860EEF /* Target+Testing.swift in Sources */,
+				0B281555742C6F8C6EBF0FBE /* TargetIDConsolidatedTargetKeyDictionary+ExtensionsTests.swift in Sources */,
+				D773FA4AB7E2A2EAE79C48D7 /* TargetIDTargetDictionary+ExtensionsTests.swift in Sources */,
+				8E5E957E506A144AE260C58D /* XCScheme+ExtensionsTests.swift in Sources */,
+				CA5DEFB1A09A9DEF9F8BEB43 /* XCSchemeEnvironmentVariablesExtensionsTests.swift in Sources */,
+				378D57513B4A7DC2895B50B7 /* XCSchemeInfo+BuildActionInfoTests.swift in Sources */,
+				75B6D016F0844FA4F96DB047 /* XCSchemeInfo+BuildTargetInfoTests.swift in Sources */,
+				EED9347A12E5203D2BFF549A /* XCSchemeInfo+HostInfoTests.swift in Sources */,
+				15FE35D9681C4F4ED15E1A26 /* XCSchemeInfo+LaunchActionInfoTests.swift in Sources */,
+				368E7AB1F5DD66541ED65FA3 /* XCSchemeInfo+PrePostActionInfoTests.swift in Sources */,
+				B6EED570E552C9301BDF03AA /* XCSchemeInfo+ProfileActionInfoTests.swift in Sources */,
+				764D00E02A1135C735045C33 /* XCSchemeInfo+TargetInfoTests.swift in Sources */,
+				A8B8E29B9FA72D53BB350DF5 /* XCSchemeInfo+TestActionInfoTests.swift in Sources */,
+				D0406CB515045CFAB4A58F5F /* XCSchemeInfoTests.swift in Sources */,
+				BDAD54CAD85BF764668F2AF1 /* XcodeProj+CustomDump.swift in Sources */,
+				F4C7BD2388A4D2AED049E3B3 /* XcodeScheme+BuildForTests.swift in Sources */,
+				3B267216E076CF5A2E84FB0D /* XcodeScheme+ExtensionsTests.swift in Sources */,
+				6920C4E11D16C63A0A539636 /* XcodeSchemeTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		AEE39ECBDE31398DC29C14A8 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -3854,60 +3723,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				0DAB38A0245A8A172824EB09 /* PathKit.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		D2FE7AB6AB128B8DFB0FBE8E /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				13673DB7CBFBA4795F6512F1 /* AddTargetsTests.swift in Sources */,
-				F144C2F1E08395AF734D2126 /* Array+ExtensionsTests.swift in Sources */,
-				6915F69F36EEF9AD28ECDD73 /* BazelLabel+TestExtensions.swift in Sources */,
-				6957A8090F71A97C66C31B16 /* BazelLabelTests.swift in Sources */,
-				FDF6ABB962723AA68B66D721 /* BuildSettingConditionalTests.swift in Sources */,
-				9153DEDFAF55DEB2B0B775B2 /* ConsolidateTargetsTests.swift in Sources */,
-				C70C0BBAF9D7D987A1AEACE4 /* ConsolidatedTargetExtensionsTests.swift in Sources */,
-				A58203E13F0FAAB40B743997 /* ConsolidatedTargetTests.swift in Sources */,
-				6F352F13B291659C236B5FA6 /* CreateAutogeneratedXCSchemesTests.swift in Sources */,
-				06C242CB0FC1647D23E5CC54 /* CreateCustomXCSchemesTests.swift in Sources */,
-				0D0588E5D7507DA45D6DE2D7 /* CreateFilesAndGroupsTests.swift in Sources */,
-				A79F22633FBD54A436E411DF /* CreateProductsTest.swift in Sources */,
-				451E14EDFD86EE2A635537BB /* CreateProjectTests.swift in Sources */,
-				6AD8A3F1432E501376A90831 /* CreateXCSharedDataTests.swift in Sources */,
-				0B4E35D4EB957952588C1423 /* CreateXCUserDataTests.swift in Sources */,
-				E871B6F3ABCE1C15709244DF /* CreateXcodeProjTests.swift in Sources */,
-				798CDEAFF42E17EEE2A046E3 /* Dictionary+ExtensionTests.swift in Sources */,
-				70492AA4724E71202A1C300D /* DirectoriesTests.swift in Sources */,
-				6766FD137C3A8812D583F21A /* DisambiguateTargetsTests.swift in Sources */,
-				53102E6881AB59008DC74EAF /* Fixtures.swift in Sources */,
-				DFC56ABCEDD4AD5A55ACD7C4 /* GeneratorTests.swift in Sources */,
-				3929E9E8AE690E4F6AA32C25 /* Optional+ExtensionsTests.swift in Sources */,
-				F9FF65FE76842C2D711468C6 /* PBXProductTypeExtensionsTests.swift in Sources */,
-				7F62DA1396B4FF7AE2FCF664 /* PBXProj+Testing.swift in Sources */,
-				5F3DDFEA3E9151D8589BCD8D /* PBXTarget+ExtensionsTests.swift in Sources */,
-				F9EEAE6231468E31203BDF17 /* Platform+ExtensionsTests.swift in Sources */,
-				7E5146DB1C449A171E464CA1 /* PopulateMainGroupTests.swift in Sources */,
-				E42E4D14D08DEF1CBC91E235 /* SetTargetConfigurationsTests.swift in Sources */,
-				10C66F27D038A118CCABE0F3 /* SetTargetDependenciesTests.swift in Sources */,
-				81D957300C6CC1793147859A /* Target+Testing.swift in Sources */,
-				47AE14B2FCDCA1D66DFAA3BF /* TargetIDConsolidatedTargetKeyDictionary+ExtensionsTests.swift in Sources */,
-				53C2D694F0A99BA6F5897D49 /* TargetIDTargetDictionary+ExtensionsTests.swift in Sources */,
-				D31A161CA3A1C1C652ACF61F /* XCScheme+ExtensionsTests.swift in Sources */,
-				70387B1E48C2965836EF186A /* XCSchemeEnvironmentVariablesExtensionsTests.swift in Sources */,
-				4B27712B5700EAED713F3BB2 /* XCSchemeInfo+BuildActionInfoTests.swift in Sources */,
-				E878DF62DF7E8E9A3A17E0E8 /* XCSchemeInfo+BuildTargetInfoTests.swift in Sources */,
-				94B87D5DA7CD19C3D11DC5B6 /* XCSchemeInfo+HostInfoTests.swift in Sources */,
-				B2A6DDB3BE75E56F9359D96B /* XCSchemeInfo+LaunchActionInfoTests.swift in Sources */,
-				4FAF39013EEE169D4BD611B3 /* XCSchemeInfo+PrePostActionInfoTests.swift in Sources */,
-				947D744BB29BC53AB4E1A212 /* XCSchemeInfo+ProfileActionInfoTests.swift in Sources */,
-				745699294D7E0C6500A7C69D /* XCSchemeInfo+TargetInfoTests.swift in Sources */,
-				602CAD18311C1CC452A8B3B7 /* XCSchemeInfo+TestActionInfoTests.swift in Sources */,
-				410CC6B7DB3511BD39FF1752 /* XCSchemeInfoTests.swift in Sources */,
-				B8EBCDB822E3973C723B89DD /* XcodeProj+CustomDump.swift in Sources */,
-				B5355BDBCB77D7AFBB91CD96 /* XcodeScheme+BuildForTests.swift in Sources */,
-				A15641EE8EB25CA9241647F9 /* XcodeScheme+ExtensionsTests.swift in Sources */,
-				8CA9B2943580024FF4259E7E /* XcodeSchemeTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4022,6 +3837,12 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		02991226505D2F59EC54038D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = BazelDependencies;
+			target = 7E7D155EBCA520F35DEA3571 /* BazelDependencies */;
+			targetProxy = 1B37F14BCD93FD7AB94FD7E0 /* PBXContainerItemProxy */;
+		};
 		087CAB74CE7704B72BB52837 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = BazelDependencies;
@@ -4034,23 +3855,11 @@
 			target = 7E7D155EBCA520F35DEA3571 /* BazelDependencies */;
 			targetProxy = A6D175644279574512871E94 /* PBXContainerItemProxy */;
 		};
-		2379B8BCAE7FC7A3A4ADC589 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = BazelDependencies;
-			target = 7E7D155EBCA520F35DEA3571 /* BazelDependencies */;
-			targetProxy = 7A43F01DAA6648FE0AAB9328 /* PBXContainerItemProxy */;
-		};
 		248C27B8CD62810B45507CD6 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = BazelDependencies;
 			target = 7E7D155EBCA520F35DEA3571 /* BazelDependencies */;
 			targetProxy = 6BA13D7167A2D734540FB39B /* PBXContainerItemProxy */;
-		};
-		3E56C8DFA5E97BC3DBDF764D /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = BazelDependencies;
-			target = 7E7D155EBCA520F35DEA3571 /* BazelDependencies */;
-			targetProxy = 8A919CC0D2E51B1967384D12 /* PBXContainerItemProxy */;
 		};
 		49193367A3BB0A1F434F8451 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -4191,30 +4000,7 @@
 			};
 			name = Profile;
 		};
-		156FF98E49394C1523E6365D /* Profile */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = x86_64;
-				ASAN_OTHER_CFLAGS__ = "$(ASAN_OTHER_CFLAGS__NO)";
-				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) -ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/c.compile.params";
-				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
-				BAZEL_LABEL = "@com_github_michaeleisel_jjliso8601dateformatter//:JJLISO8601DateFormatter";
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/com_github_michaeleisel_jjliso8601dateformatter";
-				BAZEL_TARGET_ID = "@com_github_michaeleisel_jjliso8601dateformatter//:JJLISO8601DateFormatter macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2";
-				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
-				COMPILE_TARGET_NAME = JJLISO8601DateFormatter;
-				C_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/com_github_michaeleisel_jjliso8601dateformatter/JJLISO8601DateFormatter.rules_xcodeproj.c.compile.params";
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				OTHER_CFLAGS = "$(ASAN_OTHER_CFLAGS__$(CLANG_ADDRESS_SANITIZER))";
-				PRODUCT_NAME = JJLISO8601DateFormatter;
-				SDKROOT = macosx;
-				SUPPORTED_PLATFORMS = macosx;
-				TARGET_NAME = JJLISO8601DateFormatter;
-			};
-			name = Profile;
-		};
-		1AA14725C89E2840DAA06372 /* Release */ = {
+		1076EE29CB5F12F1E6BEFA6C /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
@@ -4251,40 +4037,26 @@
 			};
 			name = Release;
 		};
-		1EA56815E7ADAB4D586D91C1 /* Profile */ = {
+		156FF98E49394C1523E6365D /* Profile */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
-				BAZEL_COMPILE_TARGET_IDS = "//tools/generators/legacy/test:tests.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2";
-				"BAZEL_COMPILE_TARGET_IDS[sdk=macosx*]" = "$(BAZEL_COMPILE_TARGET_IDS)";
-				BAZEL_LABEL = "@//tools/generators/legacy/test:tests";
-				BAZEL_OUTPUTS_DSYM = "\"bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/generators/legacy/test/tests.xctest.dSYM\"";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/generators/legacy/test/tests.__internal__.__test_bundle.zip";
-				BAZEL_OUTPUTS_PRODUCT_BASENAME = tests.xctest;
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/generators/legacy/test";
-				BAZEL_TARGET_ID = "//tools/generators/legacy/test:tests.__internal__.__test_bundle applebin_macos-darwin_x86_64-opt-STABLE-4";
+				ASAN_OTHER_CFLAGS__ = "$(ASAN_OTHER_CFLAGS__NO)";
+				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) -ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/c.compile.params";
+				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
+				BAZEL_LABEL = "@com_github_michaeleisel_jjliso8601dateformatter//:JJLISO8601DateFormatter";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/com_github_michaeleisel_jjliso8601dateformatter";
+				BAZEL_TARGET_ID = "@com_github_michaeleisel_jjliso8601dateformatter//:JJLISO8601DateFormatter macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2";
 				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
-				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
-				CODE_SIGN_STYLE = Manual;
-				COMPILE_TARGET_NAME = tests.library;
+				COMPILE_TARGET_NAME = JJLISO8601DateFormatter;
+				C_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/com_github_michaeleisel_jjliso8601dateformatter/JJLISO8601DateFormatter.rules_xcodeproj.c.compile.params";
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEPLOYMENT_LOCATION = NO;
-				INFOPLIST_FILE = "$(BAZEL_OUT)/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/generators/legacy/test/rules_xcodeproj/tests.__internal__.__test_bundle/Info.plist";
-				LINK_PARAMS_FILE = "$(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-0/bin/external/rules_xcodeproj_generated/generator/test/fixtures/generator/xcodeproj_bwb/xcodeproj_bwb-params/tests.26.link.params";
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				OTHER_LDFLAGS = "@$(DERIVED_FILE_DIR)/link.params";
-				OTHER_SWIFT_FLAGS = "-Xcc -working-directory -Xcc $(PROJECT_DIR) -working-directory $(PROJECT_DIR) -Xcc -ivfsoverlay -Xcc $(OBJROOT)/bazel-out-overlay.yaml -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml $(PREVIEWS_SWIFT_INCLUDE__$(ENABLE_PREVIEWS)) @$(DERIVED_FILE_DIR)/swift.compile.params -F$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/Library/Frameworks -I$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/usr/lib -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/com_github_apple_swift_argument_parser -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/lib/GeneratorCommon -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/com_github_apple_swift_collections -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/com_github_kylef_pathkit -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/com_github_michaeleisel_zippyjson -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/com_github_tadija_aexml -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/com_github_tuist_xcodeproj -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/legacy -Xcc -I -Xcc $(BAZEL_EXTERNAL)/com_github_michaeleisel_jjliso8601dateformatter/Sources/JJLISO8601DateFormatter/include -Xcc -I -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/com_github_michaeleisel_jjliso8601dateformatter/Sources/JJLISO8601DateFormatter/include -Xcc -I -Xcc $(BAZEL_EXTERNAL)/com_github_michaeleisel_zippyjsoncfamily/Sources/ZippyJSONCFamily/include -Xcc -I -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/com_github_michaeleisel_zippyjsoncfamily/Sources/ZippyJSONCFamily/include -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/com_github_michaeleisel_jjliso8601dateformatter -Xcc -iquote -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/com_github_michaeleisel_jjliso8601dateformatter -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/com_github_michaeleisel_zippyjsoncfamily -Xcc -iquote -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/com_github_michaeleisel_zippyjsoncfamily -Xcc -iquote -Xcc $(PROJECT_DIR) -Xcc -iquote -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin -Xcc -fmodule-map-file=$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/com_github_michaeleisel_jjliso8601dateformatter/JJLISO8601DateFormatter.swift.modulemap -Xcc -fmodule-map-file=$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/com_github_michaeleisel_zippyjsoncfamily/ZippyJSONCFamily.swift.modulemap -Xcc -Os -Xcc -DNDEBUG=1 -Xcc -Wno-unused-variable -Xcc -Winit-self -Xcc -Wno-extra";
-				PREVIEWS_SWIFT_INCLUDE__ = "";
-				PREVIEWS_SWIFT_INCLUDE__NO = "";
-				PREVIEWS_SWIFT_INCLUDE__YES = "-I bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/legacy/test";
-				PRODUCT_BUNDLE_IDENTIFIER = com.bazelbuild.rulesapple.Tests;
-				PRODUCT_MODULE_NAME = tests;
-				PRODUCT_NAME = tests;
+				OTHER_CFLAGS = "$(ASAN_OTHER_CFLAGS__$(CLANG_ADDRESS_SANITIZER))";
+				PRODUCT_NAME = JJLISO8601DateFormatter;
 				SDKROOT = macosx;
 				SUPPORTED_PLATFORMS = macosx;
-				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/legacy/test/tests.library.rules_xcodeproj.swift.compile.params";
-				TARGET_NAME = tests;
+				TARGET_NAME = JJLISO8601DateFormatter;
 			};
 			name = Profile;
 		};
@@ -4460,40 +4232,6 @@
 				TARGET_NAME = ArgumentParserToolInfo;
 			};
 			name = Debug;
-		};
-		270F66D927D3963BE91156EE /* Profile */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = x86_64;
-				BAZEL_COMPILE_TARGET_IDS = "//tools/generators/legacy/test:tests.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1";
-				"BAZEL_COMPILE_TARGET_IDS[sdk=macosx*]" = "$(BAZEL_COMPILE_TARGET_IDS)";
-				BAZEL_LABEL = "@//tools/generators/legacy/test:tests";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-3/bin/tools/generators/legacy/test/tests.__internal__.__test_bundle.zip";
-				BAZEL_OUTPUTS_PRODUCT_BASENAME = tests.xctest;
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-3/bin/tools/generators/legacy/test";
-				BAZEL_TARGET_ID = "//tools/generators/legacy/test:tests.__internal__.__test_bundle applebin_macos-darwin_x86_64-dbg-STABLE-3";
-				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
-				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
-				CODE_SIGN_STYLE = Manual;
-				COMPILE_TARGET_NAME = tests.library;
-				DEPLOYMENT_LOCATION = NO;
-				INFOPLIST_FILE = "$(BAZEL_OUT)/applebin_macos-darwin_x86_64-dbg-STABLE-3/bin/tools/generators/legacy/test/rules_xcodeproj/tests.__internal__.__test_bundle/Info.plist";
-				LINK_PARAMS_FILE = "$(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-0/bin/external/rules_xcodeproj_generated/generator/test/fixtures/generator/xcodeproj_bwb/xcodeproj_bwb-params/tests.13.link.params";
-				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				OTHER_LDFLAGS = "@$(DERIVED_FILE_DIR)/link.params";
-				OTHER_SWIFT_FLAGS = "-Xcc -working-directory -Xcc $(PROJECT_DIR) -working-directory $(PROJECT_DIR) -Xcc -ivfsoverlay -Xcc $(OBJROOT)/bazel-out-overlay.yaml -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml $(PREVIEWS_SWIFT_INCLUDE__$(ENABLE_PREVIEWS)) @$(DERIVED_FILE_DIR)/swift.compile.params -F$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/Library/Frameworks -I$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/usr/lib -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_apple_swift_argument_parser -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generators/lib/GeneratorCommon -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_apple_swift_collections -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_kylef_pathkit -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_zippyjson -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_tadija_aexml -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_tuist_xcodeproj -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generators/legacy -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_pointfreeco_xctest_dynamic_overlay -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_pointfreeco_swift_custom_dump -Xcc -I -Xcc $(BAZEL_EXTERNAL)/com_github_michaeleisel_jjliso8601dateformatter/Sources/JJLISO8601DateFormatter/include -Xcc -I -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_jjliso8601dateformatter/Sources/JJLISO8601DateFormatter/include -Xcc -I -Xcc $(BAZEL_EXTERNAL)/com_github_michaeleisel_zippyjsoncfamily/Sources/ZippyJSONCFamily/include -Xcc -I -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_zippyjsoncfamily/Sources/ZippyJSONCFamily/include -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/com_github_michaeleisel_jjliso8601dateformatter -Xcc -iquote -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_jjliso8601dateformatter -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/com_github_michaeleisel_zippyjsoncfamily -Xcc -iquote -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_zippyjsoncfamily -Xcc -iquote -Xcc $(PROJECT_DIR) -Xcc -iquote -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin -Xcc -fmodule-map-file=$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_jjliso8601dateformatter/JJLISO8601DateFormatter.swift.modulemap -Xcc -fmodule-map-file=$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_zippyjsoncfamily/ZippyJSONCFamily.swift.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all";
-				PREVIEWS_SWIFT_INCLUDE__ = "";
-				PREVIEWS_SWIFT_INCLUDE__NO = "";
-				PREVIEWS_SWIFT_INCLUDE__YES = "-I bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generators/legacy/test";
-				PRODUCT_BUNDLE_IDENTIFIER = com.bazelbuild.rulesapple.Tests;
-				PRODUCT_MODULE_NAME = tests;
-				PRODUCT_NAME = tests;
-				SDKROOT = macosx;
-				SUPPORTED_PLATFORMS = macosx;
-				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generators/legacy/test/tests.library.rules_xcodeproj.swift.compile.params";
-				TARGET_NAME = tests;
-			};
-			name = Profile;
 		};
 		2852F291F04A785E911971B6 /* Release */ = {
 			isa = XCBuildConfiguration;
@@ -4790,40 +4528,6 @@
 			};
 			name = Debug;
 		};
-		6ACED4EA54B59B8B5CEB577A /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = x86_64;
-				BAZEL_COMPILE_TARGET_IDS = "//tools/generators/legacy/test:tests.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1";
-				"BAZEL_COMPILE_TARGET_IDS[sdk=macosx*]" = "$(BAZEL_COMPILE_TARGET_IDS)";
-				BAZEL_LABEL = "@//tools/generators/legacy/test:tests";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-3/bin/tools/generators/legacy/test/tests.__internal__.__test_bundle.zip";
-				BAZEL_OUTPUTS_PRODUCT_BASENAME = tests.xctest;
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-3/bin/tools/generators/legacy/test";
-				BAZEL_TARGET_ID = "//tools/generators/legacy/test:tests.__internal__.__test_bundle applebin_macos-darwin_x86_64-dbg-STABLE-3";
-				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
-				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
-				CODE_SIGN_STYLE = Manual;
-				COMPILE_TARGET_NAME = tests.library;
-				DEPLOYMENT_LOCATION = NO;
-				INFOPLIST_FILE = "$(BAZEL_OUT)/applebin_macos-darwin_x86_64-dbg-STABLE-3/bin/tools/generators/legacy/test/rules_xcodeproj/tests.__internal__.__test_bundle/Info.plist";
-				LINK_PARAMS_FILE = "$(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-0/bin/external/rules_xcodeproj_generated/generator/test/fixtures/generator/xcodeproj_bwb/xcodeproj_bwb-params/tests.13.link.params";
-				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				OTHER_LDFLAGS = "@$(DERIVED_FILE_DIR)/link.params";
-				OTHER_SWIFT_FLAGS = "-Xcc -working-directory -Xcc $(PROJECT_DIR) -working-directory $(PROJECT_DIR) -Xcc -ivfsoverlay -Xcc $(OBJROOT)/bazel-out-overlay.yaml -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml $(PREVIEWS_SWIFT_INCLUDE__$(ENABLE_PREVIEWS)) @$(DERIVED_FILE_DIR)/swift.compile.params -F$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/Library/Frameworks -I$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/usr/lib -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_apple_swift_argument_parser -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generators/lib/GeneratorCommon -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_apple_swift_collections -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_kylef_pathkit -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_zippyjson -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_tadija_aexml -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_tuist_xcodeproj -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generators/legacy -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_pointfreeco_xctest_dynamic_overlay -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_pointfreeco_swift_custom_dump -Xcc -I -Xcc $(BAZEL_EXTERNAL)/com_github_michaeleisel_jjliso8601dateformatter/Sources/JJLISO8601DateFormatter/include -Xcc -I -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_jjliso8601dateformatter/Sources/JJLISO8601DateFormatter/include -Xcc -I -Xcc $(BAZEL_EXTERNAL)/com_github_michaeleisel_zippyjsoncfamily/Sources/ZippyJSONCFamily/include -Xcc -I -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_zippyjsoncfamily/Sources/ZippyJSONCFamily/include -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/com_github_michaeleisel_jjliso8601dateformatter -Xcc -iquote -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_jjliso8601dateformatter -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/com_github_michaeleisel_zippyjsoncfamily -Xcc -iquote -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_zippyjsoncfamily -Xcc -iquote -Xcc $(PROJECT_DIR) -Xcc -iquote -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin -Xcc -fmodule-map-file=$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_jjliso8601dateformatter/JJLISO8601DateFormatter.swift.modulemap -Xcc -fmodule-map-file=$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_zippyjsoncfamily/ZippyJSONCFamily.swift.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all";
-				PREVIEWS_SWIFT_INCLUDE__ = "";
-				PREVIEWS_SWIFT_INCLUDE__NO = "";
-				PREVIEWS_SWIFT_INCLUDE__YES = "-I bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generators/legacy/test";
-				PRODUCT_BUNDLE_IDENTIFIER = com.bazelbuild.rulesapple.Tests;
-				PRODUCT_MODULE_NAME = tests;
-				PRODUCT_NAME = tests;
-				SDKROOT = macosx;
-				SUPPORTED_PLATFORMS = macosx;
-				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generators/legacy/test/tests.library.rules_xcodeproj.swift.compile.params";
-				TARGET_NAME = tests;
-			};
-			name = Debug;
-		};
 		772D3CDBDFBD70FE82E194DF /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -4866,40 +4570,6 @@
 				TARGET_NAME = ZippyJSONCFamily;
 			};
 			name = Profile;
-		};
-		7EEC5BF9E03EB95DEDC12D11 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = x86_64;
-				BAZEL_COMPILE_TARGET_IDS = "//tools/generators/legacy/test:tests.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1";
-				"BAZEL_COMPILE_TARGET_IDS[sdk=macosx*]" = "$(BAZEL_COMPILE_TARGET_IDS)";
-				BAZEL_LABEL = "@//tools/generators/legacy/test:tests";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-3/bin/tools/generators/legacy/test/tests.__internal__.__test_bundle.zip";
-				BAZEL_OUTPUTS_PRODUCT_BASENAME = tests.xctest;
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-3/bin/tools/generators/legacy/test";
-				BAZEL_TARGET_ID = "//tools/generators/legacy/test:tests.__internal__.__test_bundle applebin_macos-darwin_x86_64-dbg-STABLE-3";
-				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
-				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
-				CODE_SIGN_STYLE = Manual;
-				COMPILE_TARGET_NAME = tests.library;
-				DEPLOYMENT_LOCATION = NO;
-				INFOPLIST_FILE = "$(BAZEL_OUT)/applebin_macos-darwin_x86_64-dbg-STABLE-3/bin/tools/generators/legacy/test/rules_xcodeproj/tests.__internal__.__test_bundle/Info.plist";
-				LINK_PARAMS_FILE = "$(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-0/bin/external/rules_xcodeproj_generated/generator/test/fixtures/generator/xcodeproj_bwb/xcodeproj_bwb-params/tests.13.link.params";
-				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				OTHER_LDFLAGS = "@$(DERIVED_FILE_DIR)/link.params";
-				OTHER_SWIFT_FLAGS = "-Xcc -working-directory -Xcc $(PROJECT_DIR) -working-directory $(PROJECT_DIR) -Xcc -ivfsoverlay -Xcc $(OBJROOT)/bazel-out-overlay.yaml -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml $(PREVIEWS_SWIFT_INCLUDE__$(ENABLE_PREVIEWS)) @$(DERIVED_FILE_DIR)/swift.compile.params -F$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/Library/Frameworks -I$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/usr/lib -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_apple_swift_argument_parser -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generators/lib/GeneratorCommon -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_apple_swift_collections -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_kylef_pathkit -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_zippyjson -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_tadija_aexml -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_tuist_xcodeproj -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generators/legacy -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_pointfreeco_xctest_dynamic_overlay -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_pointfreeco_swift_custom_dump -Xcc -I -Xcc $(BAZEL_EXTERNAL)/com_github_michaeleisel_jjliso8601dateformatter/Sources/JJLISO8601DateFormatter/include -Xcc -I -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_jjliso8601dateformatter/Sources/JJLISO8601DateFormatter/include -Xcc -I -Xcc $(BAZEL_EXTERNAL)/com_github_michaeleisel_zippyjsoncfamily/Sources/ZippyJSONCFamily/include -Xcc -I -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_zippyjsoncfamily/Sources/ZippyJSONCFamily/include -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/com_github_michaeleisel_jjliso8601dateformatter -Xcc -iquote -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_jjliso8601dateformatter -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/com_github_michaeleisel_zippyjsoncfamily -Xcc -iquote -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_zippyjsoncfamily -Xcc -iquote -Xcc $(PROJECT_DIR) -Xcc -iquote -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin -Xcc -fmodule-map-file=$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_jjliso8601dateformatter/JJLISO8601DateFormatter.swift.modulemap -Xcc -fmodule-map-file=$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_zippyjsoncfamily/ZippyJSONCFamily.swift.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all";
-				PREVIEWS_SWIFT_INCLUDE__ = "";
-				PREVIEWS_SWIFT_INCLUDE__NO = "";
-				PREVIEWS_SWIFT_INCLUDE__YES = "-I bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generators/legacy/test";
-				PRODUCT_BUNDLE_IDENTIFIER = com.bazelbuild.rulesapple.Tests;
-				PRODUCT_MODULE_NAME = tests;
-				PRODUCT_NAME = tests;
-				SDKROOT = macosx;
-				SUPPORTED_PLATFORMS = macosx;
-				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generators/legacy/test/tests.library.rules_xcodeproj.swift.compile.params";
-				TARGET_NAME = tests;
-			};
-			name = Release;
 		};
 		7EFDE38A9EB09A4DD6074C28 /* Release */ = {
 			isa = XCBuildConfiguration;
@@ -5137,43 +4807,6 @@
 			};
 			name = Debug;
 		};
-		BC251676302B7DDD857A2279 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = x86_64;
-				BAZEL_COMPILE_TARGET_IDS = "//tools/generators/legacy/test:tests.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2";
-				"BAZEL_COMPILE_TARGET_IDS[sdk=macosx*]" = "$(BAZEL_COMPILE_TARGET_IDS)";
-				BAZEL_LABEL = "@//tools/generators/legacy/test:tests";
-				BAZEL_OUTPUTS_DSYM = "\"bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/generators/legacy/test/tests.xctest.dSYM\"";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/generators/legacy/test/tests.__internal__.__test_bundle.zip";
-				BAZEL_OUTPUTS_PRODUCT_BASENAME = tests.xctest;
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/generators/legacy/test";
-				BAZEL_TARGET_ID = "//tools/generators/legacy/test:tests.__internal__.__test_bundle applebin_macos-darwin_x86_64-opt-STABLE-4";
-				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
-				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
-				CODE_SIGN_STYLE = Manual;
-				COMPILE_TARGET_NAME = tests.library;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEPLOYMENT_LOCATION = NO;
-				INFOPLIST_FILE = "$(BAZEL_OUT)/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/generators/legacy/test/rules_xcodeproj/tests.__internal__.__test_bundle/Info.plist";
-				LINK_PARAMS_FILE = "$(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-0/bin/external/rules_xcodeproj_generated/generator/test/fixtures/generator/xcodeproj_bwb/xcodeproj_bwb-params/tests.26.link.params";
-				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				OTHER_LDFLAGS = "@$(DERIVED_FILE_DIR)/link.params";
-				OTHER_SWIFT_FLAGS = "-Xcc -working-directory -Xcc $(PROJECT_DIR) -working-directory $(PROJECT_DIR) -Xcc -ivfsoverlay -Xcc $(OBJROOT)/bazel-out-overlay.yaml -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml $(PREVIEWS_SWIFT_INCLUDE__$(ENABLE_PREVIEWS)) @$(DERIVED_FILE_DIR)/swift.compile.params -F$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/Library/Frameworks -I$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/usr/lib -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/com_github_apple_swift_argument_parser -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/lib/GeneratorCommon -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/com_github_apple_swift_collections -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/com_github_kylef_pathkit -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/com_github_michaeleisel_zippyjson -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/com_github_tadija_aexml -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/com_github_tuist_xcodeproj -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/legacy -Xcc -I -Xcc $(BAZEL_EXTERNAL)/com_github_michaeleisel_jjliso8601dateformatter/Sources/JJLISO8601DateFormatter/include -Xcc -I -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/com_github_michaeleisel_jjliso8601dateformatter/Sources/JJLISO8601DateFormatter/include -Xcc -I -Xcc $(BAZEL_EXTERNAL)/com_github_michaeleisel_zippyjsoncfamily/Sources/ZippyJSONCFamily/include -Xcc -I -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/com_github_michaeleisel_zippyjsoncfamily/Sources/ZippyJSONCFamily/include -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/com_github_michaeleisel_jjliso8601dateformatter -Xcc -iquote -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/com_github_michaeleisel_jjliso8601dateformatter -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/com_github_michaeleisel_zippyjsoncfamily -Xcc -iquote -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/com_github_michaeleisel_zippyjsoncfamily -Xcc -iquote -Xcc $(PROJECT_DIR) -Xcc -iquote -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin -Xcc -fmodule-map-file=$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/com_github_michaeleisel_jjliso8601dateformatter/JJLISO8601DateFormatter.swift.modulemap -Xcc -fmodule-map-file=$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/com_github_michaeleisel_zippyjsoncfamily/ZippyJSONCFamily.swift.modulemap -Xcc -Os -Xcc -DNDEBUG=1 -Xcc -Wno-unused-variable -Xcc -Winit-self -Xcc -Wno-extra";
-				PREVIEWS_SWIFT_INCLUDE__ = "";
-				PREVIEWS_SWIFT_INCLUDE__NO = "";
-				PREVIEWS_SWIFT_INCLUDE__YES = "-I bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/legacy/test";
-				PRODUCT_BUNDLE_IDENTIFIER = com.bazelbuild.rulesapple.Tests;
-				PRODUCT_MODULE_NAME = tests;
-				PRODUCT_NAME = tests;
-				SDKROOT = macosx;
-				SUPPORTED_PLATFORMS = macosx;
-				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/legacy/test/tests.library.rules_xcodeproj.swift.compile.params";
-				TARGET_NAME = tests;
-			};
-			name = Debug;
-		};
 		BC77DEF100AC5EA0E56E62C8 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -5283,6 +4916,77 @@
 				SUPPORTED_PLATFORMS = macosx;
 				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_pointfreeco_swift_custom_dump/CustomDump.rules_xcodeproj.swift.compile.params";
 				TARGET_NAME = CustomDump;
+			};
+			name = Debug;
+		};
+		CA4924B79049DFBD2F6E932F /* Profile */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				BAZEL_COMPILE_TARGET_IDS = "//tools/generators/legacy/test:tests.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2";
+				"BAZEL_COMPILE_TARGET_IDS[sdk=macosx*]" = "$(BAZEL_COMPILE_TARGET_IDS)";
+				BAZEL_LABEL = "@//tools/generators/legacy/test:tests";
+				BAZEL_OUTPUTS_DSYM = "\"bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/generators/legacy/test/tests.xctest.dSYM\"";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/generators/legacy/test/tests.__internal__.__test_bundle.zip";
+				BAZEL_OUTPUTS_PRODUCT_BASENAME = tests.xctest;
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/generators/legacy/test";
+				BAZEL_TARGET_ID = "//tools/generators/legacy/test:tests.__internal__.__test_bundle applebin_macos-darwin_x86_64-opt-STABLE-4";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
+				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
+				CODE_SIGN_STYLE = Manual;
+				COMPILE_TARGET_NAME = tests.library;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEPLOYMENT_LOCATION = NO;
+				INFOPLIST_FILE = "$(BAZEL_OUT)/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/generators/legacy/test/rules_xcodeproj/tests.__internal__.__test_bundle/Info.plist";
+				LINK_PARAMS_FILE = "$(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-0/bin/external/rules_xcodeproj_generated/generator/test/fixtures/generator/xcodeproj_bwb/xcodeproj_bwb-params/tests.26.link.params";
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
+				OTHER_LDFLAGS = "@$(DERIVED_FILE_DIR)/link.params";
+				OTHER_SWIFT_FLAGS = "-Xcc -working-directory -Xcc $(PROJECT_DIR) -working-directory $(PROJECT_DIR) -Xcc -ivfsoverlay -Xcc $(OBJROOT)/bazel-out-overlay.yaml -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml $(PREVIEWS_SWIFT_INCLUDE__$(ENABLE_PREVIEWS)) @$(DERIVED_FILE_DIR)/swift.compile.params -F$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/Library/Frameworks -I$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/usr/lib -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/com_github_apple_swift_argument_parser -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/lib/GeneratorCommon -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/com_github_apple_swift_collections -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/com_github_kylef_pathkit -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/com_github_michaeleisel_zippyjson -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/com_github_tadija_aexml -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/com_github_tuist_xcodeproj -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/legacy -Xcc -I -Xcc $(BAZEL_EXTERNAL)/com_github_michaeleisel_jjliso8601dateformatter/Sources/JJLISO8601DateFormatter/include -Xcc -I -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/com_github_michaeleisel_jjliso8601dateformatter/Sources/JJLISO8601DateFormatter/include -Xcc -I -Xcc $(BAZEL_EXTERNAL)/com_github_michaeleisel_zippyjsoncfamily/Sources/ZippyJSONCFamily/include -Xcc -I -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/com_github_michaeleisel_zippyjsoncfamily/Sources/ZippyJSONCFamily/include -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/com_github_michaeleisel_jjliso8601dateformatter -Xcc -iquote -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/com_github_michaeleisel_jjliso8601dateformatter -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/com_github_michaeleisel_zippyjsoncfamily -Xcc -iquote -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/com_github_michaeleisel_zippyjsoncfamily -Xcc -iquote -Xcc $(PROJECT_DIR) -Xcc -iquote -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin -Xcc -fmodule-map-file=$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/com_github_michaeleisel_jjliso8601dateformatter/JJLISO8601DateFormatter.swift.modulemap -Xcc -fmodule-map-file=$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/com_github_michaeleisel_zippyjsoncfamily/ZippyJSONCFamily.swift.modulemap -Xcc -Os -Xcc -DNDEBUG=1 -Xcc -Wno-unused-variable -Xcc -Winit-self -Xcc -Wno-extra";
+				PREVIEWS_SWIFT_INCLUDE__ = "";
+				PREVIEWS_SWIFT_INCLUDE__NO = "";
+				PREVIEWS_SWIFT_INCLUDE__YES = "-I bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/legacy/test";
+				PRODUCT_BUNDLE_IDENTIFIER = com.bazelbuild.rulesapple.Tests;
+				PRODUCT_MODULE_NAME = tests;
+				PRODUCT_NAME = tests;
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/legacy/test/tests.library.rules_xcodeproj.swift.compile.params";
+				TARGET_NAME = tests;
+			};
+			name = Profile;
+		};
+		CE8A864F719785A99D16C3BC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				BAZEL_COMPILE_TARGET_IDS = "//tools/generators/legacy/test:tests.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1";
+				"BAZEL_COMPILE_TARGET_IDS[sdk=macosx*]" = "$(BAZEL_COMPILE_TARGET_IDS)";
+				BAZEL_LABEL = "@//tools/generators/legacy/test:tests";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-3/bin/tools/generators/legacy/test/tests.__internal__.__test_bundle.zip";
+				BAZEL_OUTPUTS_PRODUCT_BASENAME = tests.xctest;
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-3/bin/tools/generators/legacy/test";
+				BAZEL_TARGET_ID = "//tools/generators/legacy/test:tests.__internal__.__test_bundle applebin_macos-darwin_x86_64-dbg-STABLE-3";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
+				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
+				CODE_SIGN_STYLE = Manual;
+				COMPILE_TARGET_NAME = tests.library;
+				DEPLOYMENT_LOCATION = NO;
+				INFOPLIST_FILE = "$(BAZEL_OUT)/applebin_macos-darwin_x86_64-dbg-STABLE-3/bin/tools/generators/legacy/test/rules_xcodeproj/tests.__internal__.__test_bundle/Info.plist";
+				LINK_PARAMS_FILE = "$(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-0/bin/external/rules_xcodeproj_generated/generator/test/fixtures/generator/xcodeproj_bwb/xcodeproj_bwb-params/tests.13.link.params";
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
+				OTHER_LDFLAGS = "@$(DERIVED_FILE_DIR)/link.params";
+				OTHER_SWIFT_FLAGS = "-Xcc -working-directory -Xcc $(PROJECT_DIR) -working-directory $(PROJECT_DIR) -Xcc -ivfsoverlay -Xcc $(OBJROOT)/bazel-out-overlay.yaml -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml $(PREVIEWS_SWIFT_INCLUDE__$(ENABLE_PREVIEWS)) @$(DERIVED_FILE_DIR)/swift.compile.params -F$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/Library/Frameworks -I$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/usr/lib -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_apple_swift_argument_parser -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generators/lib/GeneratorCommon -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_apple_swift_collections -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_kylef_pathkit -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_zippyjson -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_tadija_aexml -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_tuist_xcodeproj -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generators/legacy -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_pointfreeco_xctest_dynamic_overlay -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_pointfreeco_swift_custom_dump -Xcc -I -Xcc $(BAZEL_EXTERNAL)/com_github_michaeleisel_jjliso8601dateformatter/Sources/JJLISO8601DateFormatter/include -Xcc -I -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_jjliso8601dateformatter/Sources/JJLISO8601DateFormatter/include -Xcc -I -Xcc $(BAZEL_EXTERNAL)/com_github_michaeleisel_zippyjsoncfamily/Sources/ZippyJSONCFamily/include -Xcc -I -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_zippyjsoncfamily/Sources/ZippyJSONCFamily/include -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/com_github_michaeleisel_jjliso8601dateformatter -Xcc -iquote -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_jjliso8601dateformatter -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/com_github_michaeleisel_zippyjsoncfamily -Xcc -iquote -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_zippyjsoncfamily -Xcc -iquote -Xcc $(PROJECT_DIR) -Xcc -iquote -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin -Xcc -fmodule-map-file=$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_jjliso8601dateformatter/JJLISO8601DateFormatter.swift.modulemap -Xcc -fmodule-map-file=$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_zippyjsoncfamily/ZippyJSONCFamily.swift.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all";
+				PREVIEWS_SWIFT_INCLUDE__ = "";
+				PREVIEWS_SWIFT_INCLUDE__NO = "";
+				PREVIEWS_SWIFT_INCLUDE__YES = "-I bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generators/legacy/test";
+				PRODUCT_BUNDLE_IDENTIFIER = com.bazelbuild.rulesapple.Tests;
+				PRODUCT_MODULE_NAME = tests;
+				PRODUCT_NAME = tests;
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generators/legacy/test/tests.library.rules_xcodeproj.swift.compile.params";
+				TARGET_NAME = tests;
 			};
 			name = Debug;
 		};
@@ -5548,22 +5252,22 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
-		06784B7CB7AE20060EA8A240 /* Build configuration list for PBXNativeTarget "tests (Debug)" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				6ACED4EA54B59B8B5CEB577A /* Debug */,
-				270F66D927D3963BE91156EE /* Profile */,
-				7EEC5BF9E03EB95DEDC12D11 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Debug;
-		};
 		1BA766419055D2CBF67F72AB /* Build configuration list for PBXNativeTarget "generator (Library)" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				B57F0CC892F232DAA143A65F /* Debug */,
 				CFD6D295455658A68A417E6E /* Profile */,
 				3333D00658A63403566A9CD9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		2AE3F241DE7B5C62A4FBFD3F /* Build configuration list for PBXNativeTarget "tests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CE8A864F719785A99D16C3BC /* Debug */,
+				CA4924B79049DFBD2F6E932F /* Profile */,
+				1076EE29CB5F12F1E6BEFA6C /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
@@ -5664,16 +5368,6 @@
 				690A039D63AF0A09BE54B464 /* Debug */,
 				37F8C02D0B20B2EB308AC215 /* Profile */,
 				C213DC3019AC0A2998C3496B /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Debug;
-		};
-		9695454E652B6441B25CFA8A /* Build configuration list for PBXNativeTarget "tests (Profile, Release)" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				BC251676302B7DDD857A2279 /* Debug */,
-				1EA56815E7ADAB4D586D91C1 /* Profile */,
-				1AA14725C89E2840DAA06372 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/test/fixtures/generator/bwb.xcodeproj/xcshareddata/xcschemes/generator.xcscheme
+++ b/test/fixtures/generator/bwb.xcodeproj/xcshareddata/xcschemes/generator.xcscheme
@@ -57,14 +57,14 @@
          <ExecutionAction
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
-               title = "Set Bazel Build Output Groups for tests (Debug)"
+               title = "Set Bazel Build Output Groups for tests"
                scriptText = "echo &quot;$BAZEL_LABEL,$BAZEL_TARGET_ID&quot; &gt;&gt; &quot;$SCHEME_TARGET_IDS_FILE&quot;&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
-                     BlueprintIdentifier = "1F8ACFD448DBFCE4D2BCD6CD"
+                     BlueprintIdentifier = "979D12680661F4B864602CE6"
                      BuildableName = "tests.xctest"
-                     BlueprintName = "tests (Debug)"
+                     BlueprintName = "tests"
                      ReferencedContainer = "container:../../../../../test/fixtures/generator/bwb.xcodeproj">
                   </BuildableReference>
                </EnvironmentBuildable>
@@ -128,9 +128,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "1F8ACFD448DBFCE4D2BCD6CD"
+               BlueprintIdentifier = "979D12680661F4B864602CE6"
                BuildableName = "tests.xctest"
-               BlueprintName = "tests (Debug)"
+               BlueprintName = "tests"
                ReferencedContainer = "container:../../../../../test/fixtures/generator/bwb.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -151,9 +151,9 @@
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
-                     BlueprintIdentifier = "1F8ACFD448DBFCE4D2BCD6CD"
+                     BlueprintIdentifier = "979D12680661F4B864602CE6"
                      BuildableName = "tests.xctest"
-                     BlueprintName = "tests (Debug)"
+                     BlueprintName = "tests"
                      ReferencedContainer = "container:../../../../../test/fixtures/generator/bwb.xcodeproj">
                   </BuildableReference>
                </EnvironmentBuildable>
@@ -163,9 +163,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "1F8ACFD448DBFCE4D2BCD6CD"
+            BlueprintIdentifier = "979D12680661F4B864602CE6"
             BuildableName = "tests.xctest"
-            BlueprintName = "tests (Debug)"
+            BlueprintName = "tests"
             ReferencedContainer = "container:../../../../../test/fixtures/generator/bwb.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -174,9 +174,9 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "1F8ACFD448DBFCE4D2BCD6CD"
+               BlueprintIdentifier = "979D12680661F4B864602CE6"
                BuildableName = "tests.xctest"
-               BlueprintName = "tests (Debug)"
+               BlueprintName = "tests"
                ReferencedContainer = "container:../../../../../test/fixtures/generator/bwb.xcodeproj">
             </BuildableReference>
          </TestableReference>

--- a/test/fixtures/generator/bwb_targets_spec.json
+++ b/test/fixtures/generator/bwb_targets_spec.json
@@ -28,11 +28,6 @@
             "PRODUCT_MODULE_NAME": "tests"
         },
         "c": "applebin_macos-darwin_x86_64-dbg-STABLE-3",
-        "d": [
-            "//tools/generators/legacy:generator.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
-            "//tools/generators/lib/GeneratorCommon:GeneratorCommon macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
-            "@com_github_pointfreeco_swift_custom_dump//:CustomDump macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1"
-        ],
         "i": {
             "s": [
                 "tools/generators/legacy/test/AddTargetsTests.swift",
@@ -137,10 +132,6 @@
             "SWIFT_COMPILATION_MODE": "wholemodule"
         },
         "c": "applebin_macos-darwin_x86_64-opt-STABLE-4",
-        "d": [
-            "//tools/generators/legacy:generator.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2",
-            "//tools/generators/lib/GeneratorCommon:GeneratorCommon macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2"
-        ],
         "i": {
             "s": [
                 "tools/generators/legacy/test/AddTargetsTests.swift",
@@ -229,9 +220,6 @@
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "generator_codesigned"
         },
         "c": "applebin_macos-darwin_x86_64-dbg-STABLE-3",
-        "d": [
-            "//tools/generators/legacy:generator.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1"
-        ],
         "l": "//tools/generators/legacy:generator",
         "n": "generator",
         "p": {
@@ -259,9 +247,6 @@
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym"
         },
         "c": "applebin_macos-darwin_x86_64-opt-STABLE-4",
-        "d": [
-            "//tools/generators/legacy:generator.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2"
-        ],
         "l": "//tools/generators/legacy:generator",
         "n": "generator",
         "p": {
@@ -289,13 +274,6 @@
             "PRODUCT_MODULE_NAME": "generator"
         },
         "c": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
-        "d": [
-            "//tools/generators/lib/GeneratorCommon:GeneratorCommon macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
-            "@com_github_apple_swift_collections//:OrderedCollections macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
-            "@com_github_kylef_pathkit//:PathKit macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
-            "@com_github_michaeleisel_zippyjson//:ZippyJSON macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
-            "@com_github_tuist_xcodeproj//:XcodeProj macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1"
-        ],
         "i": {
             "s": [
                 "tools/generators/legacy/src/BuildSettingConditional.swift",
@@ -397,13 +375,6 @@
             "SWIFT_COMPILATION_MODE": "wholemodule"
         },
         "c": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2",
-        "d": [
-            "//tools/generators/lib/GeneratorCommon:GeneratorCommon macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2",
-            "@com_github_apple_swift_collections//:OrderedCollections macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2",
-            "@com_github_kylef_pathkit//:PathKit macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2",
-            "@com_github_michaeleisel_zippyjson//:ZippyJSON macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2",
-            "@com_github_tuist_xcodeproj//:XcodeProj macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2"
-        ],
         "i": {
             "s": [
                 "tools/generators/legacy/src/BuildSettingConditional.swift",
@@ -507,9 +478,6 @@
             "PRODUCT_MODULE_NAME": "GeneratorCommon"
         },
         "c": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
-        "d": [
-            "@com_github_apple_swift_argument_parser//:ArgumentParser macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1"
-        ],
         "i": {
             "s": [
                 "tools/generators/lib/GeneratorCommon/src/BuildMode.swift",
@@ -550,9 +518,6 @@
             "SWIFT_COMPILATION_MODE": "wholemodule"
         },
         "c": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2",
-        "d": [
-            "@com_github_apple_swift_argument_parser//:ArgumentParser macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2"
-        ],
         "i": {
             "s": [
                 "tools/generators/lib/GeneratorCommon/src/BuildMode.swift",
@@ -694,9 +659,6 @@
             "PRODUCT_MODULE_NAME": "ArgumentParser"
         },
         "c": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
-        "d": [
-            "@com_github_apple_swift_argument_parser//:ArgumentParserToolInfo macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1"
-        ],
         "i": {
             "s": [
                 "external/com_github_apple_swift_argument_parser/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift",
@@ -771,9 +733,6 @@
             "SWIFT_COMPILATION_MODE": "wholemodule"
         },
         "c": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2",
-        "d": [
-            "@com_github_apple_swift_argument_parser//:ArgumentParserToolInfo macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2"
-        ],
         "i": {
             "s": [
                 "external/com_github_apple_swift_argument_parser/Sources/ArgumentParser/Completions/BashCompletionsGenerator.swift",
@@ -1225,10 +1184,6 @@
             "PRODUCT_MODULE_NAME": "ZippyJSON"
         },
         "c": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
-        "d": [
-            "@com_github_michaeleisel_jjliso8601dateformatter//:JJLISO8601DateFormatter macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
-            "@com_github_michaeleisel_zippyjsoncfamily//:ZippyJSONCFamily macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1"
-        ],
         "i": {
             "s": [
                 "external/com_github_michaeleisel_zippyjson/Sources/ZippyJSON/ZippyJSONDecoder.swift"
@@ -1264,10 +1219,6 @@
             "SWIFT_COMPILATION_MODE": "wholemodule"
         },
         "c": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2",
-        "d": [
-            "@com_github_michaeleisel_jjliso8601dateformatter//:JJLISO8601DateFormatter macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2",
-            "@com_github_michaeleisel_zippyjsoncfamily//:ZippyJSONCFamily macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2"
-        ],
         "i": {
             "s": [
                 "external/com_github_michaeleisel_zippyjson/Sources/ZippyJSON/ZippyJSONDecoder.swift"
@@ -1366,9 +1317,6 @@
             "PRODUCT_MODULE_NAME": "CustomDump"
         },
         "c": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
-        "d": [
-            "@com_github_pointfreeco_xctest_dynamic_overlay//:XCTestDynamicOverlay macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1"
-        ],
         "i": {
             "s": [
                 "external/com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Conformances/CoreImage.swift",
@@ -1460,9 +1408,6 @@
             "PRODUCT_MODULE_NAME": "XcodeProj"
         },
         "c": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
-        "d": [
-            "@com_github_kylef_pathkit//:PathKit macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1"
-        ],
         "i": {
             "s": [
                 "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Errors/Errors.swift",
@@ -1593,9 +1538,6 @@
             "SWIFT_COMPILATION_MODE": "wholemodule"
         },
         "c": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2",
-        "d": [
-            "@com_github_kylef_pathkit//:PathKit macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2"
-        ],
         "i": {
             "s": [
                 "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Errors/Errors.swift",

--- a/tools/generators/legacy/src/Generator/SetTargetDependencies.swift
+++ b/tools/generators/legacy/src/Generator/SetTargetDependencies.swift
@@ -39,13 +39,6 @@ Target \(key)'s dependency on \(dependencyKey) not found in `pbxTargets`
                     }
                     let dependency = labeledDependency.pbxTarget
 
-                    guard disambiguatedTarget.target.shouldIncludeDependency(
-                        dependency,
-                        buildMode: buildMode
-                    ) else {
-                        return nil
-                    }
-
                     return dependency
                 }
                 // Sort them by name
@@ -57,22 +50,5 @@ Target \(key)'s dependency on \(dependencyKey) not found in `pbxTargets`
                 // Add the dependencies to the `PBXNativeTarget`
                 .forEach { _ = try pbxTarget.addDependency(target: $0) }
         }
-    }
-}
-
-extension ConsolidatedTarget {
-    func shouldIncludeDependency(
-        _ dependency: PBXNativeTarget,
-        buildMode: BuildMode
-    ) -> Bool {
-        guard buildMode == .bazel else {
-            return true
-        }
-
-        // Test hosts need to be copied
-        // watchOS 2 App Extensions need to be embedded
-        return (product.type.isTestBundle && dependency.isLaunchable)
-            || (product.type == .watch2App &&
-                dependency.productType?.isAppExtension == true)
     }
 }

--- a/tools/generators/pbxtargetdependencies/src/Generator/ConsolidationMapsArguments.swift
+++ b/tools/generators/pbxtargetdependencies/src/Generator/ConsolidationMapsArguments.swift
@@ -152,7 +152,7 @@ Dependencies for all of the targets. See <dependency-counts> for how these \
 dependencies will be distributed between the targets.
 """
     )
-    var dependencies: [TargetID]
+    var dependencies: [TargetID] = []
 
     mutating func validate() throws {
         guard labelCounts.count == outputPaths.count else {

--- a/xcodeproj/internal/library_targets.bzl
+++ b/xcodeproj/internal/library_targets.bzl
@@ -65,6 +65,7 @@ def process_library_target(
     )
 
     dependencies, transitive_dependencies = process_dependencies(
+        build_mode = build_mode,
         transitive_infos = transitive_infos,
     )
 

--- a/xcodeproj/internal/non_xcode_targets.bzl
+++ b/xcodeproj/internal/non_xcode_targets.bzl
@@ -41,6 +41,7 @@ def process_non_xcode_target(
     Returns:
         The value returned from `processed_target`.
     """
+    build_mode = ctx.attr._build_mode
     cc_info = target[CcInfo] if CcInfo in target else None
     objc = target[apple_common.Objc] if apple_common.Objc in target else None
     swift_info = target[SwiftInfo] if SwiftInfo in target else None
@@ -93,6 +94,7 @@ rules_xcodeproj requires {} to have `{}` set.
     swiftmodules = process_swiftmodules(swift_info = swift_info)
 
     dependencies, transitive_dependencies = process_dependencies(
+        build_mode = build_mode,
         transitive_infos = transitive_infos,
     )
 
@@ -130,7 +132,7 @@ rules_xcodeproj requires {} to have `{}` set.
         dependencies = dependencies,
         inputs = provider_inputs,
         lldb_context = lldb_contexts.collect(
-            build_mode = ctx.attr._build_mode,
+            build_mode = build_mode,
             id = None,
             is_swift = False,
             # TODO: Should we still collect this?

--- a/xcodeproj/internal/target_properties.bzl
+++ b/xcodeproj/internal/target_properties.bzl
@@ -3,6 +3,9 @@
 load(":collections.bzl", "set_if_true", "uniq")
 load(":memory_efficiency.bzl", "memory_efficient_depset")
 
+_WATCHKIT2 = "com.apple.product-type.application.watchapp2"
+_WATCHKIT2_EXTENSION = "com.apple.product-type.watchkit2-extension"
+
 def should_include_non_xcode_outputs(ctx):
     """Determines whether outputs of non Xcode targets should be included in \
     output groups.
@@ -16,10 +19,20 @@ def should_include_non_xcode_outputs(ctx):
     """
     return ctx.attr._build_mode == "xcode"
 
-def process_dependencies(*, transitive_infos):
+def process_dependencies(
+        *,
+        build_mode,
+        top_level_product_type = None,
+        test_host = None,
+        transitive_infos):
     """Logic for processing target dependencies.
 
     Args:
+        build_mode: See `xcodeproj.build_mode`.
+        top_level_product_type: If this target is a top-level target, then the
+            product type for this target, else `None`.
+        test_host: The `xcode_target.id` of the target that is the test host for
+            this target, or `None` if this target does not have a test host.
         transitive_infos: A `list` of `XcodeProjInfo`s for the transitive
             dependencies of `target`.
 
@@ -29,17 +42,29 @@ def process_dependencies(*, transitive_infos):
         *   A `depset` of direct dependencies.
         *   A `depset` of direct and transitive dependencies.
     """
+    include_all_deps = build_mode != "bazel"
+
     direct_dependencies = []
     direct_transitive_dependencies = []
+    transitive_direct_dependencies = []
     all_transitive_dependencies = []
     for info in transitive_infos:
         all_transitive_dependencies.append(info.transitive_dependencies)
-        if info.xcode_target and info.xcode_target.should_create_xcode_target:
+        xcode_target = info.xcode_target
+        if xcode_target and xcode_target.should_create_xcode_target:
             # TODO: Refactor `should_create_xcode_target` and
             # `should_generate_target` handling. The only reason we don't use
             # `should_generate_target` for header-only targets is because we
             # want to be able to unfocus their files.
-            direct_dependencies.append(info.xcode_target.id)
+            if (include_all_deps or
+                # Test hosts need to be copied
+                test_host == xcode_target.id or
+                # watchOS 2 App Extensions need to be embedded
+                (top_level_product_type == _WATCHKIT2 and
+                xcode_target.product.type == _WATCHKIT2_EXTENSION)
+            ):
+                direct_dependencies.append(xcode_target.id)
+            transitive_direct_dependencies.append(xcode_target.id)
         else:
             # We pass on the next level of dependencies if the previous target
             # didn't create an Xcode target.
@@ -50,7 +75,7 @@ def process_dependencies(*, transitive_infos):
         transitive = direct_transitive_dependencies,
     )
     transitive = memory_efficient_depset(
-        direct_dependencies,
+        transitive_direct_dependencies,
         transitive = all_transitive_dependencies,
     )
     return (direct, transitive)

--- a/xcodeproj/internal/target_properties.bzl
+++ b/xcodeproj/internal/target_properties.bzl
@@ -56,12 +56,13 @@ def process_dependencies(
             # `should_generate_target` handling. The only reason we don't use
             # `should_generate_target` for header-only targets is because we
             # want to be able to unfocus their files.
-            if (include_all_deps or
+            if (
+                include_all_deps or
                 # Test hosts need to be copied
                 test_host == xcode_target.id or
                 # watchOS 2 App Extensions need to be embedded
                 (top_level_product_type == _WATCHKIT2 and
-                xcode_target.product.type == _WATCHKIT2_EXTENSION)
+                 xcode_target.product.type == _WATCHKIT2_EXTENSION)
             ):
                 direct_dependencies.append(xcode_target.id)
             transitive_direct_dependencies.append(xcode_target.id)

--- a/xcodeproj/internal/top_level_targets.bzl
+++ b/xcodeproj/internal/top_level_targets.bzl
@@ -189,10 +189,6 @@ def process_top_level_target(
     label = target.label
     id = get_id(label = label, configuration = configuration)
 
-    dependencies, transitive_dependencies = process_dependencies(
-        transitive_infos = transitive_infos,
-    )
-
     frameworks = getattr(ctx.rule.attr, "frameworks", [])
     framework_infos = [
         framework[XcodeProjInfo]
@@ -310,6 +306,13 @@ def process_top_level_target(
         build_settings = build_settings,
     )
     platform = platforms.collect(ctx = ctx)
+
+    dependencies, transitive_dependencies = process_dependencies(
+        build_mode = build_mode,
+        test_host = test_host,
+        top_level_product_type = props.product_type,
+        transitive_infos = transitive_infos,
+    )
 
     avoid_compilation_providers_list = [
         (info.xcode_target, info.compilation_providers)

--- a/xcodeproj/internal/xcodeprojinfo.bzl
+++ b/xcodeproj/internal/xcodeprojinfo.bzl
@@ -217,6 +217,7 @@ def _target_info_fields(
 def _skip_target(
         *,
         ctx,
+        build_mode,
         target,
         target_skip_type,
         deps,
@@ -230,6 +231,7 @@ def _skip_target(
 
     Args:
         ctx: The aspect context.
+        build_mode: See `xcodeproj.build_mode`.
         target_skip_type: The `skip_type` for this `target` (see `_get_skip_type`).
         target: The `Target` to skip.
         deps: `Target`s collected from `ctx.attr.deps`.
@@ -264,6 +266,7 @@ def _skip_target(
     ]
 
     dependencies, transitive_dependencies = process_dependencies(
+        build_mode = build_mode,
         transitive_infos = valid_transitive_infos,
     )
 
@@ -357,7 +360,7 @@ def _skip_target(
             transitive_infos = valid_transitive_infos,
         ),
         lldb_context = lldb_contexts.collect(
-            build_mode = ctx.attr._build_mode,
+            build_mode = build_mode,
             id = None,
             is_swift = False,
             transitive_infos = valid_transitive_infos,
@@ -620,6 +623,7 @@ def create_xcodeprojinfo(*, ctx, build_mode, target, attrs, transitive_infos):
     if target_skip_type:
         info_fields = _skip_target(
             ctx = ctx,
+            build_mode = build_mode,
             target = target,
             target_skip_type = target_skip_type,
             deps = [


### PR DESCRIPTION
- Less information sent to generator
- Less memory Starlark memory retained
- Better target consolidation (since it was taking into account removed dependencies)