### PR TITLE
Simplify/improve `non_xcode_targets` `mergable_xcode_library_targets` calculation

### DIFF
--- a/docs/bazel.md
+++ b/docs/bazel.md
@@ -605,7 +605,7 @@ Provides information needed to generate an Xcode project.
 | <a id="XcodeProjInfo-label"></a>label |  The `Label` of the target.    |
 | <a id="XcodeProjInfo-labels"></a>labels |  A `depset` of `Labels` for the target and its transitive dependencies.    |
 | <a id="XcodeProjInfo-lldb_context"></a>lldb_context |  A value returned from `lldb_context.collect`.    |
-| <a id="XcodeProjInfo-mergable_xcode_library_targets"></a>mergable_xcode_library_targets |  A `depset` of `struct`s of target ids (see `xcode_target.id`). Each id represents a target that can potentially merge into a top-level target (to be decided by the top-level target).    |
+| <a id="XcodeProjInfo-mergable_xcode_library_targets"></a>mergable_xcode_library_targets |  A `depset` of target ids (see `xcode_target.id`). Each represents a target that can potentially merge into a top-level target (to be decided by the top-level target).    |
 | <a id="XcodeProjInfo-potential_target_merges"></a>potential_target_merges |  A `depset` of `struct`s with 'src' and 'dest' fields. The 'src' field is the id of the target that can be merged into the target with the id of the 'dest' field.    |
 | <a id="XcodeProjInfo-outputs"></a>outputs |  A value returned from `output_files.collect`, that contains information about the output files for this target and its transitive dependencies.    |
 | <a id="XcodeProjInfo-replacement_labels"></a>replacement_labels |  A `depset` of `struct`s with `id` and `label` fields. The `id` field is the target id of the target that have its label (and name) be replaced with the label in the `label` field.    |

--- a/docs/bazel.md
+++ b/docs/bazel.md
@@ -605,7 +605,7 @@ Provides information needed to generate an Xcode project.
 | <a id="XcodeProjInfo-label"></a>label |  The `Label` of the target.    |
 | <a id="XcodeProjInfo-labels"></a>labels |  A `depset` of `Labels` for the target and its transitive dependencies.    |
 | <a id="XcodeProjInfo-lldb_context"></a>lldb_context |  A value returned from `lldb_context.collect`.    |
-| <a id="XcodeProjInfo-mergable_xcode_library_targets"></a>mergable_xcode_library_targets |  A `List` of `struct`s with 'id' and 'product_path' fields. The 'id' field is the id of the target. The 'product_path' is the path to the target's product.    |
+| <a id="XcodeProjInfo-mergable_xcode_library_targets"></a>mergable_xcode_library_targets |  A `depset` of `struct`s with 'id' and 'product_path' fields. The 'id' field is the id of the target. The 'product_path' is the path to the target's product.    |
 | <a id="XcodeProjInfo-potential_target_merges"></a>potential_target_merges |  A `depset` of `struct`s with 'src' and 'dest' fields. The 'src' field is the id of the target that can be merged into the target with the id of the 'dest' field.    |
 | <a id="XcodeProjInfo-outputs"></a>outputs |  A value returned from `output_files.collect`, that contains information about the output files for this target and its transitive dependencies.    |
 | <a id="XcodeProjInfo-replacement_labels"></a>replacement_labels |  A `depset` of `struct`s with `id` and `label` fields. The `id` field is the target id of the target that have its label (and name) be replaced with the label in the `label` field.    |

--- a/docs/bazel.md
+++ b/docs/bazel.md
@@ -605,7 +605,7 @@ Provides information needed to generate an Xcode project.
 | <a id="XcodeProjInfo-label"></a>label |  The `Label` of the target.    |
 | <a id="XcodeProjInfo-labels"></a>labels |  A `depset` of `Labels` for the target and its transitive dependencies.    |
 | <a id="XcodeProjInfo-lldb_context"></a>lldb_context |  A value returned from `lldb_context.collect`.    |
-| <a id="XcodeProjInfo-mergable_xcode_library_targets"></a>mergable_xcode_library_targets |  A `depset` of `struct`s with 'id' and 'product_path' fields. The 'id' field is the id of the target. The 'product_path' is the path to the target's product.    |
+| <a id="XcodeProjInfo-mergable_xcode_library_targets"></a>mergable_xcode_library_targets |  A `depset` of `struct`s of target ids (see `xcode_target.id`). Each id represents a target that can potentially merge into a top-level target (to be decided by the top-level target).    |
 | <a id="XcodeProjInfo-potential_target_merges"></a>potential_target_merges |  A `depset` of `struct`s with 'src' and 'dest' fields. The 'src' field is the id of the target that can be merged into the target with the id of the 'dest' field.    |
 | <a id="XcodeProjInfo-outputs"></a>outputs |  A value returned from `output_files.collect`, that contains information about the output files for this target and its transitive dependencies.    |
 | <a id="XcodeProjInfo-replacement_labels"></a>replacement_labels |  A `depset` of `struct`s with `id` and `label` fields. The `id` field is the target id of the target that have its label (and name) be replaced with the label in the `label` field.    |

