### PR TITLE
Add bazel_features dependency

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,6 +5,7 @@ module(
     repo_name = "rules_xcodeproj",
 )
 
+bazel_dep(name = "bazel_features", version = "1.0.0")
 bazel_dep(name = "bazel_skylib", version = "1.3.0")
 bazel_dep(
     name = "rules_swift",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -8,6 +8,10 @@ load(
 
 xcodeproj_rules_dependencies()
 
+load("@bazel_features//:deps.bzl", "bazel_features_deps")
+
+bazel_features_deps()
+
 load(
     "@build_bazel_rules_apple//apple:repositories.bzl",
     "apple_rules_dependencies",

--- a/examples/cc/WORKSPACE
+++ b/examples/cc/WORKSPACE
@@ -10,6 +10,10 @@ load(
 
 xcodeproj_rules_dependencies()
 
+load("@bazel_features//:deps.bzl", "bazel_features_deps")
+
+bazel_features_deps()
+
 load(
     "@build_bazel_rules_apple//apple:repositories.bzl",
     "apple_rules_dependencies",

--- a/examples/integration/WORKSPACE
+++ b/examples/integration/WORKSPACE
@@ -10,6 +10,10 @@ load(
 
 xcodeproj_rules_dependencies()
 
+load("@bazel_features//:deps.bzl", "bazel_features_deps")
+
+bazel_features_deps()
+
 load(
     "@build_bazel_rules_apple//apple:repositories.bzl",
     "apple_rules_dependencies",

--- a/examples/rules_ios/WORKSPACE
+++ b/examples/rules_ios/WORKSPACE
@@ -33,6 +33,10 @@ load(
 
 xcodeproj_rules_dependencies()
 
+load("@bazel_features//:deps.bzl", "bazel_features_deps")
+
+bazel_features_deps()
+
 load(
     "@build_bazel_rules_apple//apple:repositories.bzl",
     "apple_rules_dependencies",

--- a/examples/sanitizers/WORKSPACE
+++ b/examples/sanitizers/WORKSPACE
@@ -10,6 +10,10 @@ load(
 
 xcodeproj_rules_dependencies()
 
+load("@bazel_features//:deps.bzl", "bazel_features_deps")
+
+bazel_features_deps()
+
 load(
     "@build_bazel_rules_apple//apple:repositories.bzl",
     "apple_rules_dependencies",

--- a/xcodeproj/repositories.bzl
+++ b/xcodeproj/repositories.bzl
@@ -111,6 +111,15 @@ def xcodeproj_rules_dependencies(
     if include_bzlmod_ready_dependencies:
         _maybe(
             http_archive,
+            name = "bazel_features",
+            sha256 = "9fcb3d7cbe908772462aaa52f02b857a225910d30daa3c252f670e3af6d8036d",
+            strip_prefix = "bazel_features-1.0.0",
+            url = "https://github.com/bazel-contrib/bazel_features/releases/download/v1.0.0/bazel_features-v1.0.0.tar.gz",
+            ignore_version_differences = ignore_version_differences,
+        )
+
+        _maybe(
+            http_archive,
             name = "bazel_skylib",
             sha256 = "66ffd9315665bfaafc96b52278f57c7e2dd09f5ede279ea6d39b2be471e7e3aa",
             url = "https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.2/bazel-skylib-1.4.2.tar.gz",


### PR DESCRIPTION
This will be used to check for `ObjcProvider` linker info availability.