### PR TITLE
Stop generating static framework targets in Xcode

### DIFF
--- a/xcodeproj/internal/automatic_target_info.bzl
+++ b/xcodeproj/internal/automatic_target_info.bzl
@@ -49,6 +49,12 @@ def _is_test_target(target):
         return False
     return target[AppleBundleInfo].product_type in _TEST_TARGET_PRODUCT_TYPES
 
+def _is_static_framework(target):
+    """Returns whether the given target is a static framework or not."""
+    if AppleBundleInfo not in target:
+        return False
+    return target[AppleBundleInfo].product_type == "com.apple.product-type.framework.static"
+
 ## Aspects
 
 # These are declared as constants to cause starlark to reuse the same instances
@@ -211,6 +217,13 @@ def calculate_automatic_target_info(ctx, build_mode, target):
         is_top_level = True
         provisioning_profile = "provisioning_profile"
         xcode_targets = _TEST_BUNDLE_XCODE_TARGETS
+    elif _is_static_framework(target):
+        # TODO: https://github.com/MobileNativeFoundation/rules_xcodeproj/issues/105
+        # Static frameworks are not supported yet as Xcode targets.
+        is_supported = False
+        is_top_level = True
+        collect_uncategorized_files = rule_kind != "apple_bundle_import"
+        xcode_targets = _DEFAULT_XCODE_TARGETS[this_target_type]
     elif AppleBundleInfo in target and target[AppleBundleInfo].binary:
         # Checking for `binary` being set is to work around a rules_ios issue
         alternate_icons = "alternate_icons"

--- a/xcodeproj/internal/unsupported_targets.bzl
+++ b/xcodeproj/internal/unsupported_targets.bzl
@@ -110,6 +110,7 @@ def process_unsupported_target(
         compilation_providers = compilation_providers,
         dependencies = dependencies,
         inputs = provider_inputs,
+        is_top_level = automatic_target_info.is_top_level,
         lldb_context = lldb_contexts.collect(
             build_mode = build_mode,
             id = None,


### PR DESCRIPTION
These targets aren't buildable because of: https://github.com/MobileNativeFoundation/rules_xcodeproj/issues/105 
We shouldn't show them in Xcode.

| Before  | After |
| ------------- | ------------- |
| <img width="331" alt="Screenshot 2023-08-24 at 12 10 53 PM" src="https://github.com/MobileNativeFoundation/rules_xcodeproj/assets/13840545/bcb4c0d8-2265-4bf5-bb03-e4c47db3d626"> | <img width="331" alt="Screenshot 2023-08-24 at 12 43 25 PM" src="https://github.com/MobileNativeFoundation/rules_xcodeproj/assets/13840545/20fc0a3f-2b73-4391-83a8-4f16f9c7082b"> |