--- a/xcodeproj/internal/library_targets.bzl
+++ b/xcodeproj/internal/library_targets.bzl
@@ -207,12 +207,12 @@ def process_library_target(
         should_create_xcode_target = target.files != depset(),
     )
 
-    mergable_xcode_library_targets = [
+    mergable_xcode_library_targets = depset([
         struct(
             id = xcode_target.id,
             product_path = xcode_target.product.file_path,
         ),
-    ]
+    ])
 
     return processed_target(
         compilation_providers = compilation_providers,

--- a/xcodeproj/internal/library_targets.bzl
+++ b/xcodeproj/internal/library_targets.bzl
@@ -207,12 +207,7 @@ def process_library_target(
         should_create_xcode_target = target.files != depset(),
     )
 
-    mergable_xcode_library_targets = depset([
-        struct(
-            id = xcode_target.id,
-            product_path = xcode_target.product.file_path,
-        ),
-    ])
+    mergable_xcode_library_targets = depset([xcode_target.id])
 
     return processed_target(
         compilation_providers = compilation_providers,

--- a/xcodeproj/internal/non_xcode_targets.bzl
+++ b/xcodeproj/internal/non_xcode_targets.bzl
@@ -11,6 +11,7 @@ load(":configuration.bzl", "calculate_configuration")
 load(":input_files.bzl", "input_files")
 load(":linker_input_files.bzl", "linker_input_files")
 load(":lldb_contexts.bzl", "lldb_contexts")
+load(":memory_efficiency.bzl", "memory_efficient_depset")
 load(":output_files.bzl", "output_files")
 load(":processed_target.bzl", "processed_target")
 load(":target_id.bzl", "get_id")
@@ -98,17 +99,12 @@ rules_xcodeproj requires {} to have `{}` set.
         transitive_infos = transitive_infos,
     )
 
-    mergable_xcode_library_targets = [
-        struct(
-            id = target.id,
-            product_path = target.product.file_path,
-        )
-        for target, providers in [
-            (info.xcode_target, info.compilation_providers)
+    mergable_xcode_library_targets = memory_efficient_depset(
+        transitive = [
+            info.mergable_xcode_library_targets
             for info in transitive_infos
         ]
-        if providers._is_xcode_library_target
-    ]
+    )
 
     (_, provider_inputs) = input_files.collect(
         ctx = ctx,

--- a/xcodeproj/internal/non_xcode_targets.bzl
+++ b/xcodeproj/internal/non_xcode_targets.bzl
@@ -103,7 +103,7 @@ rules_xcodeproj requires {} to have `{}` set.
         transitive = [
             info.mergable_xcode_library_targets
             for info in transitive_infos
-        ]
+        ],
     )
 
     (_, provider_inputs) = input_files.collect(

--- a/xcodeproj/internal/processed_target.bzl
+++ b/xcodeproj/internal/processed_target.bzl
@@ -1,5 +1,6 @@
 """Functions for creating data structures related to processed bazel targets."""
 
+load(":memory_efficiency.bzl", "EMPTY_DEPSET")
 load(":providers.bzl", "target_type")
 
 def processed_target(
@@ -13,7 +14,7 @@ def processed_target(
         is_xcode_required = False,
         library = None,
         lldb_context,
-        mergable_xcode_library_targets = None,
+        mergable_xcode_library_targets = EMPTY_DEPSET,
         outputs,
         potential_target_merges = None,
         resource_bundle_informations = None,
@@ -37,9 +38,8 @@ def processed_target(
         library: A `File` for the static library produced by this target, or
             `None`.
         lldb_context: A value as returned from `lldb_context.collect`.
-        mergable_xcode_library_targets: An optional `list` of `struct`s that
-            will be in the `XcodeProjInfo.mergable_xcode_library_targets`
-            `depset`.
+        mergable_xcode_library_targets: A `depset` of `struct`s that will be in
+            the `XcodeProjInfo.mergable_xcode_library_targets` field.
         outputs: A value as returned from `output_files.collect` that will
             provide values for the `XcodeProjInfo.outputs` field.
         potential_target_merges: An optional `list` of `struct`s that will be in

--- a/xcodeproj/internal/providers.bzl
+++ b/xcodeproj/internal/providers.bzl
@@ -154,8 +154,9 @@ A `depset` of `Labels` for the target and its transitive dependencies.
 """,
         "lldb_context": "A value returned from `lldb_context.collect`.",
         "mergable_xcode_library_targets": """\
-A `depset` of `struct`s with 'id' and 'product_path' fields. The 'id' field
-is the id of the target. The 'product_path' is the path to the target's product.
+A `depset` of `struct`s of target ids (see `xcode_target.id`). Each id
+represents a target that can potentially merge into a top-level target (to be
+decided by the top-level target).
 """,
         "potential_target_merges": """\
 A `depset` of `struct`s with 'src' and 'dest' fields. The 'src' field is the id

--- a/xcodeproj/internal/providers.bzl
+++ b/xcodeproj/internal/providers.bzl
@@ -154,9 +154,8 @@ A `depset` of `Labels` for the target and its transitive dependencies.
 """,
         "lldb_context": "A value returned from `lldb_context.collect`.",
         "mergable_xcode_library_targets": """\
-A `List` of `struct`s with 'id' and 'product_path' fields. The 'id' field
-is the id of the target. The 'product_path' is the path to the target's
-product.
+A `depset` of `struct`s with 'id' and 'product_path' fields. The 'id' field
+is the id of the target. The 'product_path' is the path to the target's product.
 """,
         "potential_target_merges": """\
 A `depset` of `struct`s with 'src' and 'dest' fields. The 'src' field is the id

--- a/xcodeproj/internal/providers.bzl
+++ b/xcodeproj/internal/providers.bzl
@@ -154,9 +154,9 @@ A `depset` of `Labels` for the target and its transitive dependencies.
 """,
         "lldb_context": "A value returned from `lldb_context.collect`.",
         "mergable_xcode_library_targets": """\
-A `depset` of `struct`s of target ids (see `xcode_target.id`). Each id
-represents a target that can potentially merge into a top-level target (to be
-decided by the top-level target).
+A `depset` of target ids (see `xcode_target.id`). Each represents a target that
+can potentially merge into a top-level target (to be decided by the top-level
+target).
 """,
         "potential_target_merges": """\
 A `depset` of `struct`s with 'src' and 'dest' fields. The 'src' field is the id

--- a/xcodeproj/internal/top_level_targets.bzl
+++ b/xcodeproj/internal/top_level_targets.bzl
@@ -18,6 +18,7 @@ load(":linker_input_files.bzl", "linker_input_files")
 load(":lldb_contexts.bzl", "lldb_contexts")
 load(
     ":memory_efficiency.bzl",
+    "EMPTY_DEPSET",
     "EMPTY_LIST",
     "memory_efficient_depset",
 )
@@ -529,7 +530,7 @@ def process_top_level_target(
         is_top_level_target = not is_app_extension,
         is_xcode_required = True,
         lldb_context = lldb_context,
-        mergable_xcode_library_targets = EMPTY_LIST,
+        mergable_xcode_library_targets = EMPTY_DEPSET,
         outputs = provider_outputs,
         potential_target_merges = potential_target_merges,
         transitive_dependencies = transitive_dependencies,

--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -506,7 +506,7 @@ targets.
 
     raw_target_merge_dests = {}
     for merge in potential_target_merges:
-        src_target = unprocessed_targets[merge.src.id]
+        src_target = unprocessed_targets[merge.src]
         src_label = bazel_labels.normalize_label(src_target.label)
         dest_target = unprocessed_targets[merge.dest]
         dest_label = bazel_labels.normalize_label(dest_target.label)
@@ -516,12 +516,12 @@ targets.
         # Exclude targets not in focused nor unfocused targets from
         # potential merges since they're not possible Xcode targets.
         merge_src_is_xcode_target = (
-            merge.src.id in focused_targets or
-            merge.src.id in unfocused_targets
+            merge.src in focused_targets or
+            merge.src in unfocused_targets
         )
         if not merge_src_is_xcode_target:
             continue
-        raw_target_merge_dests.setdefault(merge.dest, []).append(merge.src.id)
+        raw_target_merge_dests.setdefault(merge.dest, []).append(merge.src)
 
     target_merge_dests = {}
     for dest, src_ids in raw_target_merge_dests.items():

--- a/xcodeproj/internal/xcodeprojinfo.bzl
+++ b/xcodeproj/internal/xcodeprojinfo.bzl
@@ -544,8 +544,8 @@ def _create_xcodeprojinfo(
         ),
         inputs = processed_target.inputs,
         lldb_context = processed_target.lldb_context,
-        mergable_xcode_library_targets = memory_efficient_depset(
-            processed_target.mergable_xcode_library_targets,
+        mergable_xcode_library_targets = (
+            processed_target.mergable_xcode_library_targets
         ),
         non_top_level_rule_kind = (
             None if processed_target.is_top_level_target else ctx.rule.kind


### PR DESCRIPTION
This now allows multiple layers of non-Xcode targets to exist between the top-level target and the library. The `product_path` was no longer used, so I removed that as well.