### PR TITLE
Use apple_support Xcode toolchain

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -31,6 +31,7 @@ use_repo(
 bazel_dep(
     name = "apple_support",
     version = "1.8.1",
+    dev_dependency = True,
     repo_name = "build_bazel_apple_support",
 )
 bazel_dep(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -29,6 +29,11 @@ use_repo(
 # Non-release dependencies
 
 bazel_dep(
+    name = "apple_support",
+    version = "1.8.1",
+    repo_name = "build_bazel_apple_support",
+)
+bazel_dep(
     name = "buildifier_prebuilt",
     version = "6.1.0",
     dev_dependency = True,
@@ -50,6 +55,12 @@ single_version_override(
     module_name = "bazel_skylib",
     version = "1.4.2",
 )
+
+apple_cc_configure = use_extension(
+    "@build_bazel_apple_support//crosstool:setup.bzl",
+    "apple_cc_configure_extension",
+)
+use_repo(apple_cc_configure, "local_config_apple_cc")
 
 use_repo(
     non_module_deps,

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -60,6 +60,7 @@ single_version_override(
 apple_cc_configure = use_extension(
     "@build_bazel_apple_support//crosstool:setup.bzl",
     "apple_cc_configure_extension",
+    dev_dependency = True,
 )
 use_repo(apple_cc_configure, "local_config_apple_cc")
 

--- a/examples/cc/.bazelrc
+++ b/examples/cc/.bazelrc
@@ -1,6 +1,11 @@
 # Import parent workspace settings
 import %workspace%/../../shared.bazelrc
 
+# Don't use the apple_support Xcode toolchain
+build --apple_crosstool_top=@bazel_tools//tools/cpp:toolchain
+build --crosstool_top=@bazel_tools//tools/cpp:toolchain
+build --host_crosstool_top=@bazel_tools//tools/cpp:toolchain
+
 build --macos_minimum_os=12.0
 
 build --experimental_cc_implementation_deps

--- a/examples/integration/MODULE.bazel
+++ b/examples/integration/MODULE.bazel
@@ -37,6 +37,12 @@ local_path_override(
     path = "iOSApp/external",
 )
 
+apple_cc_configure = use_extension(
+    "@build_bazel_apple_support//crosstool:setup.bzl",
+    "apple_cc_configure_extension",
+)
+use_repo(apple_cc_configure, "local_config_apple_cc")
+
 non_module_deps = use_extension(":repositories.bzl", "non_module_deps")
 use_repo(
     non_module_deps,

--- a/shared.bazelrc
+++ b/shared.bazelrc
@@ -2,6 +2,12 @@ build --experimental_strict_conflict_checks
 build --incompatible_disallow_empty_glob
 build --experimental_convenience_symlinks=ignore
 
+# apple_support Xcode toolchain
+build --enable_platform_specific_config
+build:macos --apple_crosstool_top=@local_config_apple_cc//:toolchain
+build:macos --crosstool_top=@local_config_apple_cc//:toolchain
+build:macos --host_crosstool_top=@local_config_apple_cc//:toolchain
+
 # Work around https://github.com/bazelbuild/bazel/issues/13912
 build --experimental_action_cache_store_output_metadata
 

--- a/shared.bazelrc
+++ b/shared.bazelrc
@@ -2,11 +2,10 @@ build --experimental_strict_conflict_checks
 build --incompatible_disallow_empty_glob
 build --experimental_convenience_symlinks=ignore
 
-# apple_support Xcode toolchain
-build --enable_platform_specific_config
-build:macos --apple_crosstool_top=@local_config_apple_cc//:toolchain
-build:macos --crosstool_top=@local_config_apple_cc//:toolchain
-build:macos --host_crosstool_top=@local_config_apple_cc//:toolchain
+# Use apple_support Xcode toolchain
+build --apple_crosstool_top=@local_config_apple_cc//:toolchain
+build --crosstool_top=@local_config_apple_cc//:toolchain
+build --host_crosstool_top=@local_config_apple_cc//:toolchain
 
 # Work around https://github.com/bazelbuild/bazel/issues/13912
 build --experimental_action_cache_store_output_metadata


### PR DESCRIPTION
This is required with Bazel 7, so changing over now makes adding CI for Bazel 7 easier.