### PR TITLE
Simplify `output_files.bzl`

### DIFF
--- a/xcodeproj/internal/non_xcode_targets.bzl
+++ b/xcodeproj/internal/non_xcode_targets.bzl
@@ -119,7 +119,7 @@ rules_xcodeproj requires {} to have `{}` set.
         automatic_target_info = automatic_target_info,
         transitive_infos = transitive_infos,
     )
-    (_, provider_outputs) = output_files.merge(
+    provider_outputs = output_files.merge(
         transitive_infos = transitive_infos,
     )
 

--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -1483,7 +1483,7 @@ configurations: {}""".format(", ".join(xcode_configurations)))
     name = ctx.attr.name
     project_name = ctx.attr.project_name
 
-    (_, provider_outputs) = output_files.merge(
+    provider_outputs = output_files.merge(
         transitive_infos = infos,
     )
 

--- a/xcodeproj/internal/xcodeprojinfo.bzl
+++ b/xcodeproj/internal/xcodeprojinfo.bzl
@@ -270,7 +270,7 @@ def _skip_target(
         transitive_infos = valid_transitive_infos,
     )
 
-    (_, provider_outputs) = output_files.merge(
+    provider_outputs = output_files.merge(
         transitive_infos = valid_transitive_infos,
     )
 


### PR DESCRIPTION
After various past optimizations the need for `_create` with a lot of conditionals is no longer needed. Instead most of that code is merged into `_collect_output_files`, and `_merge_output_files` is greatly simplified.