### PR TITLE
Change sorting of build action in schemes

### DIFF
--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/UIFramework.tvOS.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/UIFramework.tvOS.xcscheme
@@ -48,9 +48,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "C03F5C0CA2104493AE9E52C9"
-               BuildableName = "LibFramework.tvOS.framework"
-               BlueprintName = "LibFramework.tvOS"
+               BlueprintIdentifier = "A23C98B4BFB6C775689A2A7D"
+               BuildableName = "UIFramework.tvOS.framework"
+               BlueprintName = "UIFramework.tvOS"
                ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -62,9 +62,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "A23C98B4BFB6C775689A2A7D"
-               BuildableName = "UIFramework.tvOS.framework"
-               BlueprintName = "UIFramework.tvOS"
+               BlueprintIdentifier = "C03F5C0CA2104493AE9E52C9"
+               BuildableName = "LibFramework.tvOS.framework"
+               BlueprintName = "LibFramework.tvOS"
                ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/UIFramework.watchOS.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/UIFramework.watchOS.xcscheme
@@ -48,9 +48,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "1EF2B99D58C7884FED2A0769"
-               BuildableName = "LibFramework.watchOS.framework"
-               BlueprintName = "LibFramework.watchOS"
+               BlueprintIdentifier = "F619A1189B9E946F6BE02A2F"
+               BuildableName = "UIFramework.watchOS.framework"
+               BlueprintName = "UIFramework.watchOS"
                ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -62,9 +62,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "F619A1189B9E946F6BE02A2F"
-               BuildableName = "UIFramework.watchOS.framework"
-               BlueprintName = "UIFramework.watchOS"
+               BlueprintIdentifier = "1EF2B99D58C7884FED2A0769"
+               BuildableName = "LibFramework.watchOS.framework"
+               BlueprintName = "LibFramework.watchOS"
                ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSApp.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSApp.xcscheme
@@ -64,6 +64,20 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1765D91CC168F25A5BC51603"
+               BuildableName = "iOSApp.app"
+               BlueprintName = "iOSApp"
+               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "13A68B4984727F4B3DAE6AFB"
                BuildableName = "AppClip.app"
                BlueprintName = "AppClip"
@@ -81,20 +95,6 @@
                BlueprintIdentifier = "64AE6000A6317B9C077F3B1E"
                BuildableName = "CoreUtilsObjC.framework"
                BlueprintName = "CoreUtilsObjC"
-               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "1765D91CC168F25A5BC51603"
-               BuildableName = "iOSApp.app"
-               BlueprintName = "iOSApp"
                ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSAppObjCUnitTestSuite.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSAppObjCUnitTestSuite.xcscheme
@@ -64,6 +64,20 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8EE630791B4B7821701DA6DE"
+               BuildableName = "iOSAppObjCUnitTestSuite.xctest"
+               BlueprintName = "iOSAppObjCUnitTestSuite"
+               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "13A68B4984727F4B3DAE6AFB"
                BuildableName = "AppClip.app"
                BlueprintName = "AppClip"
@@ -95,20 +109,6 @@
                BlueprintIdentifier = "1765D91CC168F25A5BC51603"
                BuildableName = "iOSApp.app"
                BlueprintName = "iOSApp"
-               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "8EE630791B4B7821701DA6DE"
-               BuildableName = "iOSAppObjCUnitTestSuite.xctest"
-               BlueprintName = "iOSAppObjCUnitTestSuite"
                ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSAppObjCUnitTests.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSAppObjCUnitTests.xcscheme
@@ -64,6 +64,20 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "41EA1ABC35FAFDF6B7FE0600"
+               BuildableName = "iOSAppObjCUnitTests.xctest"
+               BlueprintName = "iOSAppObjCUnitTests"
+               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "13A68B4984727F4B3DAE6AFB"
                BuildableName = "AppClip.app"
                BlueprintName = "AppClip"
