### PR TITLE
Add support for Bazel 7 `ObjcProvider` changes

### DIFF
--- a/examples/cc/MODULE.bazel
+++ b/examples/cc/MODULE.bazel
@@ -23,6 +23,8 @@ bazel_dep(
     version = "0.0.1",
 )
 
+bazel_dep(name = "bazel_features", version = "1.0.0", dev_dependency = True)
+
 local_path_override(
     module_name = "rules_xcodeproj",
     path = "../..",

--- a/examples/cc/test/fixtures/BUILD
+++ b/examples/cc/test/fixtures/BUILD
@@ -1,3 +1,4 @@
+load("@bazel_features//:features.bzl", "bazel_features")
 load(
     "@rules_xcodeproj//xcodeproj:testing.bzl",
     "update_fixtures",
@@ -6,13 +7,21 @@ load(
 )
 load("//:xcodeproj_targets.bzl", "XCODEPROJ_TARGETS")
 
+_FIXTURE_MODE_AND_SUFFIXES = (
+    [("bazel", "bwb")] if bazel_features.cc.objc_linking_info_migrated else [
+        ("xcode", "bwx"),
+        ("bazel", "bwb"),
+    ]
+)
+
 xcodeproj_fixture(
+    modes_and_suffixes = _FIXTURE_MODE_AND_SUFFIXES,
     top_level_targets = XCODEPROJ_TARGETS,
 )
 
 _FIXTURES = [
-    ":xcodeproj_bwb",
-    ":xcodeproj_bwx",
+    ":xcodeproj_{}".format(suffix)
+    for _, suffix in _FIXTURE_MODE_AND_SUFFIXES
 ]
 
 update_fixtures(

--- a/examples/integration/MODULE.bazel
+++ b/examples/integration/MODULE.bazel
@@ -27,6 +27,8 @@ bazel_dep(
     version = "0.0.1",
 )
 
+bazel_dep(name = "bazel_features", version = "1.0.0", dev_dependency = True)
+
 local_path_override(
     module_name = "rules_xcodeproj",
     path = "../..",

--- a/examples/integration/test/fixtures/BUILD
+++ b/examples/integration/test/fixtures/BUILD
@@ -1,3 +1,4 @@
+load("@bazel_features//:features.bzl", "bazel_features")
 load(
     "@rules_xcodeproj//xcodeproj:testing.bzl",
     "update_fixtures",
@@ -21,6 +22,13 @@ load(
     "get_xcode_schemes",
 )
 
+_FIXTURE_MODE_AND_SUFFIXES = (
+    [("bazel", "bwb")] if bazel_features.cc.objc_linking_info_migrated else [
+        ("xcode", "bwx"),
+        ("bazel", "bwb"),
+    ]
+)
+
 xcodeproj_fixture(
     associated_extra_files = ASSOCIATED_EXTRA_FILES,
     bazel_env = BAZEL_ENV,
@@ -28,6 +36,7 @@ xcodeproj_fixture(
     default_xcode_configuration = DEFAULT_XCODE_CONFIGURATION,
     extra_files = EXTRA_FILES,
     fail_for_invalid_extra_files_targets = FAIL_FOR_INVALID_EXTRA_FILES_TARGETS,
+    modes_and_suffixes = _FIXTURE_MODE_AND_SUFFIXES,
     pre_build = PRE_BUILD,
     project_options = PROJECT_OPTIONS,
     scheme_autogeneration_mode = SCHEME_AUTOGENERATION_MODE,
@@ -38,8 +47,8 @@ xcodeproj_fixture(
 )
 
 _FIXTURES = [
-    ":xcodeproj_bwb",
-    ":xcodeproj_bwx",
+    ":xcodeproj_{}".format(suffix)
+    for _, suffix in _FIXTURE_MODE_AND_SUFFIXES
 ]
 
 update_fixtures(

--- a/examples/rules_ios/test/fixtures/BUILD
+++ b/examples/rules_ios/test/fixtures/BUILD
@@ -11,6 +11,7 @@ load(
 )
 
 xcodeproj_fixture(
+    modes_and_suffixes = [("bazel", "bwb")],
     scheme_autogeneration_mode = SCHEME_AUTOGENERATION_MODE,
     top_level_targets = XCODEPROJ_TARGETS,
 )

--- a/examples/sanitizers/test/fixtures/BUILD
+++ b/examples/sanitizers/test/fixtures/BUILD
@@ -1,3 +1,4 @@
+load("@bazel_features//:features.bzl", "bazel_features")
 load(
     "@rules_xcodeproj//xcodeproj:testing.bzl",
     "update_fixtures",
@@ -11,15 +12,23 @@ load(
     "get_xcode_schemes",
 )
 
+_FIXTURE_MODE_AND_SUFFIXES = (
+    [("bazel", "bwb")] if bazel_features.cc.objc_linking_info_migrated else [
+        ("xcode", "bwx"),
+        ("bazel", "bwb"),
+    ]
+)
+
 xcodeproj_fixture(
+    modes_and_suffixes = _FIXTURE_MODE_AND_SUFFIXES,
     scheme_autogeneration_mode = SCHEME_AUTOGENERATION_MODE,
     schemes = get_xcode_schemes(),
     top_level_targets = XCODEPROJ_TARGETS,
 )
 
 _FIXTURES = [
-    ":xcodeproj_bwb",
-    ":xcodeproj_bwx",
+    ":xcodeproj_{}".format(suffix)
+    for _, suffix in _FIXTURE_MODE_AND_SUFFIXES
 ]
 
 update_fixtures(

--- a/test/fixtures/fixtures.bzl
+++ b/test/fixtures/fixtures.bzl
@@ -1,15 +1,22 @@
 """Constants for fixture declarations."""
 
+load("@bazel_features//:features.bzl", "bazel_features")
+
 _FIXTURE_BASENAMES = [
     "generator",
 ]
 
-_FIXTURE_SUFFIXES = ["bwx", "bwb"]
+FIXTURE_MODE_AND_SUFFIXES = (
+    [("bazel", "bwb")] if bazel_features.cc.objc_linking_info_migrated else [
+        ("xcode", "bwx"),
+        ("bazel", "bwb"),
+    ]
+)
 
 _FIXTURE_PACKAGES = ["//test/fixtures/{}".format(b) for b in _FIXTURE_BASENAMES]
 
 FIXTURE_TARGETS = [
     "{}:xcodeproj_{}".format(package, suffix)
     for package in _FIXTURE_PACKAGES
-    for suffix in _FIXTURE_SUFFIXES
+    for _, suffix in FIXTURE_MODE_AND_SUFFIXES
 ]

--- a/test/fixtures/generator/BUILD
+++ b/test/fixtures/generator/BUILD
@@ -6,9 +6,11 @@ load(
     "XCODE_CONFIGURATIONS",
     "get_xcode_schemes",
 )
+load("//test/fixtures:fixtures.bzl", "FIXTURE_MODE_AND_SUFFIXES")
 load("//xcodeproj:testing.bzl", "xcodeproj_fixture")
 
 xcodeproj_fixture(
+    modes_and_suffixes = FIXTURE_MODE_AND_SUFFIXES,
     scheme_autogeneration_mode = SCHEME_AUTOGENERATION_MODE,
     schemes = get_xcode_schemes(),
     top_level_targets = TOP_LEVEL_TARGETS,

--- a/test/fixtures/generator/BUILD
+++ b/test/fixtures/generator/BUILD
@@ -1,3 +1,4 @@
+load("//test/fixtures:fixtures.bzl", "FIXTURE_MODE_AND_SUFFIXES")
 load(
     "//tools/generators/legacy:xcodeproj_targets.bzl",
     "SCHEME_AUTOGENERATION_MODE",
@@ -6,7 +7,6 @@ load(
     "XCODE_CONFIGURATIONS",
     "get_xcode_schemes",
 )
-load("//test/fixtures:fixtures.bzl", "FIXTURE_MODE_AND_SUFFIXES")
 load("//xcodeproj:testing.bzl", "xcodeproj_fixture")
 
 xcodeproj_fixture(

--- a/xcodeproj/internal/compilation_providers.bzl
+++ b/xcodeproj/internal/compilation_providers.bzl
@@ -162,6 +162,7 @@ def _merge_compilation_providers(
             ],
             order = "topological",
         )
+
         # Works around an issue with `*_dynamic_framework`
         cc_info = None
     else:

--- a/xcodeproj/internal/compilation_providers.bzl
+++ b/xcodeproj/internal/compilation_providers.bzl
@@ -1,5 +1,12 @@
 """Module for propagating compilation providers."""
 
+load("@bazel_features//:features.bzl", "bazel_features")
+load(
+    ":memory_efficiency.bzl",
+    "EMPTY_DEPSET",
+    "memory_efficient_depset",
+)
+
 def _legacy_merge_cc_compilation_context(
         *,
         direct_compilation_context,
@@ -64,6 +71,8 @@ _merge_cc_compilation_context = (
     _modern_merge_cc_compilation_context if hasattr(apple_common, "link_multi_arch_static_library") else _legacy_merge_cc_compilation_context
 )
 
+_objc_has_linking_info = not bazel_features.cc.objc_linking_info_migrated
+
 def _collect_compilation_providers(
         *,
         cc_info,
@@ -102,10 +111,16 @@ def _collect_compilation_providers(
         ],
     )
 
+    if not _objc_has_linking_info:
+        objc = None
+
     return (
         struct(
+            _framework_files = EMPTY_DEPSET,
             _is_top_level = False,
             _is_xcode_library_target = is_xcode_library_target,
+            _propagated_cc_info = cc_info,
+            _propagated_framework_files = EMPTY_DEPSET,
             _propagated_objc = objc,
             cc_info = cc_info,
             objc = objc,
@@ -133,13 +148,32 @@ def _merge_compilation_providers(
         `compilation_providers.collect`.
     """
     merged_cc_info = cc_common.merge_cc_infos(
-        direct_cc_infos = [cc_info] if cc_info else [],
+        direct_cc_infos = [],
         cc_infos = [
             providers.cc_info
             for _, providers in transitive_compilation_providers
             if providers.cc_info
         ],
     )
+
+    framework_files = memory_efficient_depset(
+        transitive = [
+            providers._propagated_framework_files
+            for _, providers in transitive_compilation_providers
+        ],
+        order = "topological",
+    )
+
+    if apple_dynamic_framework_info:
+        propagated_framework_files = memory_efficient_depset(
+            transitive = [
+                apple_dynamic_framework_info.framework_files,
+                framework_files,
+            ],
+            order = "topological",
+        )
+    else:
+        propagated_framework_files = framework_files
 
     # We don't actually merge the compilation context here, because no top-level
     # rules have (or will need) implementation deps
@@ -148,22 +182,27 @@ def _merge_compilation_providers(
     )
 
     objc = None
-    maybe_objc_providers = [
-        _to_objc(providers._propagated_objc, providers.cc_info)
-        for _, providers in transitive_compilation_providers
-    ]
-    objc_providers = [objc for objc in maybe_objc_providers if objc]
-    if objc_providers:
-        objc = apple_common.new_objc_provider(providers = objc_providers)
-    if apple_dynamic_framework_info:
-        propagated_objc = apple_dynamic_framework_info.objc
+    if _objc_has_linking_info:
+        maybe_objc_providers = [
+            _to_objc(providers._propagated_objc, providers.cc_info)
+            for _, providers in transitive_compilation_providers
+        ]
+        objc_providers = [objc for objc in maybe_objc_providers if objc]
+        if objc_providers:
+            objc = apple_common.new_objc_provider(providers = objc_providers)
+        if apple_dynamic_framework_info:
+            propagated_objc = apple_dynamic_framework_info.objc
+        else:
+            propagated_objc = objc
     else:
-        propagated_objc = objc
+        propagated_objc = None
 
     return (
         struct(
+            _framework_files = framework_files,
             _is_top_level = True,
             _is_xcode_library_target = False,
+            _propagated_framework_files = propagated_framework_files,
             _propagated_objc = propagated_objc,
             cc_info = merged_cc_info,
             objc = objc,

--- a/xcodeproj/internal/linker_input_files.bzl
+++ b/xcodeproj/internal/linker_input_files.bzl
@@ -53,7 +53,6 @@ def _collect_linker_inputs(
         )
     elif compilation_providers._is_xcode_library_target:
         primary_static_library = _compute_primary_static_library(
-            compilation_providers = compilation_providers,
             objc_libraries = objc_libraries,
             cc_linker_inputs = cc_linker_inputs,
         )
@@ -78,18 +77,17 @@ def _merge_linker_inputs(*, compilation_providers):
 
 def _compute_primary_static_library(
         *,
-        compilation_providers,
         objc_libraries,
         cc_linker_inputs):
     # Ideally we would only return the static library that is owned by this
     # target, but sometimes another rule creates the output and this rule
     # outputs it. So far the first library has always been the correct one.
-    if compilation_providers.objc:
+    if objc_libraries:
         for library in objc_libraries:
             if library.is_source:
                 continue
             return library
-    elif compilation_providers.cc_info:
+    elif cc_linker_inputs:
         for input in cc_linker_inputs:
             for library in input.libraries:
                 # TODO: Account for all of the different linking strategies
@@ -119,11 +117,12 @@ def _extract_libraries(compilation_providers):
         cc_linker_inputs = []
     elif compilation_providers.cc_info:
         cc_info = compilation_providers.cc_info
-        objc_libraries = []
         cc_linker_inputs = cc_info.linking_context.linker_inputs.to_list()
-    else:
         objc_libraries = []
+    else:
         cc_linker_inputs = []
+        objc_libraries = []
+
     return (objc_libraries, cc_linker_inputs)
 
 def _extract_top_level_values(
@@ -183,11 +182,12 @@ def _extract_top_level_values(
 """)
             avoid_linking_context = avoid_cc_info.linking_context
             avoid_libraries = {
-                file: None
-                for file in flatten([
+                library: None
+                for library in flatten([
                     input.libraries
                     for input in avoid_linking_context.linker_inputs.to_list()
                 ])
+                if library.static_library or library.pic_static_library
             }
         else:
             avoid_libraries = {}
@@ -205,6 +205,19 @@ def _extract_top_level_values(
                 if library in avoid_libraries:
                     continue
 
+                if library.dynamic_library:
+                    if library.dynamic_library.dirname.endswith(".framework"):
+                        dynamic_frameworks.append(
+                            library.resolved_symlink_dynamic_library or
+                            library.dynamic_library,
+                        )
+                        continue
+
+                if library.static_library:
+                    if library.static_library.dirname.endswith(".framework"):
+                        static_frameworks.append(library.static_library)
+                        continue
+
                 # TODO: Account for all of the different linking strategies
                 # here: https://github.com/bazelbuild/bazel/blob/986ef7b68d61b1573d9c2bb1200585d07ad24691/src/main/java/com/google/devtools/build/lib/rules/cpp/CcLinkingHelper.java#L951-L1009
                 static_library = (library.static_library or
@@ -212,6 +225,11 @@ def _extract_top_level_values(
                 if not static_library:
                     continue
                 static_libraries.append(static_library)
+
+        # Dynamic frameworks from `AppleDynamicFrameworkInfo`
+        dynamic_frameworks.extend(
+            compilation_providers._framework_files.to_list(),
+        )
 
         # Dedup libraries
         static_libraries = uniq(static_libraries)
@@ -251,16 +269,15 @@ def _process_additional_inputs(files):
 
 def _collect_libraries(
         *,
-        compilation_providers,
         objc_libraries,
         cc_linker_inputs):
     libraries = []
-    if compilation_providers.objc:
+    if objc_libraries:
         for library in objc_libraries:
             if library.is_source:
                 continue
             libraries.append(library)
-    elif compilation_providers.cc_info:
+    elif cc_linker_inputs:
         for input in cc_linker_inputs:
             for library in input.libraries:
                 # TODO: Account for all of the different linking strategies
@@ -276,7 +293,6 @@ def _collect_libraries(
 
 def _get_transitive_static_libraries_for_bwx(linker_inputs):
     return _collect_libraries(
-        compilation_providers = linker_inputs._compilation_providers,
         objc_libraries = linker_inputs._objc_libraries,
         cc_linker_inputs = linker_inputs._cc_linker_inputs,
     )
@@ -290,7 +306,6 @@ def _get_library_static_libraries_for_bwx(
     )
 
     transitive = _collect_libraries(
-        compilation_providers = linker_inputs._compilation_providers,
         objc_libraries = linker_inputs._objc_libraries,
         cc_linker_inputs = linker_inputs._cc_linker_inputs,
     )
@@ -298,7 +313,6 @@ def _get_library_static_libraries_for_bwx(
     non_direct_libraries = {
         file: None
         for file in _collect_libraries(
-            compilation_providers = dep_compilation_providers,
             objc_libraries = dep_objc_libraries,
             cc_linker_inputs = dep_cc_linker_inputs,
         )

--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -1,5 +1,6 @@
 """Implementation of the `xcodeproj` rule."""
 
+load("@bazel_features//:features.bzl", "bazel_features")
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_skylib//lib:shell.bzl", "shell")
@@ -1488,6 +1489,11 @@ configurations: {}""".format(", ".join(xcode_configurations)))
     )
     name = ctx.attr.name
     project_name = ctx.attr.project_name
+
+    if build_mode == "xcode" and bazel_features.cc.objc_linking_info_migrated:
+        fail("""\
+`build_mode = "xcode"` is currently not supported with Bazel 7+.
+""")
 
     provider_outputs = output_files.merge(
         transitive_infos = infos,


### PR DESCRIPTION
Info isn’t being populated into it like before, and eventually the provider is going away. So if we don’t find any libraries from it we fallback to the `CcInfo`.