### PR TITLE
Return an empty string from `get_targeted_device_family`

### DIFF
--- a/test/internal/build_settings/get_targeted_device_family_tests.bzl
+++ b/test/internal/build_settings/get_targeted_device_family_tests.bzl
@@ -14,7 +14,7 @@ def _get_targeted_device_family_test_impl(ctx):
 
     asserts.equals(
         env,
-        ctx.attr.expected_targeted_device_family or None,
+        ctx.attr.expected_targeted_device_family,
         targeted_device_family,
         "targeted_device_family",
     )
@@ -56,7 +56,7 @@ def get_targeted_device_family_test_suite(name):
     _add_test(
         name = "{}_mac".format(name),
         families = ["mac"],
-        expected_targeted_device_family = None,
+        expected_targeted_device_family = "",
     )
 
     # iOS

--- a/xcodeproj/internal/build_settings.bzl
+++ b/xcodeproj/internal/build_settings.bzl
@@ -74,6 +74,4 @@ def get_targeted_device_family(families):
         number = _DEVICE_FAMILY_VALUES[family]
         if number:
             family_ids.append(number)
-    if family_ids:
-        return ",".join(family_ids)
-    return None
+    return ",".join(family_ids)


### PR DESCRIPTION
Better for incremental generators.