@@ -95,20 +109,6 @@
                BlueprintIdentifier = "1765D91CC168F25A5BC51603"
                BuildableName = "iOSApp.app"
                BlueprintName = "iOSApp"
-               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "41EA1ABC35FAFDF6B7FE0600"
-               BuildableName = "iOSAppObjCUnitTests.xctest"
-               BlueprintName = "iOSAppObjCUnitTests"
                ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSAppSwiftUnitTestSuite.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSAppSwiftUnitTestSuite.xcscheme
@@ -64,6 +64,20 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ACDA5ACDC1BF2DFDEAE93AFB"
+               BuildableName = "iOSAppSwiftUnitTestSuite.xctest"
+               BlueprintName = "iOSAppSwiftUnitTestSuite"
+               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "13A68B4984727F4B3DAE6AFB"
                BuildableName = "AppClip.app"
                BlueprintName = "AppClip"
@@ -95,20 +109,6 @@
                BlueprintIdentifier = "1765D91CC168F25A5BC51603"
                BuildableName = "iOSApp.app"
                BlueprintName = "iOSApp"
-               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "ACDA5ACDC1BF2DFDEAE93AFB"
-               BuildableName = "iOSAppSwiftUnitTestSuite.xctest"
-               BlueprintName = "iOSAppSwiftUnitTestSuite"
                ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSAppSwiftUnitTests.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSAppSwiftUnitTests.xcscheme
@@ -64,6 +64,20 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D2B147BDA8E8FC10D91B53BB"
+               BuildableName = "iOSAppSwiftUnitTests.xctest"
+               BlueprintName = "iOSAppSwiftUnitTests"
+               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "13A68B4984727F4B3DAE6AFB"
                BuildableName = "AppClip.app"
                BlueprintName = "AppClip"
@@ -95,20 +109,6 @@
                BlueprintIdentifier = "1765D91CC168F25A5BC51603"
                BuildableName = "iOSApp.app"
                BlueprintName = "iOSApp"
-               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "D2B147BDA8E8FC10D91B53BB"
-               BuildableName = "iOSAppSwiftUnitTests.xctest"
-               BlueprintName = "iOSAppSwiftUnitTests"
                ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSAppSwiftUnitTests_CommandLineArgs_Scheme.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSAppSwiftUnitTests_CommandLineArgs_Scheme.xcscheme
@@ -64,6 +64,20 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D2B147BDA8E8FC10D91B53BB"
+               BuildableName = "iOSAppSwiftUnitTests.xctest"
+               BlueprintName = "iOSAppSwiftUnitTests"
+               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "13A68B4984727F4B3DAE6AFB"
                BuildableName = "AppClip.app"
                BlueprintName = "AppClip"
@@ -95,20 +109,6 @@
                BlueprintIdentifier = "1765D91CC168F25A5BC51603"
                BuildableName = "iOSApp.app"
                BlueprintName = "iOSApp"
-               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "NO"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "D2B147BDA8E8FC10D91B53BB"
-               BuildableName = "iOSAppSwiftUnitTests.xctest"
-               BlueprintName = "iOSAppSwiftUnitTests"
                ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSAppUnitTestSuite_Scheme.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSAppUnitTestSuite_Scheme.xcscheme
@@ -80,6 +80,34 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8EE630791B4B7821701DA6DE"
+               BuildableName = "iOSAppObjCUnitTestSuite.xctest"
+               BlueprintName = "iOSAppObjCUnitTestSuite"
+               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ACDA5ACDC1BF2DFDEAE93AFB"
+               BuildableName = "iOSAppSwiftUnitTestSuite.xctest"
+               BlueprintName = "iOSAppSwiftUnitTestSuite"
+               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "13A68B4984727F4B3DAE6AFB"
                BuildableName = "AppClip.app"
                BlueprintName = "AppClip"
