### PR TITLE
Upgrade `examples/rules_ios` rules_apple to 2.5.0 as well

### DIFF
--- a/examples/rules_ios/WORKSPACE
+++ b/examples/rules_ios/WORKSPACE
@@ -3,9 +3,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # TODO: Undo this `rules_apple` bump once there's a new version of `rules_ios` consuming a newer `rules_apple`
 http_archive(
     name = "build_bazel_rules_apple",
-    sha256 = "1e152d031de08e98ca6c8078cd36f31bf670c1bea7bc9ab3692a81589e6a8569",
-    strip_prefix = "rules_apple-5150ef97f52e4044c0702b16c4b7c0b758204f70",
-    url = "https://github.com/bazelbuild/rules_apple/archive/5150ef97f52e4044c0702b16c4b7c0b758204f70.tar.gz",
+    sha256 = "f89786b86c19f0e99a99a03dc64005ba13e715dbc49959239bad0620c66cdc83",
+    strip_prefix = "rules_apple-4b4f645b75ba1df7e70244b696151bb2172ac8f2",
+    url = "https://github.com/bazelbuild/rules_apple/archive/4b4f645b75ba1df7e70244b696151bb2172ac8f2.tar.gz",
 )
 
 http_archive(


### PR DESCRIPTION
Enables Bazel 7 testing.