### PR TITLE
Fix `-ivfsoverlay` for mixed-language targets

### DIFF
--- a/examples/rules_ios/test/fixtures/bazel-6/bwb_replacements.txt
+++ b/examples/rules_ios/test/fixtures/bazel-6/bwb_replacements.txt
@@ -1,4 +1,4 @@
-darwin_x86_64-dbg-STABLE-0 darwin_x86_64-dbg-ST-c1364496ad04
+darwin_x86_64-dbg-STABLE-0 darwin_x86_64-dbg-ST-40b5e5d10671
 ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1 ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-fa03a09cd9d2
 ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-2 ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-8621be700a58
 applebin_ios-ios_x86_64-dbg-STABLE-3 applebin_ios-ios_x86_64-dbg-ST-fa03a09cd9d2

--- a/examples/rules_ios/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/rules_ios/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -4443,7 +4443,7 @@
 			buildSettings = {
 				ARCHS = x86_64;
 				ASAN_OTHER_CFLAGS__ = "$(ASAN_OTHER_CFLAGS__NO)";
-				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) @$(DERIVED_FILE_DIR)/c.compile.params";
+				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) -ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/c.compile.params";
 				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
 				BAZEL_COMPILE_TARGET_IDS = "//iOSApp/Test/MixedUnitTests:iOSAppMixedUnitTests_swift ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1 //iOSApp/Test/MixedUnitTests:iOSAppMixedUnitTests_objc ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1";
 				"BAZEL_COMPILE_TARGET_IDS[sdk=iphonesimulator*]" = "$(BAZEL_COMPILE_TARGET_IDS)";

--- a/examples/sanitizers/test/fixtures/bazel-6/bwb_replacements.txt
+++ b/examples/sanitizers/test/fixtures/bazel-6/bwb_replacements.txt
@@ -1,3 +1,3 @@
-darwin_x86_64-dbg-STABLE-0 darwin_x86_64-dbg-ST-c1364496ad04
+darwin_x86_64-dbg-STABLE-0 darwin_x86_64-dbg-ST-40b5e5d10671
 ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1 ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-fa03a09cd9d2
 applebin_ios-ios_x86_64-dbg-STABLE-2 applebin_ios-ios_x86_64-dbg-ST-fa03a09cd9d2

--- a/examples/sanitizers/test/fixtures/bazel-6/bwx_replacements.txt
+++ b/examples/sanitizers/test/fixtures/bazel-6/bwx_replacements.txt
@@ -1,3 +1,3 @@
-darwin_x86_64-dbg-STABLE-0 darwin_x86_64-dbg-ST-c1364496ad04
+darwin_x86_64-dbg-STABLE-0 darwin_x86_64-dbg-ST-40b5e5d10671
 ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1 ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-fa03a09cd9d2
 applebin_ios-ios_x86_64-dbg-STABLE-2 applebin_ios-ios_x86_64-dbg-ST-fa03a09cd9d2

--- a/tools/generators/legacy/src/Generator/SetTargetConfigurations.swift
+++ b/tools/generators/legacy/src/Generator/SetTargetConfigurations.swift
@@ -474,19 +474,18 @@ $(BAZEL_OUT)\#(swiftParams.path.string.dropFirst(9))
                     "-vfsoverlay",
                     "$(OBJROOT)/bazel-out-overlay.yaml",
                 ])
-            } else {
-                if !cFlags.isEmpty {
-                    cFlagsPrefix.append(contentsOf: [
-                        "-ivfsoverlay",
-                        "$(OBJROOT)/bazel-out-overlay.yaml",
-                    ])
-                }
-                if !cxxFlags.isEmpty {
-                    cxxFlagsPrefix.append(contentsOf: [
-                        "-ivfsoverlay",
-                        "$(OBJROOT)/bazel-out-overlay.yaml",
-                    ])
-                }
+            }
+            if !cFlags.isEmpty {
+                cFlagsPrefix.append(contentsOf: [
+                    "-ivfsoverlay",
+                    "$(OBJROOT)/bazel-out-overlay.yaml",
+                ])
+            }
+            if !cxxFlags.isEmpty {
+                cxxFlagsPrefix.append(contentsOf: [
+                    "-ivfsoverlay",
+                    "$(OBJROOT)/bazel-out-overlay.yaml",
+                ])
             }
         }
 


### PR DESCRIPTION
We were incorrectly only setting `-ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml` for targets with no Swift code. This could break mixed-language targets.