@@ -111,34 +139,6 @@
                BlueprintIdentifier = "1765D91CC168F25A5BC51603"
                BuildableName = "iOSApp.app"
                BlueprintName = "iOSApp"
-               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "NO"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "8EE630791B4B7821701DA6DE"
-               BuildableName = "iOSAppObjCUnitTestSuite.xctest"
-               BlueprintName = "iOSAppObjCUnitTestSuite"
-               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "NO"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "ACDA5ACDC1BF2DFDEAE93AFB"
-               BuildableName = "iOSAppSwiftUnitTestSuite.xctest"
-               BlueprintName = "iOSAppSwiftUnitTestSuite"
                ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSAppUnitTests_Scheme.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSAppUnitTests_Scheme.xcscheme
@@ -80,6 +80,34 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "41EA1ABC35FAFDF6B7FE0600"
+               BuildableName = "iOSAppObjCUnitTests.xctest"
+               BlueprintName = "iOSAppObjCUnitTests"
+               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D2B147BDA8E8FC10D91B53BB"
+               BuildableName = "iOSAppSwiftUnitTests.xctest"
+               BlueprintName = "iOSAppSwiftUnitTests"
+               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "13A68B4984727F4B3DAE6AFB"
                BuildableName = "AppClip.app"
                BlueprintName = "AppClip"
@@ -111,34 +139,6 @@
                BlueprintIdentifier = "1765D91CC168F25A5BC51603"
                BuildableName = "iOSApp.app"
                BlueprintName = "iOSApp"
-               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "NO"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "41EA1ABC35FAFDF6B7FE0600"
-               BuildableName = "iOSAppObjCUnitTests.xctest"
-               BlueprintName = "iOSAppObjCUnitTests"
-               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "NO"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "D2B147BDA8E8FC10D91B53BB"
-               BuildableName = "iOSAppSwiftUnitTests.xctest"
-               BlueprintName = "iOSAppSwiftUnitTests"
                ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/tvOSApp.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/tvOSApp.xcscheme
@@ -64,9 +64,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "C03F5C0CA2104493AE9E52C9"
-               BuildableName = "LibFramework.tvOS.framework"
-               BlueprintName = "LibFramework.tvOS"
+               BlueprintIdentifier = "ACEF2F653E0F6BEA37D2C7B6"
+               BuildableName = "tvOSApp.app"
+               BlueprintName = "tvOSApp"
                ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -78,9 +78,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "ACEF2F653E0F6BEA37D2C7B6"
-               BuildableName = "tvOSApp.app"
-               BlueprintName = "tvOSApp"
+               BlueprintIdentifier = "C03F5C0CA2104493AE9E52C9"
+               BuildableName = "LibFramework.tvOS.framework"
+               BlueprintName = "LibFramework.tvOS"
                ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/tvOSAppUnitTests.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/tvOSAppUnitTests.xcscheme
@@ -64,6 +64,20 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "76D3DE86C1DB5149A9A669ED"
+               BuildableName = "tvOSAppUnitTests.xctest"
+               BlueprintName = "tvOSAppUnitTests"
+               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "C03F5C0CA2104493AE9E52C9"
                BuildableName = "LibFramework.tvOS.framework"
                BlueprintName = "LibFramework.tvOS"
@@ -81,20 +95,6 @@
                BlueprintIdentifier = "ACEF2F653E0F6BEA37D2C7B6"
                BuildableName = "tvOSApp.app"
                BlueprintName = "tvOSApp"
-               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "76D3DE86C1DB5149A9A669ED"
-               BuildableName = "tvOSAppUnitTests.xctest"
-               BlueprintName = "tvOSAppUnitTests"
                ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/watchOSApp.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/watchOSApp.xcscheme
@@ -64,6 +64,20 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "632D255CE04E97FB997EBDD7"
+               BuildableName = "watchOSApp.app"
+               BlueprintName = "watchOSApp"
+               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "1EF2B99D58C7884FED2A0769"
                BuildableName = "LibFramework.watchOS.framework"
                BlueprintName = "LibFramework.watchOS"
@@ -81,20 +95,6 @@
                BlueprintIdentifier = "F619A1189B9E946F6BE02A2F"
                BuildableName = "UIFramework.watchOS.framework"
                BlueprintName = "UIFramework.watchOS"
-               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "632D255CE04E97FB997EBDD7"
-               BuildableName = "watchOSApp.app"
-               BlueprintName = "watchOSApp"
                ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/watchOSAppExtensionUnitTests.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/watchOSAppExtensionUnitTests.xcscheme
@@ -64,6 +64,20 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D72E91668AA84CA0E91BC0E9"
+               BuildableName = "watchOSAppExtensionUnitTests.xctest"
+               BlueprintName = "watchOSAppExtensionUnitTests"
+               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "1EF2B99D58C7884FED2A0769"
                BuildableName = "LibFramework.watchOS.framework"
                BlueprintName = "LibFramework.watchOS"
@@ -81,20 +95,6 @@
                BlueprintIdentifier = "F619A1189B9E946F6BE02A2F"
                BuildableName = "UIFramework.watchOS.framework"
                BlueprintName = "UIFramework.watchOS"
-               ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "D72E91668AA84CA0E91BC0E9"
-               BuildableName = "watchOSAppExtensionUnitTests.xctest"
-               BlueprintName = "watchOSAppExtensionUnitTests"
                ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>

--- a/examples/rules_ios/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSAppMixedUnitTests.xcscheme
+++ b/examples/rules_ios/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSAppMixedUnitTests.xcscheme
@@ -64,9 +64,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "3748F894E3DA974CB6A80689"
-               BuildableName = "iOSApp.app"
-               BlueprintName = "iOSApp (App)"
+               BlueprintIdentifier = "B25A16ED5B68231D785FFFC0"
+               BuildableName = "iOSAppMixedUnitTests.xctest"
+               BlueprintName = "iOSAppMixedUnitTests"
                ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -78,9 +78,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "B25A16ED5B68231D785FFFC0"
-               BuildableName = "iOSAppMixedUnitTests.xctest"
-               BlueprintName = "iOSAppMixedUnitTests"
+               BlueprintIdentifier = "3748F894E3DA974CB6A80689"
+               BuildableName = "iOSApp.app"
+               BlueprintName = "iOSApp (App)"
                ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>

--- a/examples/rules_ios/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSAppObjCUnitTestSuite.xcscheme
+++ b/examples/rules_ios/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSAppObjCUnitTestSuite.xcscheme
@@ -64,9 +64,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "3748F894E3DA974CB6A80689"
-               BuildableName = "iOSApp.app"
-               BlueprintName = "iOSApp (App)"
+               BlueprintIdentifier = "8EE630791B4B7821701DA6DE"
+               BuildableName = "iOSAppObjCUnitTestSuite.xctest"
+               BlueprintName = "iOSAppObjCUnitTestSuite"
                ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -78,9 +78,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "8EE630791B4B7821701DA6DE"
-               BuildableName = "iOSAppObjCUnitTestSuite.xctest"
-               BlueprintName = "iOSAppObjCUnitTestSuite"
+               BlueprintIdentifier = "3748F894E3DA974CB6A80689"
+               BuildableName = "iOSApp.app"
+               BlueprintName = "iOSApp (App)"
                ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>

--- a/examples/rules_ios/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSAppObjCUnitTestSuite_macro.xcscheme
+++ b/examples/rules_ios/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSAppObjCUnitTestSuite_macro.xcscheme
@@ -64,9 +64,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "3748F894E3DA974CB6A80689"
-               BuildableName = "iOSApp.app"
-               BlueprintName = "iOSApp (App)"
+               BlueprintIdentifier = "64207215DA153DB2E4005A70"
+               BuildableName = "iOSAppObjCUnitTestSuite_macro.xctest"
+               BlueprintName = "iOSAppObjCUnitTestSuite_macro"
                ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -78,9 +78,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "64207215DA153DB2E4005A70"
-               BuildableName = "iOSAppObjCUnitTestSuite_macro.xctest"
-               BlueprintName = "iOSAppObjCUnitTestSuite_macro"
+               BlueprintIdentifier = "3748F894E3DA974CB6A80689"
+               BuildableName = "iOSApp.app"
+               BlueprintName = "iOSApp (App)"
                ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>

--- a/examples/rules_ios/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSAppObjCUnitTests_macro.xcscheme
+++ b/examples/rules_ios/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSAppObjCUnitTests_macro.xcscheme
@@ -64,9 +64,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "3748F894E3DA974CB6A80689"
-               BuildableName = "iOSApp.app"
-               BlueprintName = "iOSApp (App)"
+               BlueprintIdentifier = "B00C5FDD50ED76D9EF9E686F"
+               BuildableName = "iOSAppObjCUnitTests_macro.xctest"
+               BlueprintName = "iOSAppObjCUnitTests_macro"
                ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -78,9 +78,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "B00C5FDD50ED76D9EF9E686F"
-               BuildableName = "iOSAppObjCUnitTests_macro.xctest"
-               BlueprintName = "iOSAppObjCUnitTests_macro"
+               BlueprintIdentifier = "3748F894E3DA974CB6A80689"
+               BuildableName = "iOSApp.app"
+               BlueprintName = "iOSApp (App)"
                ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>

--- a/examples/rules_ios/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSAppSwiftUnitTestSuite.xcscheme
+++ b/examples/rules_ios/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSAppSwiftUnitTestSuite.xcscheme
@@ -64,9 +64,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "3748F894E3DA974CB6A80689"
-               BuildableName = "iOSApp.app"
-               BlueprintName = "iOSApp (App)"
+               BlueprintIdentifier = "ACDA5ACDC1BF2DFDEAE93AFB"
+               BuildableName = "iOSAppSwiftUnitTestSuite.xctest"
+               BlueprintName = "iOSAppSwiftUnitTestSuite"
                ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -78,9 +78,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "ACDA5ACDC1BF2DFDEAE93AFB"
-               BuildableName = "iOSAppSwiftUnitTestSuite.xctest"
-               BlueprintName = "iOSAppSwiftUnitTestSuite"
+               BlueprintIdentifier = "3748F894E3DA974CB6A80689"
+               BuildableName = "iOSApp.app"
+               BlueprintName = "iOSApp (App)"
                ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>

--- a/examples/rules_ios/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSAppSwiftUnitTests.xcscheme
+++ b/examples/rules_ios/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSAppSwiftUnitTests.xcscheme
@@ -64,9 +64,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "3748F894E3DA974CB6A80689"
-               BuildableName = "iOSApp.app"
-               BlueprintName = "iOSApp (App)"
+               BlueprintIdentifier = "D2B147BDA8E8FC10D91B53BB"
+               BuildableName = "iOSAppSwiftUnitTests.xctest"
+               BlueprintName = "iOSAppSwiftUnitTests"
                ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -78,9 +78,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "D2B147BDA8E8FC10D91B53BB"
-               BuildableName = "iOSAppSwiftUnitTests.xctest"
-               BlueprintName = "iOSAppSwiftUnitTests"
+               BlueprintIdentifier = "3748F894E3DA974CB6A80689"
+               BuildableName = "iOSApp.app"
+               BlueprintName = "iOSApp (App)"
                ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>

--- a/tools/generators/legacy/src/Generator/XCSchemeInfo+BuildTargetInfo.swift
+++ b/tools/generators/legacy/src/Generator/XCSchemeInfo+BuildTargetInfo.swift
@@ -1,3 +1,4 @@
+import OrderedCollections
 import XcodeProj
 
 extension XCSchemeInfo {
@@ -19,24 +20,70 @@ extension Sequence where Element == XCSchemeInfo.BuildTargetInfo {
     /// Return all of the `BuildAction.Entry` values.
     var buildActionEntries: [XCScheme.BuildAction.Entry] {
         get throws {
-            // Create a (BuildableReference, BuildFor) for all buildable references
-            let buildRefAndBuildFors = flatMap { buildTargetInfo in
-                return buildTargetInfo.targetInfo.buildableReferences.map {
-                    ($0, buildTargetInfo.buildFor)
-                }
+            // Create a (BuildableReference, BuildFor) for all buildable
+            // references
+            var buildRefAndBuildFors = flatMap { buildTargetInfo in
+                return buildTargetInfo.targetInfo.selfAndHostBuildableReferences
+                    .map { buildableReference in
+                        return (
+                            buildableReference: buildableReference,
+                            productType: buildTargetInfo.targetInfo.productType,
+                            buildFor: buildTargetInfo.buildFor
+                        )
+                    }
             }
+                .sorted { lhs, rhs in
+                    let lhsIsTopLevel = lhs.productType.isTopLevel
+                    let rhsIsTopLevel = rhs.productType.isTopLevel
+                    guard lhsIsTopLevel == rhsIsTopLevel else {
+                        return lhsIsTopLevel
+                    }
 
-            // Collect the buildFors by BuildableReference, create the BuildAction.Entry values, and
-            // sort the result.
-            return try Dictionary(grouping: buildRefAndBuildFors, by: { $0.0 })
-                .map { buildableReference, buildRefAndBuildFors in
-                    return try XCScheme.BuildAction.Entry(
-                        buildableReference: buildableReference,
-                        buildFor: buildRefAndBuildFors.map(\.1).merged().xcSchemeValue
-                    )
+                    if lhsIsTopLevel {
+                        let lhsIsTest = lhs.productType.isTestBundle
+                        let rhsIsTest = rhs.productType.isTestBundle
+                        guard lhsIsTest == rhsIsTest else {
+                            // Test come after other top levels
+                            return rhsIsTest
+                        }
+                    }
+
+                    return lhs.buildableReference.blueprintName
+                        .localizedStandardCompare(
+                            rhs.buildableReference.blueprintName
+                        ) == .orderedAscending
                 }
-                // Sort by in stable order by blueprint name
-                .sortedLocalizedStandard(\.buildableReference.blueprintName)
+
+            // Add additional targets after
+            buildRefAndBuildFors.append(
+                contentsOf: flatMap { buildTargetInfo in
+                    return buildTargetInfo.targetInfo
+                        .additionalBuildableReferences
+                        .map { buildableReference in
+                            return (
+                                buildableReference: buildableReference,
+                                productType:
+                                    buildTargetInfo.targetInfo.productType,
+                                buildFor: buildTargetInfo.buildFor
+                            )
+                        }
+                }
+                    // Sort by in stable order by blueprint name
+                    .sortedLocalizedStandard(\.buildableReference.blueprintName)
+            )
+
+            // Collect the `buildFor`s by `BuildableReference`, and create the
+            // `BuildAction.Entry` values
+            return try OrderedDictionary(
+                grouping: buildRefAndBuildFors,
+                by: { $0.0 }
+            ).map { buildableReference, buildRefAndBuildFors in
+                return try XCScheme.BuildAction.Entry(
+                    buildableReference: buildableReference,
+                    buildFor: buildRefAndBuildFors
+                        .map(\.buildFor).merged().xcSchemeValue
+                )
+            }
         }
     }
 }

--- a/tools/generators/legacy/src/Generator/XCSchemeInfo+TargetInfo.swift
+++ b/tools/generators/legacy/src/Generator/XCSchemeInfo+TargetInfo.swift
@@ -139,15 +139,6 @@ Cannot access `selectedHostInfo` until host resolution has occurred.
 // MARK: `buildableReferences`
 
 extension XCSchemeInfo.TargetInfo {
-    /// Returns the target buildable reference along with any additionally
-    /// required buildable references (e.g. the selected host, or SwiftUI
-    /// Preview dependencies).
-    var buildableReferences: [XCScheme.BuildableReference] {
-        var results = selfAndHostBuildableReferences
-        results.append(contentsOf: additionalBuildableReferences)
-        return results
-    }
-
     /// Returns the target buildable reference along with the the selected host.
     var selfAndHostBuildableReferences: [XCScheme.BuildableReference] {
         var results = [buildableReference]

--- a/tools/generators/legacy/test/XCSchemeInfo+BuildTargetInfoTests.swift
+++ b/tools/generators/legacy/test/XCSchemeInfo+BuildTargetInfoTests.swift
@@ -1,3 +1,4 @@
+import CustomDump
 import XcodeProj
 import XCTest
 
@@ -8,12 +9,22 @@ import XCTest
 extension XCSchemeInfoBuildTargetInfoTests {
     func test_Sequence_buildActionEntries() throws {
         let buildTargetInfos = [libraryTargetInfo, appTargetInfo]
-            .map { XCSchemeInfo.BuildTargetInfo(targetInfo: $0, buildFor: .allEnabled) }
+            .map { targetInfo in
+                return XCSchemeInfo.BuildTargetInfo(
+                    targetInfo: targetInfo,
+                    buildFor: .allEnabled
+                )
+            }
+
         let expected: [XCScheme.BuildAction.Entry] = [
-            libraryTargetInfo.buildableReference,
             appTargetInfo.buildableReference,
+            libraryTargetInfo.buildableReference,
         ].map { .init(buildableReference: $0, buildFor: .default) }
-        XCTAssertEqual(try buildTargetInfos.buildActionEntries, expected)
+
+        XCTAssertNoDifference(
+            try buildTargetInfos.buildActionEntries,
+            expected
+        )
     }
 }
 

--- a/tools/generators/legacy/test/XCSchemeInfo+TargetInfoTests.swift
+++ b/tools/generators/legacy/test/XCSchemeInfo+TargetInfoTests.swift
@@ -114,20 +114,29 @@ extension XCSchemeInfoTargetInfoTests {
     }
 }
 
-// MARK: - `buildableReferences` Tests
+// MARK: - `selfAndHostBuildableReferences` Tests
 
 extension XCSchemeInfoTargetInfoTests {
     func test_buildableReferences_noHost() throws {
-        let buildableReferences = libraryTargetInfo.buildableReferences
-        XCTAssertEqual(buildableReferences, [libraryTargetInfo.buildableReference])
+        let buildableReferences =
+            libraryTargetInfo.selfAndHostBuildableReferences
+        XCTAssertEqual(
+            buildableReferences,
+            [libraryTargetInfo.buildableReference]
+        )
     }
 
     func test_buildableReferences_withHost() throws {
-        let buildableReferences = libraryTargetInfoWithHosts.buildableReferences
-        XCTAssertEqual(buildableReferences, [
-            libraryTargetInfo.buildableReference,
-            try libraryTargetInfoWithHosts.selectedHostInfo!.buildableReference,
-        ])
+        let buildableReferences =
+            libraryTargetInfoWithHosts.selfAndHostBuildableReferences
+        XCTAssertEqual(
+            buildableReferences,
+            [
+                libraryTargetInfo.buildableReference,
+                try libraryTargetInfoWithHosts.selectedHostInfo!
+                    .buildableReference,
+            ]
+        )
     }
 }
 


### PR DESCRIPTION
Fixes #2543.

This is to get the icon of the scheme to match, in order:
- Launch target
- Test target
- Other targets
- (never) Additional targets for Swift UI Previews

This still isn’t 100%, because it doesn’t use info from the other actions, but we can make it better in the incremental generators.