### PR TITLE
Disable tree artifacts for `examples/integration`

### DIFF
--- a/examples/integration/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -22248,8 +22248,8 @@
 					"\"bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-20/bin/Lib/LibFramework.watchOS.framework.dSYM\"",
 					"\"bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-20/bin/UI/UIFramework.watchOS.framework.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/UI/UIFramework.watchOS.framework";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=watchos*]" = "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-20/bin/UI/UIFramework.watchOS.framework";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/UI/UIFramework.watchOS.zip";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=watchos*]" = "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-20/bin/UI/UIFramework.watchOS.zip";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = UIFramework.watchOS.framework;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/UI";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=watchos*]" = "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-20/bin/UI";
@@ -22272,11 +22272,11 @@
 				"PREVIEWS_SWIFT_INCLUDE__YES[sdk=watchos*]" = "-I bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-7/bin/UI";
 				PREVIEW_FRAMEWORK_PATHS = (
 					"\"$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator/CryptoSwift.framework\"",
-					"\"$(BAZEL_OUT)/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/Lib/LibFramework.watchOS.framework\"",
+					"\"$(BAZEL_OUT)/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/Lib/LibFramework.watchOS.zip\"",
 				);
 				"PREVIEW_FRAMEWORK_PATHS[sdk=watchos*]" = (
 					"\"$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k/CryptoSwift.framework\"",
-					"\"$(BAZEL_OUT)/applebin_watchos-watchos_arm64_32-dbg-STABLE-20/bin/Lib/LibFramework.watchOS.framework\"",
+					"\"$(BAZEL_OUT)/applebin_watchos-watchos_arm64_32-dbg-STABLE-20/bin/Lib/LibFramework.watchOS.zip\"",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "rules-xcodeproj.UIFramework";
 				PRODUCT_MODULE_NAME = UI;
@@ -22330,8 +22330,8 @@
 				ARCHS = x86_64;
 				"ARCHS[sdk=iphoneos*]" = arm64;
 				BAZEL_LABEL = "@@//Lib/dist/dynamic:iOS";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/Lib/dist/dynamic/Lib.framework";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/Lib/dist/dynamic/Lib.framework";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/Lib/dist/dynamic/iOS.zip";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/Lib/dist/dynamic/iOS.zip";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = Lib.framework;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/Lib/dist/dynamic";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/Lib/dist/dynamic";
@@ -22378,7 +22378,7 @@
 					"\"bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Source/iOSApp.app.dSYM\"",
 					"\"bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/UITests/iOSAppUITestSuite.xctest.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/UITests/iOSAppUITestSuite.xctest";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/UITests/iOSAppUITestSuite.__internal__.__test_bundle.zip";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = iOSAppUITestSuite.xctest;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/UITests";
 				BAZEL_TARGET_ID = "@@//iOSApp/Test/UITests:iOSAppUITestSuite.__internal__.__test_bundle applebin_ios-ios_x86_64-opt-STABLE-17";
@@ -22438,8 +22438,8 @@
 				ARCHS = x86_64;
 				"ARCHS[sdk=appletvos*]" = arm64;
 				BAZEL_LABEL = "@@//Lib/dist/dynamic:tvOS";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/Lib/dist/dynamic/Lib.framework";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=appletvos*]" = "bazel-out/applebin_tvos-tvos_arm64-opt-STABLE-30/bin/Lib/dist/dynamic/Lib.framework";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/Lib/dist/dynamic/tvOS.zip";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=appletvos*]" = "bazel-out/applebin_tvos-tvos_arm64-opt-STABLE-30/bin/Lib/dist/dynamic/tvOS.zip";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = Lib.framework;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/Lib/dist/dynamic";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=appletvos*]" = "bazel-out/applebin_tvos-tvos_arm64-opt-STABLE-30/bin/Lib/dist/dynamic";
@@ -22472,8 +22472,8 @@
 				ARCHS = x86_64;
 				"ARCHS[sdk=iphoneos*]" = arm64;
 				BAZEL_LABEL = "@@//Lib/dist/dynamic:iOS";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/Lib/dist/dynamic/Lib.framework";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/Lib/dist/dynamic/Lib.framework";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/Lib/dist/dynamic/iOS.zip";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/Lib/dist/dynamic/iOS.zip";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = Lib.framework;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/Lib/dist/dynamic";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/Lib/dist/dynamic";
@@ -22531,8 +22531,8 @@
 				ARCHS = x86_64;
 				"ARCHS[sdk=watchos*]" = arm64_32;
 				BAZEL_LABEL = "@@//Lib/dist/dynamic:watchOS";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/Lib/dist/dynamic/Lib.framework";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=watchos*]" = "bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-22/bin/Lib/dist/dynamic/Lib.framework";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/Lib/dist/dynamic/watchOS.zip";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=watchos*]" = "bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-22/bin/Lib/dist/dynamic/watchOS.zip";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = Lib.framework;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/Lib/dist/dynamic";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=watchos*]" = "bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-22/bin/Lib/dist/dynamic";
@@ -22616,8 +22616,8 @@
 					"\"bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Source/iOSApp.app.dSYM\"",
 					"\"bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.xctest.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.xctest";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.xctest";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.__internal__.__test_bundle.zip";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.__internal__.__test_bundle.zip";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = iOSAppObjCUnitTests.xctest;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/ObjCUnitTests";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Test/ObjCUnitTests";
@@ -22708,8 +22708,8 @@
 					"\"bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-20/bin/watchOSAppExtension/watchOSAppExtension.appex.dSYM\"",
 					"\"bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Source/iOSApp.app.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Source/iOSApp.app";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Source/iOSApp.app";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Source/iOSApp.ipa";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Source/iOSApp.ipa";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = iOSApp.app;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Source";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Source";
@@ -22950,8 +22950,8 @@
 					"\"bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-22/bin/watchOSAppExtension/watchOSAppExtension.appex.dSYM\"",
 					"\"bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Source/iOSApp.app.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Source/iOSApp.app";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Source/iOSApp.app";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Source/iOSApp.ipa";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Source/iOSApp.ipa";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = iOSApp.app;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Source";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Source";
@@ -23011,8 +23011,8 @@
 					"\"bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-28/bin/Lib/LibFramework.tvOS.framework.dSYM\"",
 					"\"bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-28/bin/UI/UIFramework.tvOS.framework.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/UI/UIFramework.tvOS.framework";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=appletvos*]" = "bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-28/bin/UI/UIFramework.tvOS.framework";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/UI/UIFramework.tvOS.zip";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=appletvos*]" = "bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-28/bin/UI/UIFramework.tvOS.zip";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = UIFramework.tvOS.framework;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/UI";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=appletvos*]" = "bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-28/bin/UI";
@@ -23035,11 +23035,11 @@
 				"PREVIEWS_SWIFT_INCLUDE__YES[sdk=appletvos*]" = "-I bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-8/bin/UI";
 				PREVIEW_FRAMEWORK_PATHS = (
 					"\"$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator/CryptoSwift.framework\"",
-					"\"$(BAZEL_OUT)/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/Lib/LibFramework.tvOS.framework\"",
+					"\"$(BAZEL_OUT)/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/Lib/LibFramework.tvOS.zip\"",
 				);
 				"PREVIEW_FRAMEWORK_PATHS[sdk=appletvos*]" = (
 					"\"$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64/CryptoSwift.framework\"",
-					"\"$(BAZEL_OUT)/applebin_tvos-tvos_arm64-dbg-STABLE-28/bin/Lib/LibFramework.tvOS.framework\"",
+					"\"$(BAZEL_OUT)/applebin_tvos-tvos_arm64-dbg-STABLE-28/bin/Lib/LibFramework.tvOS.zip\"",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "rules-xcodeproj.UIFramework";
 				PRODUCT_MODULE_NAME = UI;
@@ -23377,7 +23377,7 @@
 				"BAZEL_COMPILE_TARGET_IDS[sdk=macosx*]" = "$(BAZEL_COMPILE_TARGET_IDS)";
 				BAZEL_LABEL = "@@//Bundle:Bundle";
 				BAZEL_OUTPUTS_DSYM = "\"bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-34/bin/Bundle/ABundle.aplugin.dSYM\"";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-34/bin/Bundle/ABundle.aplugin";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-34/bin/Bundle/Bundle.zip";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = ABundle.aplugin;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-34/bin/Bundle";
 				BAZEL_TARGET_ID = "@@//Bundle:Bundle applebin_macos-darwin_x86_64-opt-STABLE-34";
@@ -23408,7 +23408,7 @@
 				"BAZEL_COMPILE_TARGET_IDS[sdk=watchsimulator*]" = "$(BAZEL_COMPILE_TARGET_IDS)";
 				BAZEL_LABEL = "@@//watchOSAppExtension/Test/UnitTests:watchOSAppExtensionUnitTests";
 				BAZEL_OUTPUTS_DSYM = "\"bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTests.xctest.dSYM\"";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTests.xctest";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTests.__internal__.__test_bundle.zip";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = watchOSAppExtensionUnitTests.xctest;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/watchOSAppExtension/Test/UnitTests";
 				BAZEL_TARGET_ID = "@@//watchOSAppExtension/Test/UnitTests:watchOSAppExtensionUnitTests.__internal__.__test_bundle applebin_watchos-watchos_x86_64-dbg-STABLE-19";
@@ -23443,8 +23443,8 @@
 				ARCHS = x86_64;
 				"ARCHS[sdk=appletvos*]" = arm64;
 				BAZEL_LABEL = "@@//Lib/dist/dynamic:tvOS";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/Lib/dist/dynamic/Lib.framework";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=appletvos*]" = "bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-28/bin/Lib/dist/dynamic/Lib.framework";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/Lib/dist/dynamic/tvOS.zip";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=appletvos*]" = "bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-28/bin/Lib/dist/dynamic/tvOS.zip";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = Lib.framework;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/Lib/dist/dynamic";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=appletvos*]" = "bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-28/bin/Lib/dist/dynamic";
@@ -23562,8 +23562,8 @@
 					"\"bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-20/bin/UI/UIFramework.watchOS.framework.dSYM\"",
 					"\"bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-20/bin/watchOSAppExtension/watchOSAppExtension.appex.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/watchOSAppExtension/watchOSAppExtension.appex";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=watchos*]" = "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-20/bin/watchOSAppExtension/watchOSAppExtension.appex";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/watchOSAppExtension/watchOSAppExtension.zip";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=watchos*]" = "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-20/bin/watchOSAppExtension/watchOSAppExtension.zip";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = watchOSAppExtension.appex;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/watchOSAppExtension";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=watchos*]" = "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-20/bin/watchOSAppExtension";
@@ -23622,7 +23622,7 @@
 					"\"bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Source/iOSApp.app.dSYM\"",
 					"\"bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTestSuite.xctest.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTestSuite.xctest";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTestSuite.__internal__.__test_bundle.zip";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = iOSAppObjCUnitTestSuite.xctest;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/ObjCUnitTests";
 				BAZEL_TARGET_ID = "@@//iOSApp/Test/ObjCUnitTests:iOSAppObjCUnitTestSuite.__internal__.__test_bundle applebin_ios-ios_x86_64-dbg-STABLE-15";
@@ -23664,7 +23664,7 @@
 					"\"bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/tvOSApp/Source/tvOSApp.app.dSYM\"",
 					"\"bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/tvOSApp/Test/UnitTests/tvOSAppUnitTests.xctest.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/tvOSApp/Test/UnitTests/tvOSAppUnitTests.xctest";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/tvOSApp/Test/UnitTests/tvOSAppUnitTests.__internal__.__test_bundle.zip";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = tvOSAppUnitTests.xctest;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/tvOSApp/Test/UnitTests";
 				BAZEL_TARGET_ID = "@@//tvOSApp/Test/UnitTests:tvOSAppUnitTests.__internal__.__test_bundle applebin_tvos-tvos_x86_64-dbg-STABLE-27";
@@ -23847,8 +23847,8 @@
 					"\"bazel-out/applebin_tvos-tvos_arm64-opt-STABLE-30/bin/UI/UIFramework.tvOS.framework.dSYM\"",
 					"\"bazel-out/applebin_tvos-tvos_arm64-opt-STABLE-30/bin/tvOSApp/Source/tvOSApp.app.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/tvOSApp/Source/tvOSApp.app";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=appletvos*]" = "bazel-out/applebin_tvos-tvos_arm64-opt-STABLE-30/bin/tvOSApp/Source/tvOSApp.app";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/tvOSApp/Source/tvOSApp.ipa";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=appletvos*]" = "bazel-out/applebin_tvos-tvos_arm64-opt-STABLE-30/bin/tvOSApp/Source/tvOSApp.ipa";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = tvOSApp.app;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/tvOSApp/Source";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=appletvos*]" = "bazel-out/applebin_tvos-tvos_arm64-opt-STABLE-30/bin/tvOSApp/Source";
@@ -23988,7 +23988,7 @@
 					"\"bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/watchOSAppExtension/watchOSAppExtension.appex.dSYM\"",
 					"\"bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/watchOSApp/Test/UITests/watchOSAppUITests.xctest.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/watchOSApp/Test/UITests/watchOSAppUITests.xctest";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/watchOSApp/Test/UITests/watchOSAppUITests.__internal__.__test_bundle.zip";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = watchOSAppUITests.xctest;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/watchOSApp/Test/UITests";
 				BAZEL_TARGET_ID = "@@//watchOSApp/Test/UITests:watchOSAppUITests.__internal__.__test_bundle applebin_watchos-watchos_x86_64-opt-STABLE-21";
@@ -24049,8 +24049,8 @@
 					"\"bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Source/iOSApp.app.dSYM\"",
 					"\"bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.xctest.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.xctest";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.xctest";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.__internal__.__test_bundle.zip";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.__internal__.__test_bundle.zip";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = iOSAppSwiftUnitTests.xctest;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/SwiftUnitTests";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Test/SwiftUnitTests";
@@ -24100,7 +24100,7 @@
 				"BAZEL_COMPILE_TARGET_IDS[sdk=watchsimulator*]" = "$(BAZEL_COMPILE_TARGET_IDS)";
 				BAZEL_LABEL = "@@//watchOSAppExtension/Test/UnitTests:watchOSAppExtensionUnitTests";
 				BAZEL_OUTPUTS_DSYM = "\"bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTests.xctest.dSYM\"";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTests.xctest";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTests.__internal__.__test_bundle.zip";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = watchOSAppExtensionUnitTests.xctest;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/watchOSAppExtension/Test/UnitTests";
 				BAZEL_TARGET_ID = "@@//watchOSAppExtension/Test/UnitTests:watchOSAppExtensionUnitTests.__internal__.__test_bundle applebin_watchos-watchos_x86_64-opt-STABLE-21";
@@ -24188,8 +24188,8 @@
 				BAZEL_LABEL = "@@//Lib:LibFramework.tvOS";
 				BAZEL_OUTPUTS_DSYM = "\"bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/Lib/LibFramework.tvOS.framework.dSYM\"";
 				"BAZEL_OUTPUTS_DSYM[sdk=appletvos*]" = "\"bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-28/bin/Lib/LibFramework.tvOS.framework.dSYM\"";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/Lib/LibFramework.tvOS.framework";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=appletvos*]" = "bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-28/bin/Lib/LibFramework.tvOS.framework";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/Lib/LibFramework.tvOS.zip";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=appletvos*]" = "bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-28/bin/Lib/LibFramework.tvOS.zip";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = LibFramework.tvOS.framework;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/Lib";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=appletvos*]" = "bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-28/bin/Lib";
@@ -24246,8 +24246,8 @@
 				BAZEL_LABEL = "@@//Lib:LibFramework.tvOS";
 				BAZEL_OUTPUTS_DSYM = "\"bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/Lib/LibFramework.tvOS.framework.dSYM\"";
 				"BAZEL_OUTPUTS_DSYM[sdk=appletvos*]" = "\"bazel-out/applebin_tvos-tvos_arm64-opt-STABLE-30/bin/Lib/LibFramework.tvOS.framework.dSYM\"";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/Lib/LibFramework.tvOS.framework";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=appletvos*]" = "bazel-out/applebin_tvos-tvos_arm64-opt-STABLE-30/bin/Lib/LibFramework.tvOS.framework";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/Lib/LibFramework.tvOS.zip";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=appletvos*]" = "bazel-out/applebin_tvos-tvos_arm64-opt-STABLE-30/bin/Lib/LibFramework.tvOS.zip";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = LibFramework.tvOS.framework;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/Lib";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=appletvos*]" = "bazel-out/applebin_tvos-tvos_arm64-opt-STABLE-30/bin/Lib";
@@ -24349,7 +24349,7 @@
 				"BAZEL_COMPILE_TARGET_IDS[sdk=macosx*]" = "$(BAZEL_COMPILE_TARGET_IDS)";
 				BAZEL_LABEL = "@@//macOSApp/Source:macOSApp";
 				BAZEL_OUTPUTS_DSYM = "\"bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-34/bin/macOSApp/Source/macOSApp.app.dSYM\"";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-34/bin/macOSApp/Source/macOSApp.app";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-34/bin/macOSApp/Source/macOSApp.zip";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = macOSApp.app;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-34/bin/macOSApp/Source";
 				BAZEL_TARGET_ID = "@@//macOSApp/Source:macOSApp applebin_macos-darwin_x86_64-opt-STABLE-34";
@@ -24414,7 +24414,7 @@
 					"\"bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/tvOSApp/Source/tvOSApp.app.dSYM\"",
 					"\"bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/tvOSApp/Test/UITests/tvOSAppUITests.xctest.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/tvOSApp/Test/UITests/tvOSAppUITests.xctest";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/tvOSApp/Test/UITests/tvOSAppUITests.__internal__.__test_bundle.zip";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = tvOSAppUITests.xctest;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/tvOSApp/Test/UITests";
 				BAZEL_TARGET_ID = "@@//tvOSApp/Test/UITests:tvOSAppUITests.__internal__.__test_bundle applebin_tvos-tvos_x86_64-opt-STABLE-29";
@@ -24563,7 +24563,7 @@
 				"BAZEL_COMPILE_TARGET_IDS[sdk=iphonesimulator*]" = "$(BAZEL_COMPILE_TARGET_IDS)";
 				BAZEL_LABEL = "@@//iMessageApp:iMessageAppExtension";
 				BAZEL_OUTPUTS_DSYM = "\"bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iMessageApp/iMessageAppExtension.appex.dSYM\"";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iMessageApp/iMessageAppExtension.appex";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iMessageApp/iMessageAppExtension.zip";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = iMessageAppExtension.appex;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iMessageApp";
 				BAZEL_TARGET_ID = "@@//iMessageApp:iMessageAppExtension applebin_ios-ios_x86_64-opt-STABLE-17";
@@ -24613,8 +24613,8 @@
 					"\"bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-28/bin/UI/UIFramework.tvOS.framework.dSYM\"",
 					"\"bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-28/bin/tvOSApp/Source/tvOSApp.app.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/tvOSApp/Source/tvOSApp.app";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=appletvos*]" = "bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-28/bin/tvOSApp/Source/tvOSApp.app";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/tvOSApp/Source/tvOSApp.ipa";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=appletvos*]" = "bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-28/bin/tvOSApp/Source/tvOSApp.ipa";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = tvOSApp.app;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/tvOSApp/Source";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=appletvos*]" = "bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-28/bin/tvOSApp/Source";
@@ -24669,8 +24669,8 @@
 					"\"bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/Lib/LibFramework.iOS.framework.dSYM\"",
 					"\"bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/UI/UIFramework.iOS.framework.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/UI/UIFramework.iOS.framework";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/UI/UIFramework.iOS.framework";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/UI/UIFramework.iOS.zip";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/UI/UIFramework.iOS.zip";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = UIFramework.iOS.framework;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/UI";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/UI";
@@ -24694,11 +24694,11 @@
 				"PREVIEWS_SWIFT_INCLUDE__YES[sdk=iphoneos*]" = "-I bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-6/bin/UI";
 				PREVIEW_FRAMEWORK_PATHS = (
 					"\"$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework\"",
-					"\"$(BAZEL_OUT)/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/Lib/LibFramework.iOS.framework\"",
+					"\"$(BAZEL_OUT)/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/Lib/LibFramework.iOS.zip\"",
 				);
 				"PREVIEW_FRAMEWORK_PATHS[sdk=iphoneos*]" = (
 					"\"$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework\"",
-					"\"$(BAZEL_OUT)/applebin_ios-ios_arm64-dbg-STABLE-16/bin/Lib/LibFramework.iOS.framework\"",
+					"\"$(BAZEL_OUT)/applebin_ios-ios_arm64-dbg-STABLE-16/bin/Lib/LibFramework.iOS.zip\"",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "rules-xcodeproj.UIFramework";
 				PRODUCT_MODULE_NAME = UI;
@@ -24777,8 +24777,8 @@
 				BAZEL_LABEL = "@@//WidgetExtension:WidgetExtension";
 				BAZEL_OUTPUTS_DSYM = "\"bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/WidgetExtension/WidgetExtension.appex.dSYM\"";
 				"BAZEL_OUTPUTS_DSYM[sdk=iphoneos*]" = "\"bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/WidgetExtension/WidgetExtension.appex.dSYM\"";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/WidgetExtension/WidgetExtension.appex";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/WidgetExtension/WidgetExtension.appex";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/WidgetExtension/WidgetExtension.zip";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/WidgetExtension/WidgetExtension.zip";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = WidgetExtension.appex;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/WidgetExtension";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/WidgetExtension";
@@ -24910,8 +24910,8 @@
 					"\"bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-22/bin/UI/UIFramework.watchOS.framework.dSYM\"",
 					"\"bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-22/bin/watchOSAppExtension/watchOSAppExtension.appex.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/watchOSAppExtension/watchOSAppExtension.appex";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=watchos*]" = "bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-22/bin/watchOSAppExtension/watchOSAppExtension.appex";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/watchOSAppExtension/watchOSAppExtension.zip";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=watchos*]" = "bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-22/bin/watchOSAppExtension/watchOSAppExtension.zip";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = watchOSAppExtension.appex;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/watchOSAppExtension";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=watchos*]" = "bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-22/bin/watchOSAppExtension";
@@ -24982,8 +24982,8 @@
 					"\"bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Source/iOSApp.app.dSYM\"",
 					"\"bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.xctest.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.xctest";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.xctest";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.__internal__.__test_bundle.zip";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.__internal__.__test_bundle.zip";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = iOSAppSwiftUnitTests.xctest;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/SwiftUnitTests";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Test/SwiftUnitTests";
@@ -25031,8 +25031,8 @@
 				"ARCHS[sdk=watchos*]" = arm64_32;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				BAZEL_LABEL = "@@//watchOSApp:watchOSApp";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-25/bin/watchOSApp/watchOSApp.app";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=watchos*]" = "bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-26/bin/watchOSApp/watchOSApp.app";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-25/bin/watchOSApp/watchOSApp.zip";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=watchos*]" = "bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-26/bin/watchOSApp/watchOSApp.zip";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = watchOSApp.app;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-25/bin/watchOSApp";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=watchos*]" = "bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-26/bin/watchOSApp";
@@ -25085,7 +25085,7 @@
 				ARCHS = x86_64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				BAZEL_LABEL = "@@//iMessageApp:iMessageApp";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iMessageApp/iMessageApp.app";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iMessageApp/iMessageApp.ipa";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = iMessageApp.app;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iMessageApp";
 				BAZEL_TARGET_ID = "@@//iMessageApp:iMessageApp applebin_ios-ios_x86_64-opt-STABLE-17";
@@ -25119,8 +25119,8 @@
 				BAZEL_LABEL = "@@//AppClip:AppClip";
 				BAZEL_OUTPUTS_DSYM = "\"bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/AppClip/AppClip.app.dSYM\"";
 				"BAZEL_OUTPUTS_DSYM[sdk=iphoneos*]" = "\"bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/AppClip/AppClip.app.dSYM\"";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/AppClip/AppClip.app";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/AppClip/AppClip.app";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/AppClip/AppClip.ipa";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/AppClip/AppClip.ipa";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = AppClip.app;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/AppClip";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/AppClip";
@@ -25224,8 +25224,8 @@
 					"\"bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/Lib/LibFramework.iOS.framework.dSYM\"",
 					"\"bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/UI/UIFramework.iOS.framework.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/UI/UIFramework.iOS.framework";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/UI/UIFramework.iOS.framework";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/UI/UIFramework.iOS.zip";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/UI/UIFramework.iOS.zip";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = UIFramework.iOS.framework;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/UI";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/UI";
@@ -25249,11 +25249,11 @@
 				"PREVIEWS_SWIFT_INCLUDE__YES[sdk=iphoneos*]" = "-I bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-12/bin/UI";
 				PREVIEW_FRAMEWORK_PATHS = (
 					"\"$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework\"",
-					"\"$(BAZEL_OUT)/applebin_ios-ios_x86_64-opt-STABLE-17/bin/Lib/LibFramework.iOS.framework\"",
+					"\"$(BAZEL_OUT)/applebin_ios-ios_x86_64-opt-STABLE-17/bin/Lib/LibFramework.iOS.zip\"",
 				);
 				"PREVIEW_FRAMEWORK_PATHS[sdk=iphoneos*]" = (
 					"\"$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework\"",
-					"\"$(BAZEL_OUT)/applebin_ios-ios_arm64-opt-STABLE-18/bin/Lib/LibFramework.iOS.framework\"",
+					"\"$(BAZEL_OUT)/applebin_ios-ios_arm64-opt-STABLE-18/bin/Lib/LibFramework.iOS.zip\"",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "rules-xcodeproj.UIFramework";
 				PRODUCT_MODULE_NAME = UI;
@@ -25351,8 +25351,8 @@
 				ARCHS = x86_64;
 				"ARCHS[sdk=watchos*]" = arm64_32;
 				BAZEL_LABEL = "@@//Lib/dist/dynamic:watchOS";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/Lib/dist/dynamic/Lib.framework";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=watchos*]" = "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-20/bin/Lib/dist/dynamic/Lib.framework";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/Lib/dist/dynamic/watchOS.zip";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=watchos*]" = "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-20/bin/Lib/dist/dynamic/watchOS.zip";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = Lib.framework;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/Lib/dist/dynamic";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=watchos*]" = "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-20/bin/Lib/dist/dynamic";
@@ -25414,8 +25414,8 @@
 					"\"bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Source/iOSApp.app.dSYM\"",
 					"\"bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.xctest.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.xctest";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.xctest";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.__internal__.__test_bundle.zip";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.__internal__.__test_bundle.zip";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = iOSAppObjCUnitTests.xctest;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/ObjCUnitTests";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Test/ObjCUnitTests";
@@ -25538,8 +25538,8 @@
 				BAZEL_LABEL = "@@//AppClip:AppClip";
 				BAZEL_OUTPUTS_DSYM = "\"bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/AppClip/AppClip.app.dSYM\"";
 				"BAZEL_OUTPUTS_DSYM[sdk=iphoneos*]" = "\"bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/AppClip/AppClip.app.dSYM\"";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/AppClip/AppClip.app";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/AppClip/AppClip.app";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/AppClip/AppClip.ipa";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/AppClip/AppClip.ipa";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = AppClip.app;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/AppClip";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/AppClip";
@@ -25689,8 +25689,8 @@
 				BAZEL_LABEL = "@@//Lib:LibFramework.watchOS";
 				BAZEL_OUTPUTS_DSYM = "\"bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/Lib/LibFramework.watchOS.framework.dSYM\"";
 				"BAZEL_OUTPUTS_DSYM[sdk=watchos*]" = "\"bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-22/bin/Lib/LibFramework.watchOS.framework.dSYM\"";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/Lib/LibFramework.watchOS.framework";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=watchos*]" = "bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-22/bin/Lib/LibFramework.watchOS.framework";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/Lib/LibFramework.watchOS.zip";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=watchos*]" = "bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-22/bin/Lib/LibFramework.watchOS.zip";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = LibFramework.watchOS.framework;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/Lib";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=watchos*]" = "bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-22/bin/Lib";
@@ -25842,7 +25842,7 @@
 					"\"bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-34/bin/macOSApp/Source/macOSApp.app.dSYM\"",
 					"\"bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-34/bin/macOSApp/Test/UITests/macOSAppUITests.xctest.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-34/bin/macOSApp/Test/UITests/macOSAppUITests.xctest";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-34/bin/macOSApp/Test/UITests/macOSAppUITests.__internal__.__test_bundle.zip";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = macOSAppUITests.xctest;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-34/bin/macOSApp/Test/UITests";
 				BAZEL_TARGET_ID = "@@//macOSApp/Test/UITests:macOSAppUITests.__internal__.__test_bundle applebin_macos-darwin_x86_64-opt-STABLE-34";
@@ -25935,7 +25935,7 @@
 					"\"bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/tvOSApp/Source/tvOSApp.app.dSYM\"",
 					"\"bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/tvOSApp/Test/UnitTests/tvOSAppUnitTests.xctest.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/tvOSApp/Test/UnitTests/tvOSAppUnitTests.xctest";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/tvOSApp/Test/UnitTests/tvOSAppUnitTests.__internal__.__test_bundle.zip";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = tvOSAppUnitTests.xctest;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/tvOSApp/Test/UnitTests";
 				BAZEL_TARGET_ID = "@@//tvOSApp/Test/UnitTests:tvOSAppUnitTests.__internal__.__test_bundle applebin_tvos-tvos_x86_64-opt-STABLE-29";
@@ -26087,7 +26087,7 @@
 				"BAZEL_COMPILE_TARGET_IDS[sdk=macosx*]" = "$(BAZEL_COMPILE_TARGET_IDS)";
 				BAZEL_LABEL = "@@//Bundle:Bundle";
 				BAZEL_OUTPUTS_DSYM = "\"bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/Bundle/ABundle.aplugin.dSYM\"";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/Bundle/ABundle.aplugin";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/Bundle/Bundle.zip";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = ABundle.aplugin;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/Bundle";
 				BAZEL_TARGET_ID = "@@//Bundle:Bundle applebin_macos-darwin_x86_64-dbg-STABLE-33";
@@ -26166,8 +26166,8 @@
 				BAZEL_LABEL = "@@//Lib:LibFramework.watchOS";
 				BAZEL_OUTPUTS_DSYM = "\"bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/Lib/LibFramework.watchOS.framework.dSYM\"";
 				"BAZEL_OUTPUTS_DSYM[sdk=watchos*]" = "\"bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-20/bin/Lib/LibFramework.watchOS.framework.dSYM\"";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/Lib/LibFramework.watchOS.framework";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=watchos*]" = "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-20/bin/Lib/LibFramework.watchOS.framework";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/Lib/LibFramework.watchOS.zip";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=watchos*]" = "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-20/bin/Lib/LibFramework.watchOS.zip";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = LibFramework.watchOS.framework;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/Lib";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=watchos*]" = "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-20/bin/Lib";
@@ -26348,7 +26348,7 @@
 					"\"bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/macOSApp/Source/macOSApp.app.dSYM\"",
 					"\"bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/macOSApp/Test/UITests/macOSAppUITests.xctest.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/macOSApp/Test/UITests/macOSAppUITests.xctest";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/macOSApp/Test/UITests/macOSAppUITests.__internal__.__test_bundle.zip";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = macOSAppUITests.xctest;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/macOSApp/Test/UITests";
 				BAZEL_TARGET_ID = "@@//macOSApp/Test/UITests:macOSAppUITests.__internal__.__test_bundle applebin_macos-darwin_x86_64-dbg-STABLE-33";
@@ -26412,8 +26412,8 @@
 				BAZEL_LABEL = "@@//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC";
 				BAZEL_OUTPUTS_DSYM = "\"bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Source/CoreUtilsObjC/CoreUtilsObjC.framework.dSYM\"";
 				"BAZEL_OUTPUTS_DSYM[sdk=iphoneos*]" = "\"bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Source/CoreUtilsObjC/CoreUtilsObjC.framework.dSYM\"";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Source/CoreUtilsObjC/CoreUtilsObjC.framework";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Source/CoreUtilsObjC/CoreUtilsObjC.framework";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Source/CoreUtilsObjC/FrameworkCoreUtilsObjC.zip";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Source/CoreUtilsObjC/FrameworkCoreUtilsObjC.zip";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = CoreUtilsObjC.framework;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Source/CoreUtilsObjC";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Source/CoreUtilsObjC";
@@ -26454,7 +26454,7 @@
 				"BAZEL_COMPILE_TARGET_IDS[sdk=iphonesimulator*]" = "$(BAZEL_COMPILE_TARGET_IDS)";
 				BAZEL_LABEL = "@@//iMessageApp:iMessageAppExtension";
 				BAZEL_OUTPUTS_DSYM = "\"bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iMessageApp/iMessageAppExtension.appex.dSYM\"";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iMessageApp/iMessageAppExtension.appex";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iMessageApp/iMessageAppExtension.zip";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = iMessageAppExtension.appex;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iMessageApp";
 				BAZEL_TARGET_ID = "@@//iMessageApp:iMessageAppExtension applebin_ios-ios_x86_64-dbg-STABLE-15";
@@ -26680,7 +26680,7 @@
 					"\"bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Source/iOSApp.app.dSYM\"",
 					"\"bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/UITests/iOSAppUITestSuite.xctest.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/UITests/iOSAppUITestSuite.xctest";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/UITests/iOSAppUITestSuite.__internal__.__test_bundle.zip";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = iOSAppUITestSuite.xctest;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/UITests";
 				BAZEL_TARGET_ID = "@@//iOSApp/Test/UITests:iOSAppUITestSuite.__internal__.__test_bundle applebin_ios-ios_x86_64-dbg-STABLE-15";
@@ -26835,8 +26835,8 @@
 					"\"bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-22/bin/Lib/LibFramework.watchOS.framework.dSYM\"",
 					"\"bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-22/bin/UI/UIFramework.watchOS.framework.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/UI/UIFramework.watchOS.framework";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=watchos*]" = "bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-22/bin/UI/UIFramework.watchOS.framework";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/UI/UIFramework.watchOS.zip";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=watchos*]" = "bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-22/bin/UI/UIFramework.watchOS.zip";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = UIFramework.watchOS.framework;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/UI";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=watchos*]" = "bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-22/bin/UI";
@@ -26859,11 +26859,11 @@
 				"PREVIEWS_SWIFT_INCLUDE__YES[sdk=watchos*]" = "-I bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-opt-STABLE-13/bin/UI";
 				PREVIEW_FRAMEWORK_PATHS = (
 					"\"$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator/CryptoSwift.framework\"",
-					"\"$(BAZEL_OUT)/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/Lib/LibFramework.watchOS.framework\"",
+					"\"$(BAZEL_OUT)/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/Lib/LibFramework.watchOS.zip\"",
 				);
 				"PREVIEW_FRAMEWORK_PATHS[sdk=watchos*]" = (
 					"\"$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k/CryptoSwift.framework\"",
-					"\"$(BAZEL_OUT)/applebin_watchos-watchos_arm64_32-opt-STABLE-22/bin/Lib/LibFramework.watchOS.framework\"",
+					"\"$(BAZEL_OUT)/applebin_watchos-watchos_arm64_32-opt-STABLE-22/bin/Lib/LibFramework.watchOS.zip\"",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "rules-xcodeproj.UIFramework";
 				PRODUCT_MODULE_NAME = UI;
@@ -26884,7 +26884,7 @@
 				ARCHS = x86_64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				BAZEL_LABEL = "@@//iMessageApp:iMessageApp";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iMessageApp/iMessageApp.app";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iMessageApp/iMessageApp.ipa";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = iMessageApp.app;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iMessageApp";
 				BAZEL_TARGET_ID = "@@//iMessageApp:iMessageApp applebin_ios-ios_x86_64-dbg-STABLE-15";
@@ -26914,7 +26914,7 @@
 				"BAZEL_COMPILE_TARGET_IDS[sdk=macosx*]" = "$(BAZEL_COMPILE_TARGET_IDS)";
 				BAZEL_LABEL = "@@//CommandLine/Tests:CommandLineToolTests";
 				BAZEL_OUTPUTS_DSYM = "\"bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-46/bin/CommandLine/Tests/CommandLineToolTests.xctest.dSYM\"";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-46/bin/CommandLine/Tests/CommandLineToolTests.xctest";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-46/bin/CommandLine/Tests/CommandLineToolTests.__internal__.__test_bundle.zip";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = CommandLineToolTests.xctest;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-46/bin/CommandLine/Tests";
 				BAZEL_TARGET_ID = "@@//CommandLine/Tests:CommandLineToolTests.__internal__.__test_bundle applebin_macos-darwin_x86_64-opt-STABLE-46";
@@ -27136,8 +27136,8 @@
 					"\"bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Source/iOSApp.app.dSYM\"",
 					"\"bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Test/UITests/iOSAppUITests.xctest.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/UITests/iOSAppUITests.xctest";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Test/UITests/iOSAppUITests.xctest";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/UITests/iOSAppUITests.__internal__.__test_bundle.zip";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Test/UITests/iOSAppUITests.__internal__.__test_bundle.zip";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = iOSAppUITests.xctest;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/UITests";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Test/UITests";
@@ -27187,8 +27187,8 @@
 				BAZEL_LABEL = "@@//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC";
 				BAZEL_OUTPUTS_DSYM = "\"bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Source/CoreUtilsObjC/CoreUtilsObjC.framework.dSYM\"";
 				"BAZEL_OUTPUTS_DSYM[sdk=iphoneos*]" = "\"bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Source/CoreUtilsObjC/CoreUtilsObjC.framework.dSYM\"";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Source/CoreUtilsObjC/CoreUtilsObjC.framework";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Source/CoreUtilsObjC/CoreUtilsObjC.framework";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Source/CoreUtilsObjC/FrameworkCoreUtilsObjC.zip";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Source/CoreUtilsObjC/FrameworkCoreUtilsObjC.zip";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = CoreUtilsObjC.framework;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Source/CoreUtilsObjC";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Source/CoreUtilsObjC";
@@ -27342,7 +27342,7 @@
 					"\"bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/watchOSAppExtension/watchOSAppExtension.appex.dSYM\"",
 					"\"bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/watchOSApp/Test/UITests/watchOSAppUITests.xctest.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/watchOSApp/Test/UITests/watchOSAppUITests.xctest";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/watchOSApp/Test/UITests/watchOSAppUITests.__internal__.__test_bundle.zip";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = watchOSAppUITests.xctest;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/watchOSApp/Test/UITests";
 				BAZEL_TARGET_ID = "@@//watchOSApp/Test/UITests:watchOSAppUITests.__internal__.__test_bundle applebin_watchos-watchos_x86_64-dbg-STABLE-19";
@@ -27402,8 +27402,8 @@
 					"\"bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Source/iOSApp.app.dSYM\"",
 					"\"bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Test/UITests/iOSAppUITests.xctest.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/UITests/iOSAppUITests.xctest";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Test/UITests/iOSAppUITests.xctest";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/UITests/iOSAppUITests.__internal__.__test_bundle.zip";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Test/UITests/iOSAppUITests.__internal__.__test_bundle.zip";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = iOSAppUITests.xctest;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/UITests";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Test/UITests";
@@ -27457,7 +27457,7 @@
 					"\"bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Source/iOSApp.app.dSYM\"",
 					"\"bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTestSuite.xctest.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTestSuite.xctest";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTestSuite.__internal__.__test_bundle.zip";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = iOSAppSwiftUnitTestSuite.xctest;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/SwiftUnitTests";
 				BAZEL_TARGET_ID = "@@//iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTestSuite.__internal__.__test_bundle applebin_ios-ios_x86_64-dbg-STABLE-15";
@@ -27672,7 +27672,7 @@
 					"\"bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Source/iOSApp.app.dSYM\"",
 					"\"bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTestSuite.xctest.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTestSuite.xctest";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTestSuite.__internal__.__test_bundle.zip";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = iOSAppSwiftUnitTestSuite.xctest;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/SwiftUnitTests";
 				BAZEL_TARGET_ID = "@@//iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTestSuite.__internal__.__test_bundle applebin_ios-ios_x86_64-opt-STABLE-17";
@@ -27760,8 +27760,8 @@
 				BAZEL_LABEL = "@@//WidgetExtension:WidgetExtension";
 				BAZEL_OUTPUTS_DSYM = "\"bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/WidgetExtension/WidgetExtension.appex.dSYM\"";
 				"BAZEL_OUTPUTS_DSYM[sdk=iphoneos*]" = "\"bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/WidgetExtension/WidgetExtension.appex.dSYM\"";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/WidgetExtension/WidgetExtension.appex";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/WidgetExtension/WidgetExtension.appex";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/WidgetExtension/WidgetExtension.zip";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/WidgetExtension/WidgetExtension.zip";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = WidgetExtension.appex;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/WidgetExtension";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/WidgetExtension";
@@ -27916,7 +27916,7 @@
 					"\"bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/tvOSApp/Source/tvOSApp.app.dSYM\"",
 					"\"bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/tvOSApp/Test/UITests/tvOSAppUITests.xctest.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/tvOSApp/Test/UITests/tvOSAppUITests.xctest";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/tvOSApp/Test/UITests/tvOSAppUITests.__internal__.__test_bundle.zip";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = tvOSAppUITests.xctest;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/tvOSApp/Test/UITests";
 				BAZEL_TARGET_ID = "@@//tvOSApp/Test/UITests:tvOSAppUITests.__internal__.__test_bundle applebin_tvos-tvos_x86_64-dbg-STABLE-27";
@@ -28043,7 +28043,7 @@
 				"BAZEL_COMPILE_TARGET_IDS[sdk=macosx*]" = "$(BAZEL_COMPILE_TARGET_IDS)";
 				BAZEL_LABEL = "@@//CommandLine/Tests:CommandLineToolTests";
 				BAZEL_OUTPUTS_DSYM = "\"bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-45/bin/CommandLine/Tests/CommandLineToolTests.xctest.dSYM\"";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-45/bin/CommandLine/Tests/CommandLineToolTests.xctest";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-45/bin/CommandLine/Tests/CommandLineToolTests.__internal__.__test_bundle.zip";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = CommandLineToolTests.xctest;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-45/bin/CommandLine/Tests";
 				BAZEL_TARGET_ID = "@@//CommandLine/Tests:CommandLineToolTests.__internal__.__test_bundle applebin_macos-darwin_x86_64-dbg-STABLE-45";
@@ -28192,7 +28192,7 @@
 					"\"bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Source/iOSApp.app.dSYM\"",
 					"\"bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTestSuite.xctest.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTestSuite.xctest";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTestSuite.__internal__.__test_bundle.zip";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = iOSAppObjCUnitTestSuite.xctest;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/ObjCUnitTests";
 				BAZEL_TARGET_ID = "@@//iOSApp/Test/ObjCUnitTests:iOSAppObjCUnitTestSuite.__internal__.__test_bundle applebin_ios-ios_x86_64-opt-STABLE-17";
@@ -28297,7 +28297,7 @@
 				"BAZEL_COMPILE_TARGET_IDS[sdk=macosx*]" = "$(BAZEL_COMPILE_TARGET_IDS)";
 				BAZEL_LABEL = "@@//macOSApp/Source:macOSApp";
 				BAZEL_OUTPUTS_DSYM = "\"bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/macOSApp/Source/macOSApp.app.dSYM\"";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/macOSApp/Source/macOSApp.app";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/macOSApp/Source/macOSApp.zip";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = macOSApp.app;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/macOSApp/Source";
 				BAZEL_TARGET_ID = "@@//macOSApp/Source:macOSApp applebin_macos-darwin_x86_64-dbg-STABLE-33";
@@ -28354,8 +28354,8 @@
 				"ARCHS[sdk=watchos*]" = arm64_32;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				BAZEL_LABEL = "@@//watchOSApp:watchOSApp";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-23/bin/watchOSApp/watchOSApp.app";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=watchos*]" = "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-24/bin/watchOSApp/watchOSApp.app";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-23/bin/watchOSApp/watchOSApp.zip";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=watchos*]" = "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-24/bin/watchOSApp/watchOSApp.zip";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = watchOSApp.app;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-23/bin/watchOSApp";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=watchos*]" = "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-24/bin/watchOSApp";
@@ -28505,8 +28505,8 @@
 					"\"bazel-out/applebin_tvos-tvos_arm64-opt-STABLE-30/bin/Lib/LibFramework.tvOS.framework.dSYM\"",
 					"\"bazel-out/applebin_tvos-tvos_arm64-opt-STABLE-30/bin/UI/UIFramework.tvOS.framework.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/UI/UIFramework.tvOS.framework";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=appletvos*]" = "bazel-out/applebin_tvos-tvos_arm64-opt-STABLE-30/bin/UI/UIFramework.tvOS.framework";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/UI/UIFramework.tvOS.zip";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=appletvos*]" = "bazel-out/applebin_tvos-tvos_arm64-opt-STABLE-30/bin/UI/UIFramework.tvOS.zip";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = UIFramework.tvOS.framework;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/UI";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=appletvos*]" = "bazel-out/applebin_tvos-tvos_arm64-opt-STABLE-30/bin/UI";
@@ -28529,11 +28529,11 @@
 				"PREVIEWS_SWIFT_INCLUDE__YES[sdk=appletvos*]" = "-I bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-opt-STABLE-14/bin/UI";
 				PREVIEW_FRAMEWORK_PATHS = (
 					"\"$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator/CryptoSwift.framework\"",
-					"\"$(BAZEL_OUT)/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/Lib/LibFramework.tvOS.framework\"",
+					"\"$(BAZEL_OUT)/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/Lib/LibFramework.tvOS.zip\"",
 				);
 				"PREVIEW_FRAMEWORK_PATHS[sdk=appletvos*]" = (
 					"\"$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64/CryptoSwift.framework\"",
-					"\"$(BAZEL_OUT)/applebin_tvos-tvos_arm64-opt-STABLE-30/bin/Lib/LibFramework.tvOS.framework\"",
+					"\"$(BAZEL_OUT)/applebin_tvos-tvos_arm64-opt-STABLE-30/bin/Lib/LibFramework.tvOS.zip\"",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "rules-xcodeproj.UIFramework";
 				PRODUCT_MODULE_NAME = UI;

--- a/examples/integration/test/fixtures/bwb_targets_spec.json
+++ b/examples/integration/test/fixtures/bwb_targets_spec.json
@@ -202,7 +202,7 @@
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/AppClip/AppClip.app.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/AppClip/AppClip.app",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/AppClip/AppClip.ipa",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "AppClip.app",
             "CODE_SIGN_ENTITLEMENTS": "$(BAZEL_OUT)/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/AppClip/Entitlements.withbundleid.plist",
             "CODE_SIGN_STYLE": "Manual",
@@ -243,7 +243,7 @@
             "e": "AppClip",
             "m": "AppClip",
             "n": "AppClip",
-            "p": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/AppClip/AppClip.app",
+            "p": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/AppClip/AppClip_archive-root/Payload/AppClip.app",
             "t": "com.apple.product-type.application.on-demand-install-capable"
         }
     },
@@ -336,7 +336,7 @@
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/WidgetExtension/WidgetExtension.appex.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/WidgetExtension/WidgetExtension.appex",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/WidgetExtension/WidgetExtension.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "WidgetExtension.appex",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -375,7 +375,7 @@
             "e": "WidgetExtension",
             "m": "WidgetExtension",
             "n": "WidgetExtension",
-            "p": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/WidgetExtension/WidgetExtension.appex",
+            "p": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/WidgetExtension/WidgetExtension_archive-root/WidgetExtension.appex",
             "t": "com.apple.product-type.app-extension"
         }
     },
@@ -400,7 +400,7 @@
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Source/CoreUtilsObjC/CoreUtilsObjC.framework.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Source/CoreUtilsObjC/CoreUtilsObjC.framework",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Source/CoreUtilsObjC/FrameworkCoreUtilsObjC.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "CoreUtilsObjC.framework",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -432,7 +432,7 @@
             "e": "CoreUtilsObjC",
             "m": "CoreUtilsObjC",
             "n": "CoreUtilsObjC",
-            "p": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Source/CoreUtilsObjC/CoreUtilsObjC.framework",
+            "p": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Source/CoreUtilsObjC/FrameworkCoreUtilsObjC_archive-root/CoreUtilsObjC.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -464,7 +464,7 @@
                 "\"bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/Lib/LibFramework.iOS.framework.dSYM\"",
                 "\"bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/UI/UIFramework.iOS.framework.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/UI/UIFramework.iOS.framework",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/UI/UIFramework.iOS.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "UIFramework.iOS.framework",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -475,7 +475,7 @@
             "PREVIEWS_SWIFT_INCLUDE__YES": "-I bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-3/bin/UI",
             "PREVIEW_FRAMEWORK_PATHS": [
                 "\"$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework\"",
-                "\"$(BAZEL_OUT)/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/Lib/LibFramework.iOS.framework\""
+                "\"$(BAZEL_OUT)/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/Lib/LibFramework.iOS.zip\""
             ],
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.UIFramework",
             "PRODUCT_MODULE_NAME": "UI",
@@ -506,7 +506,7 @@
             "e": "UIFramework.iOS",
             "m": "UIFramework.iOS",
             "n": "UIFramework.iOS",
-            "p": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/UI/UIFramework.iOS.framework",
+            "p": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/UI/UIFramework.iOS_archive-root/UIFramework.iOS.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -565,7 +565,7 @@
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/Lib/LibFramework.watchOS.framework.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/Lib/LibFramework.watchOS.framework",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/Lib/LibFramework.watchOS.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "LibFramework.watchOS.framework",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -590,7 +590,7 @@
             "e": "LibFramework.watchOS",
             "m": "LibFramework.watchOS",
             "n": "LibFramework.watchOS",
-            "p": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/Lib/LibFramework.watchOS.framework",
+            "p": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/Lib/LibFramework.watchOS_archive-root/LibFramework.watchOS.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -625,7 +625,7 @@
                 "\"bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/Lib/LibFramework.watchOS.framework.dSYM\"",
                 "\"bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/UI/UIFramework.watchOS.framework.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/UI/UIFramework.watchOS.framework",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/UI/UIFramework.watchOS.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "UIFramework.watchOS.framework",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -636,7 +636,7 @@
             "PREVIEWS_SWIFT_INCLUDE__YES": "-I bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-4/bin/UI",
             "PREVIEW_FRAMEWORK_PATHS": [
                 "\"$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator/CryptoSwift.framework\"",
-                "\"$(BAZEL_OUT)/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/Lib/LibFramework.watchOS.framework\""
+                "\"$(BAZEL_OUT)/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/Lib/LibFramework.watchOS.zip\""
             ],
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.UIFramework",
             "PRODUCT_MODULE_NAME": "UI"
@@ -663,7 +663,7 @@
             "e": "UIFramework.watchOS",
             "m": "UIFramework.watchOS",
             "n": "UIFramework.watchOS",
-            "p": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/UI/UIFramework.watchOS.framework",
+            "p": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/UI/UIFramework.watchOS_archive-root/UIFramework.watchOS.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -697,7 +697,7 @@
                 "\"bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/UI/UIFramework.watchOS.framework.dSYM\"",
                 "\"bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/watchOSAppExtension/watchOSAppExtension.appex.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/watchOSAppExtension/watchOSAppExtension.appex",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/watchOSAppExtension/watchOSAppExtension.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "watchOSAppExtension.appex",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -733,7 +733,7 @@
             "e": "watchOSAppExtension",
             "m": "watchOSAppExtension",
             "n": "watchOSAppExtension",
-            "p": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/watchOSAppExtension/watchOSAppExtension.appex",
+            "p": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/watchOSAppExtension/watchOSAppExtension_archive-root/watchOSAppExtension.appex",
             "t": "com.apple.product-type.watchkit2-extension"
         }
     },
@@ -751,7 +751,7 @@
         ],
         "b": {
             "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-23/bin/watchOSApp/watchOSApp.app",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-23/bin/watchOSApp/watchOSApp.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "watchOSApp.app",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -776,7 +776,7 @@
             "e": "watchOSApp",
             "m": "watchOSApp",
             "n": "watchOSApp",
-            "p": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-23/bin/watchOSApp/watchOSApp.app",
+            "p": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-23/bin/watchOSApp/watchOSApp_archive-root/Payload/watchOSApp.app",
             "t": "com.apple.product-type.application.watchapp2"
         }
     },
@@ -826,7 +826,7 @@
                 "\"bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/watchOSAppExtension/watchOSAppExtension.appex.dSYM\"",
                 "\"bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Source/iOSApp.app.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Source/iOSApp.app",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Source/iOSApp.ipa",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "iOSApp.app",
             "CODE_SIGN_ENTITLEMENTS": "$(SRCROOT)/iOSApp/Source/ios app.entitlements",
             "CODE_SIGN_STYLE": "Manual",
@@ -885,7 +885,7 @@
             "e": "iOSApp_ExecutableName",
             "m": "iOSApp",
             "n": "iOSApp",
-            "p": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Source/iOSApp.app",
+            "p": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Source/iOSApp_archive-root/Payload/iOSApp.app",
             "t": "com.apple.product-type.application"
         },
         "w": "@@//watchOSApp:watchOSApp applebin_watchos-watchos_x86_64-dbg-STABLE-23"
@@ -906,7 +906,7 @@
         "6": "bazel-out/darwin_x86_64-dbg-STABLE-0/bin/external/rules_xcodeproj~override~internal~rules_xcodeproj_generated/generator/test/fixtures/xcodeproj_bwb/xcodeproj_bwb-params/iOS.18.link.params",
         "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/Lib/dist/dynamic/Lib.framework",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/Lib/dist/dynamic/iOS.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "Lib.framework",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -932,7 +932,7 @@
             "e": "Lib",
             "m": "Lib",
             "n": "Lib",
-            "p": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/Lib/dist/dynamic/Lib.framework",
+            "p": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/Lib/dist/dynamic/iOS_archive-root/Lib.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -988,7 +988,7 @@
         "6": "bazel-out/darwin_x86_64-dbg-STABLE-0/bin/external/rules_xcodeproj~override~internal~rules_xcodeproj_generated/generator/test/fixtures/xcodeproj_bwb/xcodeproj_bwb-params/tvOS.20.link.params",
         "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/Lib/dist/dynamic/Lib.framework",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/Lib/dist/dynamic/tvOS.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "Lib.framework",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -1013,7 +1013,7 @@
             "e": "Lib",
             "m": "Lib",
             "n": "Lib",
-            "p": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/Lib/dist/dynamic/Lib.framework",
+            "p": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/Lib/dist/dynamic/tvOS_archive-root/Lib.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -1033,7 +1033,7 @@
         "6": "bazel-out/darwin_x86_64-dbg-STABLE-0/bin/external/rules_xcodeproj~override~internal~rules_xcodeproj_generated/generator/test/fixtures/xcodeproj_bwb/xcodeproj_bwb-params/watchOS.21.link.params",
         "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/Lib/dist/dynamic/Lib.framework",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/Lib/dist/dynamic/watchOS.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "Lib.framework",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -1058,7 +1058,7 @@
             "e": "Lib",
             "m": "Lib",
             "n": "Lib",
-            "p": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/Lib/dist/dynamic/Lib.framework",
+            "p": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/Lib/dist/dynamic/watchOS_archive-root/Lib.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -1081,7 +1081,7 @@
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/Lib/LibFramework.tvOS.framework.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/Lib/LibFramework.tvOS.framework",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/Lib/LibFramework.tvOS.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "LibFramework.tvOS.framework",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -1106,7 +1106,7 @@
             "e": "LibFramework.tvOS",
             "m": "LibFramework.tvOS",
             "n": "LibFramework.tvOS",
-            "p": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/Lib/LibFramework.tvOS.framework",
+            "p": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/Lib/LibFramework.tvOS_archive-root/LibFramework.tvOS.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -1141,7 +1141,7 @@
                 "\"bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/Lib/LibFramework.tvOS.framework.dSYM\"",
                 "\"bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/UI/UIFramework.tvOS.framework.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/UI/UIFramework.tvOS.framework",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/UI/UIFramework.tvOS.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "UIFramework.tvOS.framework",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -1152,7 +1152,7 @@
             "PREVIEWS_SWIFT_INCLUDE__YES": "-I bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-5/bin/UI",
             "PREVIEW_FRAMEWORK_PATHS": [
                 "\"$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator/CryptoSwift.framework\"",
-                "\"$(BAZEL_OUT)/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/Lib/LibFramework.tvOS.framework\""
+                "\"$(BAZEL_OUT)/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/Lib/LibFramework.tvOS.zip\""
             ],
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.UIFramework",
             "PRODUCT_MODULE_NAME": "UI"
@@ -1179,7 +1179,7 @@
             "e": "UIFramework.tvOS",
             "m": "UIFramework.tvOS",
             "n": "UIFramework.tvOS",
-            "p": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/UI/UIFramework.tvOS.framework",
+            "p": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/UI/UIFramework.tvOS_archive-root/UIFramework.tvOS.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -1216,7 +1216,7 @@
                 "\"bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/UI/UIFramework.tvOS.framework.dSYM\"",
                 "\"bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/tvOSApp/Source/tvOSApp.app.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/tvOSApp/Source/tvOSApp.app",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/tvOSApp/Source/tvOSApp.ipa",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "tvOSApp.app",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -1253,7 +1253,7 @@
             "e": "tvOSApp",
             "m": "tvOSApp",
             "n": "tvOSApp",
-            "p": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/tvOSApp/Source/tvOSApp.app",
+            "p": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/tvOSApp/Source/tvOSApp_archive-root/Payload/tvOSApp.app",
             "t": "com.apple.product-type.application"
         }
     },
@@ -1277,7 +1277,7 @@
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/Bundle/ABundle.aplugin.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/Bundle/ABundle.aplugin",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/Bundle/Bundle.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "ABundle.aplugin",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -1300,7 +1300,7 @@
             "e": "ABundle",
             "m": "ABundle",
             "n": "ABundle",
-            "p": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/Bundle/ABundle.aplugin",
+            "p": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/Bundle/Bundle_archive-root/ABundle.aplugin",
             "t": "com.apple.product-type.bundle"
         }
     },
@@ -1442,7 +1442,7 @@
                 "\"bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Source/iOSApp.app.dSYM\"",
                 "\"bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.xctest.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.xctest",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.__internal__.__test_bundle.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "iOSAppObjCUnitTests.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -1474,7 +1474,7 @@
             "e": "iOSAppObjCUnitTests",
             "m": "iOSAppObjCUnitTests",
             "n": "iOSAppObjCUnitTests",
-            "p": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.xctest",
+            "p": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.__internal__.__test_bundle_archive-root/iOSAppObjCUnitTests.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         }
     },
@@ -1507,7 +1507,7 @@
                 "\"bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Source/iOSApp.app.dSYM\"",
                 "\"bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/UITests/iOSAppUITests.xctest.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/UITests/iOSAppUITests.xctest",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/UITests/iOSAppUITests.__internal__.__test_bundle.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "iOSAppUITests.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -1542,7 +1542,7 @@
             "e": "iOSAppUITests",
             "m": "iOSAppUITests",
             "n": "iOSAppUITests",
-            "p": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/UITests/iOSAppUITests.xctest",
+            "p": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/UITests/iOSAppUITests.__internal__.__test_bundle_archive-root/iOSAppUITests.xctest",
             "t": "com.apple.product-type.bundle.ui-testing"
         }
     },
@@ -1608,7 +1608,7 @@
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iMessageApp/iMessageAppExtension.appex.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iMessageApp/iMessageAppExtension.appex",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iMessageApp/iMessageAppExtension.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "iMessageAppExtension.appex",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -1647,7 +1647,7 @@
             "e": "iMessageAppExtension",
             "m": "iMessageAppExtension",
             "n": "iMessageAppExtension",
-            "p": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iMessageApp/iMessageAppExtension.appex",
+            "p": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iMessageApp/iMessageAppExtension_archive-root/iMessageAppExtension.appex",
             "t": "com.apple.product-type.app-extension.messages"
         }
     },
@@ -1661,7 +1661,7 @@
         },
         "b": {
             "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iMessageApp/iMessageApp.app",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iMessageApp/iMessageApp.ipa",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "iMessageApp.app",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -1684,7 +1684,7 @@
             "e": "iMessageApp",
             "m": "iMessageApp",
             "n": "iMessageApp",
-            "p": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iMessageApp/iMessageApp.app",
+            "p": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iMessageApp/iMessageApp_archive-root/Payload/iMessageApp.app",
             "t": "com.apple.product-type.application.messages"
         }
     },
@@ -1732,7 +1732,7 @@
                 "\"bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Source/iOSApp.app.dSYM\"",
                 "\"bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.xctest.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.xctest",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.__internal__.__test_bundle.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "iOSAppSwiftUnitTests.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -1776,7 +1776,7 @@
             "e": "iOSAppSwiftUnitTests",
             "m": "iOSAppSwiftUnitTests",
             "n": "iOSAppSwiftUnitTests",
-            "p": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.xctest",
+            "p": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.__internal__.__test_bundle_archive-root/iOSAppSwiftUnitTests.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         }
     },
@@ -1806,7 +1806,7 @@
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/macOSApp/Source/macOSApp.app.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/macOSApp/Source/macOSApp.app",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/macOSApp/Source/macOSApp.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "macOSApp.app",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -1844,7 +1844,7 @@
             "e": "macOSApp",
             "m": "macOSApp",
             "n": "macOSApp",
-            "p": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/macOSApp/Source/macOSApp.app",
+            "p": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/macOSApp/Source/macOSApp_archive-root/Payload/macOSApp.app",
             "t": "com.apple.product-type.application"
         }
     },
@@ -1869,7 +1869,7 @@
                 "\"bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/macOSApp/Source/macOSApp.app.dSYM\"",
                 "\"bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/macOSApp/Test/UITests/macOSAppUITests.xctest.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/macOSApp/Test/UITests/macOSAppUITests.xctest",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/macOSApp/Test/UITests/macOSAppUITests.__internal__.__test_bundle.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "macOSAppUITests.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -1903,7 +1903,7 @@
             "e": "macOSAppUITests",
             "m": "macOSAppUITests",
             "n": "macOSAppUITests",
-            "p": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/macOSApp/Test/UITests/macOSAppUITests.xctest",
+            "p": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/macOSApp/Test/UITests/macOSAppUITests.__internal__.__test_bundle_archive-root/macOSAppUITests.xctest",
             "t": "com.apple.product-type.bundle.ui-testing"
         }
     },
@@ -1930,7 +1930,7 @@
                 "\"bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/tvOSApp/Source/tvOSApp.app.dSYM\"",
                 "\"bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/tvOSApp/Test/UITests/tvOSAppUITests.xctest.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/tvOSApp/Test/UITests/tvOSAppUITests.xctest",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/tvOSApp/Test/UITests/tvOSAppUITests.__internal__.__test_bundle.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "tvOSAppUITests.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -1964,7 +1964,7 @@
             "e": "tvOSAppUITests",
             "m": "tvOSAppUITests",
             "n": "tvOSAppUITests",
-            "p": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/tvOSApp/Test/UITests/tvOSAppUITests.xctest",
+            "p": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/tvOSApp/Test/UITests/tvOSAppUITests.__internal__.__test_bundle_archive-root/tvOSAppUITests.xctest",
             "t": "com.apple.product-type.bundle.ui-testing"
         }
     },
@@ -2003,7 +2003,7 @@
                 "\"bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/tvOSApp/Source/tvOSApp.app.dSYM\"",
                 "\"bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/tvOSApp/Test/UnitTests/tvOSAppUnitTests.xctest.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/tvOSApp/Test/UnitTests/tvOSAppUnitTests.xctest",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/tvOSApp/Test/UnitTests/tvOSAppUnitTests.__internal__.__test_bundle.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "tvOSAppUnitTests.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -2040,7 +2040,7 @@
             "e": "tvOSAppUnitTests",
             "m": "tvOSAppUnitTests",
             "n": "tvOSAppUnitTests",
-            "p": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/tvOSApp/Test/UnitTests/tvOSAppUnitTests.xctest",
+            "p": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/tvOSApp/Test/UnitTests/tvOSAppUnitTests.__internal__.__test_bundle_archive-root/tvOSAppUnitTests.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         }
     },
@@ -2067,7 +2067,7 @@
                 "\"bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/watchOSAppExtension/watchOSAppExtension.appex.dSYM\"",
                 "\"bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/watchOSApp/Test/UITests/watchOSAppUITests.xctest.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/watchOSApp/Test/UITests/watchOSAppUITests.xctest",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/watchOSApp/Test/UITests/watchOSAppUITests.__internal__.__test_bundle.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "watchOSAppUITests.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -2101,7 +2101,7 @@
             "e": "watchOSAppUITests",
             "m": "watchOSAppUITests",
             "n": "watchOSAppUITests",
-            "p": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/watchOSApp/Test/UITests/watchOSAppUITests.xctest",
+            "p": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/watchOSApp/Test/UITests/watchOSAppUITests.__internal__.__test_bundle_archive-root/watchOSAppUITests.xctest",
             "t": "com.apple.product-type.bundle.ui-testing"
         }
     },
@@ -2136,7 +2136,7 @@
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTests.xctest.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTests.xctest",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTests.__internal__.__test_bundle.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "watchOSAppExtensionUnitTests.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -2169,7 +2169,7 @@
             "e": "watchOSAppExtensionUnitTests",
             "m": "watchOSAppExtensionUnitTests",
             "n": "watchOSAppExtensionUnitTests",
-            "p": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTests.xctest",
+            "p": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTests.__internal__.__test_bundle_archive-root/watchOSAppExtensionUnitTests.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         }
     },
@@ -2202,7 +2202,7 @@
                 "\"bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Source/iOSApp.app.dSYM\"",
                 "\"bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/UITests/iOSAppUITestSuite.xctest.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/UITests/iOSAppUITestSuite.xctest",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/UITests/iOSAppUITestSuite.__internal__.__test_bundle.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "iOSAppUITestSuite.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -2237,7 +2237,7 @@
             "e": "iOSAppUITestSuite",
             "m": "iOSAppUITestSuite",
             "n": "iOSAppUITestSuite",
-            "p": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/UITests/iOSAppUITestSuite.xctest",
+            "p": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/UITests/iOSAppUITestSuite.__internal__.__test_bundle_archive-root/iOSAppUITestSuite.xctest",
             "t": "com.apple.product-type.bundle.ui-testing"
         }
     },
@@ -2285,7 +2285,7 @@
                 "\"bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Source/iOSApp.app.dSYM\"",
                 "\"bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTestSuite.xctest.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTestSuite.xctest",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTestSuite.__internal__.__test_bundle.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "iOSAppObjCUnitTestSuite.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -2317,7 +2317,7 @@
             "e": "iOSAppObjCUnitTestSuite",
             "m": "iOSAppObjCUnitTestSuite",
             "n": "iOSAppObjCUnitTestSuite",
-            "p": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTestSuite.xctest",
+            "p": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTestSuite.__internal__.__test_bundle_archive-root/iOSAppObjCUnitTestSuite.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         }
     },
@@ -2365,7 +2365,7 @@
                 "\"bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Source/iOSApp.app.dSYM\"",
                 "\"bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTestSuite.xctest.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTestSuite.xctest",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTestSuite.__internal__.__test_bundle.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "iOSAppSwiftUnitTestSuite.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -2409,7 +2409,7 @@
             "e": "iOSAppSwiftUnitTestSuite",
             "m": "iOSAppSwiftUnitTestSuite",
             "n": "iOSAppSwiftUnitTestSuite",
-            "p": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTestSuite.xctest",
+            "p": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTestSuite.__internal__.__test_bundle_archive-root/iOSAppSwiftUnitTestSuite.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         }
     },
@@ -5325,7 +5325,7 @@
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-45/bin/CommandLine/Tests/CommandLineToolTests.xctest.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-45/bin/CommandLine/Tests/CommandLineToolTests.xctest",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-45/bin/CommandLine/Tests/CommandLineToolTests.__internal__.__test_bundle.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "CommandLineToolTests.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -5359,7 +5359,7 @@
             "e": "CommandLineToolTests",
             "m": "CommandLineToolTests",
             "n": "CommandLineToolTests",
-            "p": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-45/bin/CommandLine/Tests/CommandLineToolTests.xctest",
+            "p": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-45/bin/CommandLine/Tests/CommandLineToolTests.__internal__.__test_bundle_archive-root/CommandLineToolTests.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         }
     },
@@ -5425,7 +5425,7 @@
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/AppClip/AppClip.app.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/AppClip/AppClip.app",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/AppClip/AppClip.ipa",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "AppClip.app",
             "CODE_SIGN_ENTITLEMENTS": "$(BAZEL_OUT)/applebin_ios-ios_arm64-dbg-STABLE-16/bin/AppClip/Entitlements.withbundleid.plist",
             "CODE_SIGN_STYLE": "Automatic",
@@ -5467,7 +5467,7 @@
             "e": "AppClip",
             "m": "AppClip",
             "n": "AppClip",
-            "p": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/AppClip/AppClip.app",
+            "p": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/AppClip/AppClip_archive-root/Payload/AppClip.app",
             "t": "com.apple.product-type.application.on-demand-install-capable"
         }
     },
@@ -5560,7 +5560,7 @@
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/WidgetExtension/WidgetExtension.appex.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/WidgetExtension/WidgetExtension.appex",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/WidgetExtension/WidgetExtension.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "WidgetExtension.appex",
             "CODE_SIGN_STYLE": "Automatic",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -5600,7 +5600,7 @@
             "e": "WidgetExtension",
             "m": "WidgetExtension",
             "n": "WidgetExtension",
-            "p": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/WidgetExtension/WidgetExtension.appex",
+            "p": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/WidgetExtension/WidgetExtension_archive-root/WidgetExtension.appex",
             "t": "com.apple.product-type.app-extension"
         }
     },
@@ -5625,7 +5625,7 @@
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Source/CoreUtilsObjC/CoreUtilsObjC.framework.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Source/CoreUtilsObjC/CoreUtilsObjC.framework",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Source/CoreUtilsObjC/FrameworkCoreUtilsObjC.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "CoreUtilsObjC.framework",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -5657,7 +5657,7 @@
             "e": "CoreUtilsObjC",
             "m": "CoreUtilsObjC",
             "n": "CoreUtilsObjC",
-            "p": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Source/CoreUtilsObjC/CoreUtilsObjC.framework",
+            "p": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Source/CoreUtilsObjC/FrameworkCoreUtilsObjC_archive-root/CoreUtilsObjC.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -5689,7 +5689,7 @@
                 "\"bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/Lib/LibFramework.iOS.framework.dSYM\"",
                 "\"bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/UI/UIFramework.iOS.framework.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/UI/UIFramework.iOS.framework",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/UI/UIFramework.iOS.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "UIFramework.iOS.framework",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -5700,7 +5700,7 @@
             "PREVIEWS_SWIFT_INCLUDE__YES": "-I bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-6/bin/UI",
             "PREVIEW_FRAMEWORK_PATHS": [
                 "\"$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework\"",
-                "\"$(BAZEL_OUT)/applebin_ios-ios_arm64-dbg-STABLE-16/bin/Lib/LibFramework.iOS.framework\""
+                "\"$(BAZEL_OUT)/applebin_ios-ios_arm64-dbg-STABLE-16/bin/Lib/LibFramework.iOS.zip\""
             ],
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.UIFramework",
             "PRODUCT_MODULE_NAME": "UI",
@@ -5731,7 +5731,7 @@
             "e": "UIFramework.iOS",
             "m": "UIFramework.iOS",
             "n": "UIFramework.iOS",
-            "p": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/UI/UIFramework.iOS.framework",
+            "p": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/UI/UIFramework.iOS_archive-root/UIFramework.iOS.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -5790,7 +5790,7 @@
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-20/bin/Lib/LibFramework.watchOS.framework.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-20/bin/Lib/LibFramework.watchOS.framework",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-20/bin/Lib/LibFramework.watchOS.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "LibFramework.watchOS.framework",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -5815,7 +5815,7 @@
             "e": "LibFramework.watchOS",
             "m": "LibFramework.watchOS",
             "n": "LibFramework.watchOS",
-            "p": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-20/bin/Lib/LibFramework.watchOS.framework",
+            "p": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-20/bin/Lib/LibFramework.watchOS_archive-root/LibFramework.watchOS.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -5850,7 +5850,7 @@
                 "\"bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-20/bin/Lib/LibFramework.watchOS.framework.dSYM\"",
                 "\"bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-20/bin/UI/UIFramework.watchOS.framework.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-20/bin/UI/UIFramework.watchOS.framework",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-20/bin/UI/UIFramework.watchOS.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "UIFramework.watchOS.framework",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -5861,7 +5861,7 @@
             "PREVIEWS_SWIFT_INCLUDE__YES": "-I bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-7/bin/UI",
             "PREVIEW_FRAMEWORK_PATHS": [
                 "\"$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k/CryptoSwift.framework\"",
-                "\"$(BAZEL_OUT)/applebin_watchos-watchos_arm64_32-dbg-STABLE-20/bin/Lib/LibFramework.watchOS.framework\""
+                "\"$(BAZEL_OUT)/applebin_watchos-watchos_arm64_32-dbg-STABLE-20/bin/Lib/LibFramework.watchOS.zip\""
             ],
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.UIFramework",
             "PRODUCT_MODULE_NAME": "UI"
@@ -5888,7 +5888,7 @@
             "e": "UIFramework.watchOS",
             "m": "UIFramework.watchOS",
             "n": "UIFramework.watchOS",
-            "p": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-20/bin/UI/UIFramework.watchOS.framework",
+            "p": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-20/bin/UI/UIFramework.watchOS_archive-root/UIFramework.watchOS.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -5922,7 +5922,7 @@
                 "\"bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-20/bin/UI/UIFramework.watchOS.framework.dSYM\"",
                 "\"bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-20/bin/watchOSAppExtension/watchOSAppExtension.appex.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-20/bin/watchOSAppExtension/watchOSAppExtension.appex",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-20/bin/watchOSAppExtension/watchOSAppExtension.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "watchOSAppExtension.appex",
             "CODE_SIGN_STYLE": "Automatic",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -5959,7 +5959,7 @@
             "e": "watchOSAppExtension",
             "m": "watchOSAppExtension",
             "n": "watchOSAppExtension",
-            "p": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-20/bin/watchOSAppExtension/watchOSAppExtension.appex",
+            "p": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-20/bin/watchOSAppExtension/watchOSAppExtension_archive-root/watchOSAppExtension.appex",
             "t": "com.apple.product-type.watchkit2-extension"
         }
     },
@@ -5977,7 +5977,7 @@
         ],
         "b": {
             "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-24/bin/watchOSApp/watchOSApp.app",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-24/bin/watchOSApp/watchOSApp.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "watchOSApp.app",
             "CODE_SIGN_STYLE": "Automatic",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -6003,7 +6003,7 @@
             "e": "watchOSApp",
             "m": "watchOSApp",
             "n": "watchOSApp",
-            "p": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-24/bin/watchOSApp/watchOSApp.app",
+            "p": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-24/bin/watchOSApp/watchOSApp_archive-root/Payload/watchOSApp.app",
             "t": "com.apple.product-type.application.watchapp2"
         }
     },
@@ -6053,7 +6053,7 @@
                 "\"bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-20/bin/watchOSAppExtension/watchOSAppExtension.appex.dSYM\"",
                 "\"bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Source/iOSApp.app.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Source/iOSApp.app",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Source/iOSApp.ipa",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "iOSApp.app",
             "CODE_SIGN_ENTITLEMENTS": "$(SRCROOT)/iOSApp/Source/ios app.entitlements",
             "CODE_SIGN_STYLE": "Automatic",
@@ -6113,7 +6113,7 @@
             "e": "iOSApp",
             "m": "iOSApp",
             "n": "iOSApp",
-            "p": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Source/iOSApp.app",
+            "p": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Source/iOSApp_archive-root/Payload/iOSApp.app",
             "t": "com.apple.product-type.application"
         },
         "w": "@@//watchOSApp:watchOSApp applebin_watchos-watchos_arm64_32-dbg-STABLE-24"
@@ -6134,7 +6134,7 @@
         "6": "bazel-out/darwin_x86_64-dbg-STABLE-0/bin/external/rules_xcodeproj~override~internal~rules_xcodeproj_generated/generator/test/fixtures/xcodeproj_bwb/xcodeproj_bwb-params/iOS.112.link.params",
         "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/Lib/dist/dynamic/Lib.framework",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/Lib/dist/dynamic/iOS.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "Lib.framework",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -6160,7 +6160,7 @@
             "e": "Lib",
             "m": "Lib",
             "n": "Lib",
-            "p": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/Lib/dist/dynamic/Lib.framework",
+            "p": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/Lib/dist/dynamic/iOS_archive-root/Lib.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -6216,7 +6216,7 @@
         "6": "bazel-out/darwin_x86_64-dbg-STABLE-0/bin/external/rules_xcodeproj~override~internal~rules_xcodeproj_generated/generator/test/fixtures/xcodeproj_bwb/xcodeproj_bwb-params/tvOS.114.link.params",
         "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-28/bin/Lib/dist/dynamic/Lib.framework",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-28/bin/Lib/dist/dynamic/tvOS.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "Lib.framework",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -6241,7 +6241,7 @@
             "e": "Lib",
             "m": "Lib",
             "n": "Lib",
-            "p": "bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-28/bin/Lib/dist/dynamic/Lib.framework",
+            "p": "bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-28/bin/Lib/dist/dynamic/tvOS_archive-root/Lib.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -6261,7 +6261,7 @@
         "6": "bazel-out/darwin_x86_64-dbg-STABLE-0/bin/external/rules_xcodeproj~override~internal~rules_xcodeproj_generated/generator/test/fixtures/xcodeproj_bwb/xcodeproj_bwb-params/watchOS.115.link.params",
         "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-20/bin/Lib/dist/dynamic/Lib.framework",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-20/bin/Lib/dist/dynamic/watchOS.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "Lib.framework",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -6286,7 +6286,7 @@
             "e": "Lib",
             "m": "Lib",
             "n": "Lib",
-            "p": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-20/bin/Lib/dist/dynamic/Lib.framework",
+            "p": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-20/bin/Lib/dist/dynamic/watchOS_archive-root/Lib.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -6309,7 +6309,7 @@
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-28/bin/Lib/LibFramework.tvOS.framework.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-28/bin/Lib/LibFramework.tvOS.framework",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-28/bin/Lib/LibFramework.tvOS.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "LibFramework.tvOS.framework",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -6334,7 +6334,7 @@
             "e": "LibFramework.tvOS",
             "m": "LibFramework.tvOS",
             "n": "LibFramework.tvOS",
-            "p": "bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-28/bin/Lib/LibFramework.tvOS.framework",
+            "p": "bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-28/bin/Lib/LibFramework.tvOS_archive-root/LibFramework.tvOS.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -6369,7 +6369,7 @@
                 "\"bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-28/bin/Lib/LibFramework.tvOS.framework.dSYM\"",
                 "\"bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-28/bin/UI/UIFramework.tvOS.framework.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-28/bin/UI/UIFramework.tvOS.framework",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-28/bin/UI/UIFramework.tvOS.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "UIFramework.tvOS.framework",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -6380,7 +6380,7 @@
             "PREVIEWS_SWIFT_INCLUDE__YES": "-I bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-8/bin/UI",
             "PREVIEW_FRAMEWORK_PATHS": [
                 "\"$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64/CryptoSwift.framework\"",
-                "\"$(BAZEL_OUT)/applebin_tvos-tvos_arm64-dbg-STABLE-28/bin/Lib/LibFramework.tvOS.framework\""
+                "\"$(BAZEL_OUT)/applebin_tvos-tvos_arm64-dbg-STABLE-28/bin/Lib/LibFramework.tvOS.zip\""
             ],
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.UIFramework",
             "PRODUCT_MODULE_NAME": "UI"
@@ -6407,7 +6407,7 @@
             "e": "UIFramework.tvOS",
             "m": "UIFramework.tvOS",
             "n": "UIFramework.tvOS",
-            "p": "bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-28/bin/UI/UIFramework.tvOS.framework",
+            "p": "bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-28/bin/UI/UIFramework.tvOS_archive-root/UIFramework.tvOS.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -6444,7 +6444,7 @@
                 "\"bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-28/bin/UI/UIFramework.tvOS.framework.dSYM\"",
                 "\"bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-28/bin/tvOSApp/Source/tvOSApp.app.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-28/bin/tvOSApp/Source/tvOSApp.app",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-28/bin/tvOSApp/Source/tvOSApp.ipa",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "tvOSApp.app",
             "CODE_SIGN_STYLE": "Automatic",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -6482,7 +6482,7 @@
             "e": "tvOSApp",
             "m": "tvOSApp",
             "n": "tvOSApp",
-            "p": "bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-28/bin/tvOSApp/Source/tvOSApp.app",
+            "p": "bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-28/bin/tvOSApp/Source/tvOSApp_archive-root/Payload/tvOSApp.app",
             "t": "com.apple.product-type.application"
         }
     },
@@ -6624,7 +6624,7 @@
                 "\"bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Source/iOSApp.app.dSYM\"",
                 "\"bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.xctest.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.xctest",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.__internal__.__test_bundle.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "iOSAppObjCUnitTests.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -6656,7 +6656,7 @@
             "e": "iOSAppObjCUnitTests",
             "m": "iOSAppObjCUnitTests",
             "n": "iOSAppObjCUnitTests",
-            "p": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.xctest",
+            "p": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.__internal__.__test_bundle_archive-root/iOSAppObjCUnitTests.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         }
     },
@@ -6689,7 +6689,7 @@
                 "\"bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Source/iOSApp.app.dSYM\"",
                 "\"bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Test/UITests/iOSAppUITests.xctest.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Test/UITests/iOSAppUITests.xctest",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Test/UITests/iOSAppUITests.__internal__.__test_bundle.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "iOSAppUITests.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -6724,7 +6724,7 @@
             "e": "iOSAppUITests",
             "m": "iOSAppUITests",
             "n": "iOSAppUITests",
-            "p": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Test/UITests/iOSAppUITests.xctest",
+            "p": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Test/UITests/iOSAppUITests.__internal__.__test_bundle_archive-root/iOSAppUITests.xctest",
             "t": "com.apple.product-type.bundle.ui-testing"
         }
     },
@@ -6772,7 +6772,7 @@
                 "\"bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Source/iOSApp.app.dSYM\"",
                 "\"bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.xctest.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.xctest",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.__internal__.__test_bundle.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "iOSAppSwiftUnitTests.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -6816,7 +6816,7 @@
             "e": "iOSAppSwiftUnitTests",
             "m": "iOSAppSwiftUnitTests",
             "n": "iOSAppSwiftUnitTests",
-            "p": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.xctest",
+            "p": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.__internal__.__test_bundle_archive-root/iOSAppSwiftUnitTests.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         }
     },
@@ -7042,7 +7042,7 @@
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/AppClip/AppClip.app.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/AppClip/AppClip.app",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/AppClip/AppClip.ipa",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "AppClip.app",
             "CODE_SIGN_ENTITLEMENTS": "$(BAZEL_OUT)/applebin_ios-ios_x86_64-opt-STABLE-17/bin/AppClip/Entitlements.withbundleid.plist",
             "CODE_SIGN_STYLE": "Manual",
@@ -7083,7 +7083,7 @@
             "e": "AppClip",
             "m": "AppClip",
             "n": "AppClip",
-            "p": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/AppClip/AppClip.app",
+            "p": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/AppClip/AppClip_archive-root/Payload/AppClip.app",
             "t": "com.apple.product-type.application.on-demand-install-capable"
         },
         "x": [
@@ -7186,7 +7186,7 @@
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/WidgetExtension/WidgetExtension.appex.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/WidgetExtension/WidgetExtension.appex",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/WidgetExtension/WidgetExtension.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "WidgetExtension.appex",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -7226,7 +7226,7 @@
             "e": "WidgetExtension",
             "m": "WidgetExtension",
             "n": "WidgetExtension",
-            "p": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/WidgetExtension/WidgetExtension.appex",
+            "p": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/WidgetExtension/WidgetExtension_archive-root/WidgetExtension.appex",
             "t": "com.apple.product-type.app-extension"
         },
         "x": [
@@ -7254,7 +7254,7 @@
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Source/CoreUtilsObjC/CoreUtilsObjC.framework.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Source/CoreUtilsObjC/CoreUtilsObjC.framework",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Source/CoreUtilsObjC/FrameworkCoreUtilsObjC.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "CoreUtilsObjC.framework",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -7286,7 +7286,7 @@
             "e": "CoreUtilsObjC",
             "m": "CoreUtilsObjC",
             "n": "CoreUtilsObjC",
-            "p": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Source/CoreUtilsObjC/CoreUtilsObjC.framework",
+            "p": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Source/CoreUtilsObjC/FrameworkCoreUtilsObjC_archive-root/CoreUtilsObjC.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -7321,7 +7321,7 @@
                 "\"bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/Lib/LibFramework.iOS.framework.dSYM\"",
                 "\"bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/UI/UIFramework.iOS.framework.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/UI/UIFramework.iOS.framework",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/UI/UIFramework.iOS.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "UIFramework.iOS.framework",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -7332,7 +7332,7 @@
             "PREVIEWS_SWIFT_INCLUDE__YES": "-I bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-9/bin/UI",
             "PREVIEW_FRAMEWORK_PATHS": [
                 "\"$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework\"",
-                "\"$(BAZEL_OUT)/applebin_ios-ios_x86_64-opt-STABLE-17/bin/Lib/LibFramework.iOS.framework\""
+                "\"$(BAZEL_OUT)/applebin_ios-ios_x86_64-opt-STABLE-17/bin/Lib/LibFramework.iOS.zip\""
             ],
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.UIFramework",
             "PRODUCT_MODULE_NAME": "UI",
@@ -7364,7 +7364,7 @@
             "e": "UIFramework.iOS",
             "m": "UIFramework.iOS",
             "n": "UIFramework.iOS",
-            "p": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/UI/UIFramework.iOS.framework",
+            "p": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/UI/UIFramework.iOS_archive-root/UIFramework.iOS.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -7430,7 +7430,7 @@
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/Lib/LibFramework.watchOS.framework.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/Lib/LibFramework.watchOS.framework",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/Lib/LibFramework.watchOS.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "LibFramework.watchOS.framework",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -7455,7 +7455,7 @@
             "e": "LibFramework.watchOS",
             "m": "LibFramework.watchOS",
             "n": "LibFramework.watchOS",
-            "p": "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/Lib/LibFramework.watchOS.framework",
+            "p": "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/Lib/LibFramework.watchOS_archive-root/LibFramework.watchOS.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -7493,7 +7493,7 @@
                 "\"bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/Lib/LibFramework.watchOS.framework.dSYM\"",
                 "\"bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/UI/UIFramework.watchOS.framework.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/UI/UIFramework.watchOS.framework",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/UI/UIFramework.watchOS.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "UIFramework.watchOS.framework",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -7504,7 +7504,7 @@
             "PREVIEWS_SWIFT_INCLUDE__YES": "-I bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-opt-STABLE-10/bin/UI",
             "PREVIEW_FRAMEWORK_PATHS": [
                 "\"$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator/CryptoSwift.framework\"",
-                "\"$(BAZEL_OUT)/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/Lib/LibFramework.watchOS.framework\""
+                "\"$(BAZEL_OUT)/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/Lib/LibFramework.watchOS.zip\""
             ],
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.UIFramework",
             "PRODUCT_MODULE_NAME": "UI",
@@ -7532,7 +7532,7 @@
             "e": "UIFramework.watchOS",
             "m": "UIFramework.watchOS",
             "n": "UIFramework.watchOS",
-            "p": "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/UI/UIFramework.watchOS.framework",
+            "p": "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/UI/UIFramework.watchOS_archive-root/UIFramework.watchOS.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -7569,7 +7569,7 @@
                 "\"bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/UI/UIFramework.watchOS.framework.dSYM\"",
                 "\"bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/watchOSAppExtension/watchOSAppExtension.appex.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/watchOSAppExtension/watchOSAppExtension.appex",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/watchOSAppExtension/watchOSAppExtension.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "watchOSAppExtension.appex",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -7606,7 +7606,7 @@
             "e": "watchOSAppExtension",
             "m": "watchOSAppExtension",
             "n": "watchOSAppExtension",
-            "p": "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/watchOSAppExtension/watchOSAppExtension.appex",
+            "p": "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/watchOSAppExtension/watchOSAppExtension_archive-root/watchOSAppExtension.appex",
             "t": "com.apple.product-type.watchkit2-extension"
         },
         "x": [
@@ -7627,7 +7627,7 @@
         ],
         "b": {
             "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-25/bin/watchOSApp/watchOSApp.app",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-25/bin/watchOSApp/watchOSApp.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "watchOSApp.app",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -7652,7 +7652,7 @@
             "e": "watchOSApp",
             "m": "watchOSApp",
             "n": "watchOSApp",
-            "p": "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-25/bin/watchOSApp/watchOSApp.app",
+            "p": "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-25/bin/watchOSApp/watchOSApp_archive-root/Payload/watchOSApp.app",
             "t": "com.apple.product-type.application.watchapp2"
         },
         "x": [
@@ -7705,7 +7705,7 @@
                 "\"bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/watchOSAppExtension/watchOSAppExtension.appex.dSYM\"",
                 "\"bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Source/iOSApp.app.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Source/iOSApp.app",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Source/iOSApp.ipa",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "iOSApp.app",
             "CODE_SIGN_ENTITLEMENTS": "$(SRCROOT)/iOSApp/Source/ios app.entitlements",
             "CODE_SIGN_STYLE": "Manual",
@@ -7760,7 +7760,7 @@
             "e": "iOSApp_ExecutableName",
             "m": "iOSApp",
             "n": "iOSApp",
-            "p": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Source/iOSApp.app",
+            "p": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Source/iOSApp_archive-root/Payload/iOSApp.app",
             "t": "com.apple.product-type.application"
         },
         "w": "@@//watchOSApp:watchOSApp applebin_watchos-watchos_x86_64-opt-STABLE-25",
@@ -7784,7 +7784,7 @@
         "6": "bazel-out/darwin_x86_64-dbg-STABLE-0/bin/external/rules_xcodeproj~override~internal~rules_xcodeproj_generated/generator/test/fixtures/xcodeproj_bwb/xcodeproj_bwb-params/iOS.143.link.params",
         "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/Lib/dist/dynamic/Lib.framework",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/Lib/dist/dynamic/iOS.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "Lib.framework",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -7810,7 +7810,7 @@
             "e": "Lib",
             "m": "Lib",
             "n": "Lib",
-            "p": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/Lib/dist/dynamic/Lib.framework",
+            "p": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/Lib/dist/dynamic/iOS_archive-root/Lib.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -7873,7 +7873,7 @@
         "6": "bazel-out/darwin_x86_64-dbg-STABLE-0/bin/external/rules_xcodeproj~override~internal~rules_xcodeproj_generated/generator/test/fixtures/xcodeproj_bwb/xcodeproj_bwb-params/tvOS.145.link.params",
         "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/Lib/dist/dynamic/Lib.framework",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/Lib/dist/dynamic/tvOS.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "Lib.framework",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -7898,7 +7898,7 @@
             "e": "Lib",
             "m": "Lib",
             "n": "Lib",
-            "p": "bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/Lib/dist/dynamic/Lib.framework",
+            "p": "bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/Lib/dist/dynamic/tvOS_archive-root/Lib.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -7921,7 +7921,7 @@
         "6": "bazel-out/darwin_x86_64-dbg-STABLE-0/bin/external/rules_xcodeproj~override~internal~rules_xcodeproj_generated/generator/test/fixtures/xcodeproj_bwb/xcodeproj_bwb-params/watchOS.146.link.params",
         "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/Lib/dist/dynamic/Lib.framework",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/Lib/dist/dynamic/watchOS.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "Lib.framework",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -7946,7 +7946,7 @@
             "e": "Lib",
             "m": "Lib",
             "n": "Lib",
-            "p": "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/Lib/dist/dynamic/Lib.framework",
+            "p": "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/Lib/dist/dynamic/watchOS_archive-root/Lib.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -7972,7 +7972,7 @@
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/Lib/LibFramework.tvOS.framework.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/Lib/LibFramework.tvOS.framework",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/Lib/LibFramework.tvOS.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "LibFramework.tvOS.framework",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -7997,7 +7997,7 @@
             "e": "LibFramework.tvOS",
             "m": "LibFramework.tvOS",
             "n": "LibFramework.tvOS",
-            "p": "bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/Lib/LibFramework.tvOS.framework",
+            "p": "bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/Lib/LibFramework.tvOS_archive-root/LibFramework.tvOS.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -8035,7 +8035,7 @@
                 "\"bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/Lib/LibFramework.tvOS.framework.dSYM\"",
                 "\"bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/UI/UIFramework.tvOS.framework.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/UI/UIFramework.tvOS.framework",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/UI/UIFramework.tvOS.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "UIFramework.tvOS.framework",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -8046,7 +8046,7 @@
             "PREVIEWS_SWIFT_INCLUDE__YES": "-I bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-opt-STABLE-11/bin/UI",
             "PREVIEW_FRAMEWORK_PATHS": [
                 "\"$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator/CryptoSwift.framework\"",
-                "\"$(BAZEL_OUT)/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/Lib/LibFramework.tvOS.framework\""
+                "\"$(BAZEL_OUT)/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/Lib/LibFramework.tvOS.zip\""
             ],
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.UIFramework",
             "PRODUCT_MODULE_NAME": "UI",
@@ -8074,7 +8074,7 @@
             "e": "UIFramework.tvOS",
             "m": "UIFramework.tvOS",
             "n": "UIFramework.tvOS",
-            "p": "bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/UI/UIFramework.tvOS.framework",
+            "p": "bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/UI/UIFramework.tvOS_archive-root/UIFramework.tvOS.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -8114,7 +8114,7 @@
                 "\"bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/UI/UIFramework.tvOS.framework.dSYM\"",
                 "\"bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/tvOSApp/Source/tvOSApp.app.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/tvOSApp/Source/tvOSApp.app",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/tvOSApp/Source/tvOSApp.ipa",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "tvOSApp.app",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -8151,7 +8151,7 @@
             "e": "tvOSApp",
             "m": "tvOSApp",
             "n": "tvOSApp",
-            "p": "bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/tvOSApp/Source/tvOSApp.app",
+            "p": "bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/tvOSApp/Source/tvOSApp_archive-root/Payload/tvOSApp.app",
             "t": "com.apple.product-type.application"
         },
         "x": [
@@ -8178,7 +8178,7 @@
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-34/bin/Bundle/ABundle.aplugin.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-34/bin/Bundle/ABundle.aplugin",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-34/bin/Bundle/Bundle.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "ABundle.aplugin",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -8201,7 +8201,7 @@
             "e": "ABundle",
             "m": "ABundle",
             "n": "ABundle",
-            "p": "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-34/bin/Bundle/ABundle.aplugin",
+            "p": "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-34/bin/Bundle/Bundle_archive-root/ABundle.aplugin",
             "t": "com.apple.product-type.bundle"
         },
         "x": [
@@ -8356,7 +8356,7 @@
                 "\"bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Source/iOSApp.app.dSYM\"",
                 "\"bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.xctest.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.xctest",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.__internal__.__test_bundle.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "iOSAppObjCUnitTests.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -8388,7 +8388,7 @@
             "e": "iOSAppObjCUnitTests",
             "m": "iOSAppObjCUnitTests",
             "n": "iOSAppObjCUnitTests",
-            "p": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.xctest",
+            "p": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.__internal__.__test_bundle_archive-root/iOSAppObjCUnitTests.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         },
         "x": [
@@ -8424,7 +8424,7 @@
                 "\"bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Source/iOSApp.app.dSYM\"",
                 "\"bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/UITests/iOSAppUITests.xctest.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/UITests/iOSAppUITests.xctest",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/UITests/iOSAppUITests.__internal__.__test_bundle.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "iOSAppUITests.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -8460,7 +8460,7 @@
             "e": "iOSAppUITests",
             "m": "iOSAppUITests",
             "n": "iOSAppUITests",
-            "p": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/UITests/iOSAppUITests.xctest",
+            "p": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/UITests/iOSAppUITests.__internal__.__test_bundle_archive-root/iOSAppUITests.xctest",
             "t": "com.apple.product-type.bundle.ui-testing"
         },
         "x": [
@@ -8533,7 +8533,7 @@
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iMessageApp/iMessageAppExtension.appex.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iMessageApp/iMessageAppExtension.appex",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iMessageApp/iMessageAppExtension.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "iMessageAppExtension.appex",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -8573,7 +8573,7 @@
             "e": "iMessageAppExtension",
             "m": "iMessageAppExtension",
             "n": "iMessageAppExtension",
-            "p": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iMessageApp/iMessageAppExtension.appex",
+            "p": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iMessageApp/iMessageAppExtension_archive-root/iMessageAppExtension.appex",
             "t": "com.apple.product-type.app-extension.messages"
         },
         "x": [
@@ -8590,7 +8590,7 @@
         },
         "b": {
             "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iMessageApp/iMessageApp.app",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iMessageApp/iMessageApp.ipa",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "iMessageApp.app",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -8613,7 +8613,7 @@
             "e": "iMessageApp",
             "m": "iMessageApp",
             "n": "iMessageApp",
-            "p": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iMessageApp/iMessageApp.app",
+            "p": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iMessageApp/iMessageApp_archive-root/Payload/iMessageApp.app",
             "t": "com.apple.product-type.application.messages"
         },
         "x": [
@@ -8664,7 +8664,7 @@
                 "\"bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Source/iOSApp.app.dSYM\"",
                 "\"bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.xctest.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.xctest",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.__internal__.__test_bundle.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "iOSAppSwiftUnitTests.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -8709,7 +8709,7 @@
             "e": "iOSAppSwiftUnitTests",
             "m": "iOSAppSwiftUnitTests",
             "n": "iOSAppSwiftUnitTests",
-            "p": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.xctest",
+            "p": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.__internal__.__test_bundle_archive-root/iOSAppSwiftUnitTests.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         },
         "x": [
@@ -8742,7 +8742,7 @@
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-34/bin/macOSApp/Source/macOSApp.app.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-34/bin/macOSApp/Source/macOSApp.app",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-34/bin/macOSApp/Source/macOSApp.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "macOSApp.app",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -8780,7 +8780,7 @@
             "e": "macOSApp",
             "m": "macOSApp",
             "n": "macOSApp",
-            "p": "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-34/bin/macOSApp/Source/macOSApp.app",
+            "p": "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-34/bin/macOSApp/Source/macOSApp_archive-root/Payload/macOSApp.app",
             "t": "com.apple.product-type.application"
         },
         "x": [
@@ -8808,7 +8808,7 @@
                 "\"bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-34/bin/macOSApp/Source/macOSApp.app.dSYM\"",
                 "\"bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-34/bin/macOSApp/Test/UITests/macOSAppUITests.xctest.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-34/bin/macOSApp/Test/UITests/macOSAppUITests.xctest",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-34/bin/macOSApp/Test/UITests/macOSAppUITests.__internal__.__test_bundle.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "macOSAppUITests.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -8843,7 +8843,7 @@
             "e": "macOSAppUITests",
             "m": "macOSAppUITests",
             "n": "macOSAppUITests",
-            "p": "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-34/bin/macOSApp/Test/UITests/macOSAppUITests.xctest",
+            "p": "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-34/bin/macOSApp/Test/UITests/macOSAppUITests.__internal__.__test_bundle_archive-root/macOSAppUITests.xctest",
             "t": "com.apple.product-type.bundle.ui-testing"
         },
         "x": [
@@ -8873,7 +8873,7 @@
                 "\"bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/tvOSApp/Source/tvOSApp.app.dSYM\"",
                 "\"bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/tvOSApp/Test/UITests/tvOSAppUITests.xctest.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/tvOSApp/Test/UITests/tvOSAppUITests.xctest",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/tvOSApp/Test/UITests/tvOSAppUITests.__internal__.__test_bundle.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "tvOSAppUITests.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -8908,7 +8908,7 @@
             "e": "tvOSAppUITests",
             "m": "tvOSAppUITests",
             "n": "tvOSAppUITests",
-            "p": "bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/tvOSApp/Test/UITests/tvOSAppUITests.xctest",
+            "p": "bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/tvOSApp/Test/UITests/tvOSAppUITests.__internal__.__test_bundle_archive-root/tvOSAppUITests.xctest",
             "t": "com.apple.product-type.bundle.ui-testing"
         },
         "x": [
@@ -8950,7 +8950,7 @@
                 "\"bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/tvOSApp/Source/tvOSApp.app.dSYM\"",
                 "\"bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/tvOSApp/Test/UnitTests/tvOSAppUnitTests.xctest.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/tvOSApp/Test/UnitTests/tvOSAppUnitTests.xctest",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/tvOSApp/Test/UnitTests/tvOSAppUnitTests.__internal__.__test_bundle.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "tvOSAppUnitTests.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -8988,7 +8988,7 @@
             "e": "tvOSAppUnitTests",
             "m": "tvOSAppUnitTests",
             "n": "tvOSAppUnitTests",
-            "p": "bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/tvOSApp/Test/UnitTests/tvOSAppUnitTests.xctest",
+            "p": "bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/tvOSApp/Test/UnitTests/tvOSAppUnitTests.__internal__.__test_bundle_archive-root/tvOSAppUnitTests.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         },
         "x": [
@@ -9018,7 +9018,7 @@
                 "\"bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/watchOSAppExtension/watchOSAppExtension.appex.dSYM\"",
                 "\"bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/watchOSApp/Test/UITests/watchOSAppUITests.xctest.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/watchOSApp/Test/UITests/watchOSAppUITests.xctest",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/watchOSApp/Test/UITests/watchOSAppUITests.__internal__.__test_bundle.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "watchOSAppUITests.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -9053,7 +9053,7 @@
             "e": "watchOSAppUITests",
             "m": "watchOSAppUITests",
             "n": "watchOSAppUITests",
-            "p": "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/watchOSApp/Test/UITests/watchOSAppUITests.xctest",
+            "p": "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/watchOSApp/Test/UITests/watchOSAppUITests.__internal__.__test_bundle_archive-root/watchOSAppUITests.xctest",
             "t": "com.apple.product-type.bundle.ui-testing"
         },
         "x": [
@@ -9091,7 +9091,7 @@
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTests.xctest.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTests.xctest",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTests.__internal__.__test_bundle.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "watchOSAppExtensionUnitTests.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -9125,7 +9125,7 @@
             "e": "watchOSAppExtensionUnitTests",
             "m": "watchOSAppExtensionUnitTests",
             "n": "watchOSAppExtensionUnitTests",
-            "p": "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTests.xctest",
+            "p": "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTests.__internal__.__test_bundle_archive-root/watchOSAppExtensionUnitTests.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         },
         "x": [
@@ -9161,7 +9161,7 @@
                 "\"bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Source/iOSApp.app.dSYM\"",
                 "\"bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/UITests/iOSAppUITestSuite.xctest.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/UITests/iOSAppUITestSuite.xctest",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/UITests/iOSAppUITestSuite.__internal__.__test_bundle.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "iOSAppUITestSuite.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -9197,7 +9197,7 @@
             "e": "iOSAppUITestSuite",
             "m": "iOSAppUITestSuite",
             "n": "iOSAppUITestSuite",
-            "p": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/UITests/iOSAppUITestSuite.xctest",
+            "p": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/UITests/iOSAppUITestSuite.__internal__.__test_bundle_archive-root/iOSAppUITestSuite.xctest",
             "t": "com.apple.product-type.bundle.ui-testing"
         },
         "x": [
@@ -9248,7 +9248,7 @@
                 "\"bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Source/iOSApp.app.dSYM\"",
                 "\"bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTestSuite.xctest.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTestSuite.xctest",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTestSuite.__internal__.__test_bundle.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "iOSAppObjCUnitTestSuite.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -9280,7 +9280,7 @@
             "e": "iOSAppObjCUnitTestSuite",
             "m": "iOSAppObjCUnitTestSuite",
             "n": "iOSAppObjCUnitTestSuite",
-            "p": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTestSuite.xctest",
+            "p": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTestSuite.__internal__.__test_bundle_archive-root/iOSAppObjCUnitTestSuite.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         },
         "x": [
@@ -9331,7 +9331,7 @@
                 "\"bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Source/iOSApp.app.dSYM\"",
                 "\"bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTestSuite.xctest.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTestSuite.xctest",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTestSuite.__internal__.__test_bundle.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "iOSAppSwiftUnitTestSuite.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -9376,7 +9376,7 @@
             "e": "iOSAppSwiftUnitTestSuite",
             "m": "iOSAppSwiftUnitTestSuite",
             "n": "iOSAppSwiftUnitTestSuite",
-            "p": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTestSuite.xctest",
+            "p": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTestSuite.__internal__.__test_bundle_archive-root/iOSAppSwiftUnitTestSuite.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         },
         "x": [
@@ -12488,7 +12488,7 @@
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-46/bin/CommandLine/Tests/CommandLineToolTests.xctest.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-46/bin/CommandLine/Tests/CommandLineToolTests.xctest",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-46/bin/CommandLine/Tests/CommandLineToolTests.__internal__.__test_bundle.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "CommandLineToolTests.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -12523,7 +12523,7 @@
             "e": "CommandLineToolTests",
             "m": "CommandLineToolTests",
             "n": "CommandLineToolTests",
-            "p": "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-46/bin/CommandLine/Tests/CommandLineToolTests.xctest",
+            "p": "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-46/bin/CommandLine/Tests/CommandLineToolTests.__internal__.__test_bundle_archive-root/CommandLineToolTests.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         },
         "x": [
@@ -12596,7 +12596,7 @@
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/AppClip/AppClip.app.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/AppClip/AppClip.app",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/AppClip/AppClip.ipa",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "AppClip.app",
             "CODE_SIGN_ENTITLEMENTS": "$(BAZEL_OUT)/applebin_ios-ios_arm64-opt-STABLE-18/bin/AppClip/Entitlements.withbundleid.plist",
             "CODE_SIGN_STYLE": "Automatic",
@@ -12638,7 +12638,7 @@
             "e": "AppClip",
             "m": "AppClip",
             "n": "AppClip",
-            "p": "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/AppClip/AppClip.app",
+            "p": "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/AppClip/AppClip_archive-root/Payload/AppClip.app",
             "t": "com.apple.product-type.application.on-demand-install-capable"
         },
         "x": [
@@ -12741,7 +12741,7 @@
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/WidgetExtension/WidgetExtension.appex.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/WidgetExtension/WidgetExtension.appex",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/WidgetExtension/WidgetExtension.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "WidgetExtension.appex",
             "CODE_SIGN_STYLE": "Automatic",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -12782,7 +12782,7 @@
             "e": "WidgetExtension",
             "m": "WidgetExtension",
             "n": "WidgetExtension",
-            "p": "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/WidgetExtension/WidgetExtension.appex",
+            "p": "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/WidgetExtension/WidgetExtension_archive-root/WidgetExtension.appex",
             "t": "com.apple.product-type.app-extension"
         },
         "x": [
@@ -12810,7 +12810,7 @@
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Source/CoreUtilsObjC/CoreUtilsObjC.framework.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Source/CoreUtilsObjC/CoreUtilsObjC.framework",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Source/CoreUtilsObjC/FrameworkCoreUtilsObjC.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "CoreUtilsObjC.framework",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -12842,7 +12842,7 @@
             "e": "CoreUtilsObjC",
             "m": "CoreUtilsObjC",
             "n": "CoreUtilsObjC",
-            "p": "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Source/CoreUtilsObjC/CoreUtilsObjC.framework",
+            "p": "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Source/CoreUtilsObjC/FrameworkCoreUtilsObjC_archive-root/CoreUtilsObjC.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -12877,7 +12877,7 @@
                 "\"bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/Lib/LibFramework.iOS.framework.dSYM\"",
                 "\"bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/UI/UIFramework.iOS.framework.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/UI/UIFramework.iOS.framework",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/UI/UIFramework.iOS.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "UIFramework.iOS.framework",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -12888,7 +12888,7 @@
             "PREVIEWS_SWIFT_INCLUDE__YES": "-I bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-12/bin/UI",
             "PREVIEW_FRAMEWORK_PATHS": [
                 "\"$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework\"",
-                "\"$(BAZEL_OUT)/applebin_ios-ios_arm64-opt-STABLE-18/bin/Lib/LibFramework.iOS.framework\""
+                "\"$(BAZEL_OUT)/applebin_ios-ios_arm64-opt-STABLE-18/bin/Lib/LibFramework.iOS.zip\""
             ],
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.UIFramework",
             "PRODUCT_MODULE_NAME": "UI",
@@ -12920,7 +12920,7 @@
             "e": "UIFramework.iOS",
             "m": "UIFramework.iOS",
             "n": "UIFramework.iOS",
-            "p": "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/UI/UIFramework.iOS.framework",
+            "p": "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/UI/UIFramework.iOS_archive-root/UIFramework.iOS.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -12986,7 +12986,7 @@
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-22/bin/Lib/LibFramework.watchOS.framework.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-22/bin/Lib/LibFramework.watchOS.framework",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-22/bin/Lib/LibFramework.watchOS.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "LibFramework.watchOS.framework",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -13011,7 +13011,7 @@
             "e": "LibFramework.watchOS",
             "m": "LibFramework.watchOS",
             "n": "LibFramework.watchOS",
-            "p": "bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-22/bin/Lib/LibFramework.watchOS.framework",
+            "p": "bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-22/bin/Lib/LibFramework.watchOS_archive-root/LibFramework.watchOS.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -13049,7 +13049,7 @@
                 "\"bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-22/bin/Lib/LibFramework.watchOS.framework.dSYM\"",
                 "\"bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-22/bin/UI/UIFramework.watchOS.framework.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-22/bin/UI/UIFramework.watchOS.framework",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-22/bin/UI/UIFramework.watchOS.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "UIFramework.watchOS.framework",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -13060,7 +13060,7 @@
             "PREVIEWS_SWIFT_INCLUDE__YES": "-I bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-opt-STABLE-13/bin/UI",
             "PREVIEW_FRAMEWORK_PATHS": [
                 "\"$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k/CryptoSwift.framework\"",
-                "\"$(BAZEL_OUT)/applebin_watchos-watchos_arm64_32-opt-STABLE-22/bin/Lib/LibFramework.watchOS.framework\""
+                "\"$(BAZEL_OUT)/applebin_watchos-watchos_arm64_32-opt-STABLE-22/bin/Lib/LibFramework.watchOS.zip\""
             ],
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.UIFramework",
             "PRODUCT_MODULE_NAME": "UI",
@@ -13088,7 +13088,7 @@
             "e": "UIFramework.watchOS",
             "m": "UIFramework.watchOS",
             "n": "UIFramework.watchOS",
-            "p": "bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-22/bin/UI/UIFramework.watchOS.framework",
+            "p": "bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-22/bin/UI/UIFramework.watchOS_archive-root/UIFramework.watchOS.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -13125,7 +13125,7 @@
                 "\"bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-22/bin/UI/UIFramework.watchOS.framework.dSYM\"",
                 "\"bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-22/bin/watchOSAppExtension/watchOSAppExtension.appex.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-22/bin/watchOSAppExtension/watchOSAppExtension.appex",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-22/bin/watchOSAppExtension/watchOSAppExtension.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "watchOSAppExtension.appex",
             "CODE_SIGN_STYLE": "Automatic",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -13163,7 +13163,7 @@
             "e": "watchOSAppExtension",
             "m": "watchOSAppExtension",
             "n": "watchOSAppExtension",
-            "p": "bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-22/bin/watchOSAppExtension/watchOSAppExtension.appex",
+            "p": "bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-22/bin/watchOSAppExtension/watchOSAppExtension_archive-root/watchOSAppExtension.appex",
             "t": "com.apple.product-type.watchkit2-extension"
         },
         "x": [
@@ -13184,7 +13184,7 @@
         ],
         "b": {
             "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-26/bin/watchOSApp/watchOSApp.app",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-26/bin/watchOSApp/watchOSApp.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "watchOSApp.app",
             "CODE_SIGN_STYLE": "Automatic",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -13210,7 +13210,7 @@
             "e": "watchOSApp",
             "m": "watchOSApp",
             "n": "watchOSApp",
-            "p": "bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-26/bin/watchOSApp/watchOSApp.app",
+            "p": "bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-26/bin/watchOSApp/watchOSApp_archive-root/Payload/watchOSApp.app",
             "t": "com.apple.product-type.application.watchapp2"
         },
         "x": [
@@ -13263,7 +13263,7 @@
                 "\"bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-22/bin/watchOSAppExtension/watchOSAppExtension.appex.dSYM\"",
                 "\"bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Source/iOSApp.app.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Source/iOSApp.app",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Source/iOSApp.ipa",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "iOSApp.app",
             "CODE_SIGN_ENTITLEMENTS": "$(SRCROOT)/iOSApp/Source/ios app.entitlements",
             "CODE_SIGN_STYLE": "Automatic",
@@ -13319,7 +13319,7 @@
             "e": "iOSApp",
             "m": "iOSApp",
             "n": "iOSApp",
-            "p": "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Source/iOSApp.app",
+            "p": "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Source/iOSApp_archive-root/Payload/iOSApp.app",
             "t": "com.apple.product-type.application"
         },
         "w": "@@//watchOSApp:watchOSApp applebin_watchos-watchos_arm64_32-opt-STABLE-26",
@@ -13343,7 +13343,7 @@
         "6": "bazel-out/darwin_x86_64-dbg-STABLE-0/bin/external/rules_xcodeproj~override~internal~rules_xcodeproj_generated/generator/test/fixtures/xcodeproj_bwb/xcodeproj_bwb-params/iOS.237.link.params",
         "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/Lib/dist/dynamic/Lib.framework",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/Lib/dist/dynamic/iOS.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "Lib.framework",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -13369,7 +13369,7 @@
             "e": "Lib",
             "m": "Lib",
             "n": "Lib",
-            "p": "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/Lib/dist/dynamic/Lib.framework",
+            "p": "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/Lib/dist/dynamic/iOS_archive-root/Lib.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -13432,7 +13432,7 @@
         "6": "bazel-out/darwin_x86_64-dbg-STABLE-0/bin/external/rules_xcodeproj~override~internal~rules_xcodeproj_generated/generator/test/fixtures/xcodeproj_bwb/xcodeproj_bwb-params/tvOS.239.link.params",
         "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_tvos-tvos_arm64-opt-STABLE-30/bin/Lib/dist/dynamic/Lib.framework",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_tvos-tvos_arm64-opt-STABLE-30/bin/Lib/dist/dynamic/tvOS.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "Lib.framework",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -13457,7 +13457,7 @@
             "e": "Lib",
             "m": "Lib",
             "n": "Lib",
-            "p": "bazel-out/applebin_tvos-tvos_arm64-opt-STABLE-30/bin/Lib/dist/dynamic/Lib.framework",
+            "p": "bazel-out/applebin_tvos-tvos_arm64-opt-STABLE-30/bin/Lib/dist/dynamic/tvOS_archive-root/Lib.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -13480,7 +13480,7 @@
         "6": "bazel-out/darwin_x86_64-dbg-STABLE-0/bin/external/rules_xcodeproj~override~internal~rules_xcodeproj_generated/generator/test/fixtures/xcodeproj_bwb/xcodeproj_bwb-params/watchOS.240.link.params",
         "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-22/bin/Lib/dist/dynamic/Lib.framework",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-22/bin/Lib/dist/dynamic/watchOS.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "Lib.framework",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -13505,7 +13505,7 @@
             "e": "Lib",
             "m": "Lib",
             "n": "Lib",
-            "p": "bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-22/bin/Lib/dist/dynamic/Lib.framework",
+            "p": "bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-22/bin/Lib/dist/dynamic/watchOS_archive-root/Lib.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -13531,7 +13531,7 @@
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/applebin_tvos-tvos_arm64-opt-STABLE-30/bin/Lib/LibFramework.tvOS.framework.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_tvos-tvos_arm64-opt-STABLE-30/bin/Lib/LibFramework.tvOS.framework",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_tvos-tvos_arm64-opt-STABLE-30/bin/Lib/LibFramework.tvOS.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "LibFramework.tvOS.framework",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -13556,7 +13556,7 @@
             "e": "LibFramework.tvOS",
             "m": "LibFramework.tvOS",
             "n": "LibFramework.tvOS",
-            "p": "bazel-out/applebin_tvos-tvos_arm64-opt-STABLE-30/bin/Lib/LibFramework.tvOS.framework",
+            "p": "bazel-out/applebin_tvos-tvos_arm64-opt-STABLE-30/bin/Lib/LibFramework.tvOS_archive-root/LibFramework.tvOS.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -13594,7 +13594,7 @@
                 "\"bazel-out/applebin_tvos-tvos_arm64-opt-STABLE-30/bin/Lib/LibFramework.tvOS.framework.dSYM\"",
                 "\"bazel-out/applebin_tvos-tvos_arm64-opt-STABLE-30/bin/UI/UIFramework.tvOS.framework.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_tvos-tvos_arm64-opt-STABLE-30/bin/UI/UIFramework.tvOS.framework",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_tvos-tvos_arm64-opt-STABLE-30/bin/UI/UIFramework.tvOS.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "UIFramework.tvOS.framework",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -13605,7 +13605,7 @@
             "PREVIEWS_SWIFT_INCLUDE__YES": "-I bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-opt-STABLE-14/bin/UI",
             "PREVIEW_FRAMEWORK_PATHS": [
                 "\"$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64/CryptoSwift.framework\"",
-                "\"$(BAZEL_OUT)/applebin_tvos-tvos_arm64-opt-STABLE-30/bin/Lib/LibFramework.tvOS.framework\""
+                "\"$(BAZEL_OUT)/applebin_tvos-tvos_arm64-opt-STABLE-30/bin/Lib/LibFramework.tvOS.zip\""
             ],
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.UIFramework",
             "PRODUCT_MODULE_NAME": "UI",
@@ -13633,7 +13633,7 @@
             "e": "UIFramework.tvOS",
             "m": "UIFramework.tvOS",
             "n": "UIFramework.tvOS",
-            "p": "bazel-out/applebin_tvos-tvos_arm64-opt-STABLE-30/bin/UI/UIFramework.tvOS.framework",
+            "p": "bazel-out/applebin_tvos-tvos_arm64-opt-STABLE-30/bin/UI/UIFramework.tvOS_archive-root/UIFramework.tvOS.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -13673,7 +13673,7 @@
                 "\"bazel-out/applebin_tvos-tvos_arm64-opt-STABLE-30/bin/UI/UIFramework.tvOS.framework.dSYM\"",
                 "\"bazel-out/applebin_tvos-tvos_arm64-opt-STABLE-30/bin/tvOSApp/Source/tvOSApp.app.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_tvos-tvos_arm64-opt-STABLE-30/bin/tvOSApp/Source/tvOSApp.app",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_tvos-tvos_arm64-opt-STABLE-30/bin/tvOSApp/Source/tvOSApp.ipa",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "tvOSApp.app",
             "CODE_SIGN_STYLE": "Automatic",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -13711,7 +13711,7 @@
             "e": "tvOSApp",
             "m": "tvOSApp",
             "n": "tvOSApp",
-            "p": "bazel-out/applebin_tvos-tvos_arm64-opt-STABLE-30/bin/tvOSApp/Source/tvOSApp.app",
+            "p": "bazel-out/applebin_tvos-tvos_arm64-opt-STABLE-30/bin/tvOSApp/Source/tvOSApp_archive-root/Payload/tvOSApp.app",
             "t": "com.apple.product-type.application"
         },
         "x": [
@@ -13866,7 +13866,7 @@
                 "\"bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Source/iOSApp.app.dSYM\"",
                 "\"bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.xctest.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.xctest",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.__internal__.__test_bundle.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "iOSAppObjCUnitTests.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -13898,7 +13898,7 @@
             "e": "iOSAppObjCUnitTests",
             "m": "iOSAppObjCUnitTests",
             "n": "iOSAppObjCUnitTests",
-            "p": "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.xctest",
+            "p": "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.__internal__.__test_bundle_archive-root/iOSAppObjCUnitTests.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         },
         "x": [
@@ -13934,7 +13934,7 @@
                 "\"bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Source/iOSApp.app.dSYM\"",
                 "\"bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Test/UITests/iOSAppUITests.xctest.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Test/UITests/iOSAppUITests.xctest",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Test/UITests/iOSAppUITests.__internal__.__test_bundle.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "iOSAppUITests.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -13970,7 +13970,7 @@
             "e": "iOSAppUITests",
             "m": "iOSAppUITests",
             "n": "iOSAppUITests",
-            "p": "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Test/UITests/iOSAppUITests.xctest",
+            "p": "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Test/UITests/iOSAppUITests.__internal__.__test_bundle_archive-root/iOSAppUITests.xctest",
             "t": "com.apple.product-type.bundle.ui-testing"
         },
         "x": [
@@ -14021,7 +14021,7 @@
                 "\"bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Source/iOSApp.app.dSYM\"",
                 "\"bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.xctest.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.xctest",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.__internal__.__test_bundle.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "iOSAppSwiftUnitTests.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
@@ -14066,7 +14066,7 @@
             "e": "iOSAppSwiftUnitTests",
             "m": "iOSAppSwiftUnitTests",
             "n": "iOSAppSwiftUnitTests",
-            "p": "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.xctest",
+            "p": "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.__internal__.__test_bundle_archive-root/iOSAppSwiftUnitTests.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         },
         "x": [

--- a/examples/integration/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -24319,8 +24319,8 @@
 				"OTHER_SWIFT_FLAGS[sdk=iphoneos*]" = "-Xcc -ivfsoverlay -Xcc $(DERIVED_FILE_DIR)/xcode-overlay.yaml -Xcc -ivfsoverlay -Xcc $(OBJROOT)/bazel-out-overlay.yaml -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml $(PREVIEWS_SWIFT_INCLUDE__$(ENABLE_PREVIEWS)) @$(DERIVED_FILE_DIR)/swift.compile.params -F$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7 -Xcc -F -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7 -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-12/bin/external/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(PROJECT_DIR) -Xcc -iquote -Xcc $(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-12/bin -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework/Modules/module.modulemap -Xcc -Os -Xcc -DNDEBUG=1 -Xcc -Wno-unused-variable -Xcc -Winit-self -Xcc -Wno-extra";
 				PREVIEWS_SWIFT_INCLUDE__ = "";
 				PREVIEWS_SWIFT_INCLUDE__NO = "";
-				PREVIEWS_SWIFT_INCLUDE__YES = "-I $(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/UI/UIFramework.iOS.framework/Modules";
-				"PREVIEWS_SWIFT_INCLUDE__YES[sdk=iphoneos*]" = "-I $(BUILD_DIR)/bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/UI/UIFramework.iOS.framework/Modules";
+				PREVIEWS_SWIFT_INCLUDE__YES = "-I $(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/UI/UIFramework.iOS.zip/Modules";
+				"PREVIEWS_SWIFT_INCLUDE__YES[sdk=iphoneos*]" = "-I $(BUILD_DIR)/bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/UI/UIFramework.iOS.zip/Modules";
 				PRODUCT_BUNDLE_IDENTIFIER = "rules-xcodeproj.UIFramework";
 				PRODUCT_MODULE_NAME = UI;
 				PRODUCT_NAME = UIFramework.iOS;
@@ -24501,8 +24501,8 @@
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-9/bin/Lib $(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/UI/UIFramework.iOS.framework/Modules $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-9/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer";
-				"SWIFT_INCLUDE_PATHS[sdk=iphoneos*]" = "$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-12/bin/Lib $(BUILD_DIR)/bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/UI/UIFramework.iOS.framework/Modules $(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-12/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer";
+				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-9/bin/Lib $(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/UI/UIFramework.iOS.zip/Modules $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-9/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer";
+				"SWIFT_INCLUDE_PATHS[sdk=iphoneos*]" = "$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-12/bin/Lib $(BUILD_DIR)/bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/UI/UIFramework.iOS.zip/Modules $(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-12/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer";
 				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-9/bin/iOSApp/Source/iOSApp.library.rules_xcodeproj.swift.compile.params";
 				"SWIFT_PARAMS_FILE[sdk=iphoneos*]" = "$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-12/bin/iOSApp/Source/iOSApp.library.rules_xcodeproj.swift.compile.params";
 				TARGETED_DEVICE_FAMILY = 1;
@@ -24776,7 +24776,7 @@
 				PRODUCT_NAME = watchOSAppExtensionUnitTests;
 				SDKROOT = watchos;
 				SUPPORTED_PLATFORMS = watchsimulator;
-				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-4/bin/Lib $(BUILD_DIR)/bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/UI/UIFramework.watchOS.framework/Modules";
+				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-4/bin/Lib $(BUILD_DIR)/bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/UI/UIFramework.watchOS.zip/Modules";
 				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-4/bin/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTests.library.rules_xcodeproj.swift.compile.params";
 				TARGET_NAME = watchOSAppExtensionUnitTests;
 				WATCHOS_DEPLOYMENT_TARGET = 7.0;
@@ -24827,8 +24827,8 @@
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-9/bin/Lib $(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/UI/UIFramework.iOS.framework/Modules $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-9/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer $(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Source $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-9/bin/iOSApp/Test/TestingUtils";
-				"SWIFT_INCLUDE_PATHS[sdk=iphoneos*]" = "$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-12/bin/Lib $(BUILD_DIR)/bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/UI/UIFramework.iOS.framework/Modules $(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-12/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer $(BUILD_DIR)/bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Source $(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-12/bin/iOSApp/Test/TestingUtils";
+				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-9/bin/Lib $(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/UI/UIFramework.iOS.zip/Modules $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-9/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer $(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Source $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-9/bin/iOSApp/Test/TestingUtils";
+				"SWIFT_INCLUDE_PATHS[sdk=iphoneos*]" = "$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-12/bin/Lib $(BUILD_DIR)/bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/UI/UIFramework.iOS.zip/Modules $(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-12/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer $(BUILD_DIR)/bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Source $(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-12/bin/iOSApp/Test/TestingUtils";
 				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-9/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.library.rules_xcodeproj.swift.compile.params";
 				"SWIFT_PARAMS_FILE[sdk=iphoneos*]" = "$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-12/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.library.rules_xcodeproj.swift.compile.params";
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -24868,7 +24868,7 @@
 				SDKROOT = watchos;
 				SUPPORTED_PLATFORMS = watchsimulator;
 				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-opt-STABLE-10/bin/Lib $(BUILD_DIR)/bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/UI/UIFramework.watchOS.framework/Modules";
+				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-opt-STABLE-10/bin/Lib $(BUILD_DIR)/bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/UI/UIFramework.watchOS.zip/Modules";
 				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-opt-STABLE-10/bin/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTests.library.rules_xcodeproj.swift.compile.params";
 				TARGET_NAME = watchOSAppExtensionUnitTests;
 				WATCHOS_DEPLOYMENT_TARGET = 7.0;
@@ -25041,8 +25041,8 @@
 				SDKROOT = appletvos;
 				SUPPORTED_PLATFORMS = "appletvsimulator appletvos";
 				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-opt-STABLE-11/bin/Lib $(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/UI/UIFramework.tvOS.framework/Modules";
-				"SWIFT_INCLUDE_PATHS[sdk=appletvos*]" = "$(BUILD_DIR)/bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-opt-STABLE-14/bin/Lib $(BUILD_DIR)/bazel-out/applebin_tvos-tvos_arm64-opt-STABLE-30/bin/UI/UIFramework.tvOS.framework/Modules";
+				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-opt-STABLE-11/bin/Lib $(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/UI/UIFramework.tvOS.zip/Modules";
+				"SWIFT_INCLUDE_PATHS[sdk=appletvos*]" = "$(BUILD_DIR)/bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-opt-STABLE-14/bin/Lib $(BUILD_DIR)/bazel-out/applebin_tvos-tvos_arm64-opt-STABLE-30/bin/UI/UIFramework.tvOS.zip/Modules";
 				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-opt-STABLE-11/bin/tvOSApp/Source/tvOSApp.library.rules_xcodeproj.swift.compile.params";
 				"SWIFT_PARAMS_FILE[sdk=appletvos*]" = "$(BAZEL_OUT)/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-opt-STABLE-14/bin/tvOSApp/Source/tvOSApp.library.rules_xcodeproj.swift.compile.params";
 				TARGET_NAME = tvOSApp;
@@ -25431,8 +25431,8 @@
 				"OTHER_SWIFT_FLAGS[sdk=appletvos*]" = "-Xcc -ivfsoverlay -Xcc $(DERIVED_FILE_DIR)/xcode-overlay.yaml -Xcc -ivfsoverlay -Xcc $(OBJROOT)/bazel-out-overlay.yaml -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml $(PREVIEWS_SWIFT_INCLUDE__$(ENABLE_PREVIEWS)) @$(DERIVED_FILE_DIR)/swift.compile.params -F$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64 -Xcc -F -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64 -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(BAZEL_OUT)/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-8/bin/external/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(PROJECT_DIR) -Xcc -iquote -Xcc $(BAZEL_OUT)/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-8/bin -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64/CryptoSwift.framework/Modules/module.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all";
 				PREVIEWS_SWIFT_INCLUDE__ = "";
 				PREVIEWS_SWIFT_INCLUDE__NO = "";
-				PREVIEWS_SWIFT_INCLUDE__YES = "-I $(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/UI/UIFramework.tvOS.framework/Modules";
-				"PREVIEWS_SWIFT_INCLUDE__YES[sdk=appletvos*]" = "-I $(BUILD_DIR)/bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-28/bin/UI/UIFramework.tvOS.framework/Modules";
+				PREVIEWS_SWIFT_INCLUDE__YES = "-I $(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/UI/UIFramework.tvOS.zip/Modules";
+				"PREVIEWS_SWIFT_INCLUDE__YES[sdk=appletvos*]" = "-I $(BUILD_DIR)/bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-28/bin/UI/UIFramework.tvOS.zip/Modules";
 				PRODUCT_BUNDLE_IDENTIFIER = "rules-xcodeproj.UIFramework";
 				PRODUCT_MODULE_NAME = UI;
 				PRODUCT_NAME = UIFramework.tvOS;
@@ -25772,8 +25772,8 @@
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
-				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-3/bin/Lib $(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/UI/UIFramework.iOS.framework/Modules $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-3/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer";
-				"SWIFT_INCLUDE_PATHS[sdk=iphoneos*]" = "$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-6/bin/Lib $(BUILD_DIR)/bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/UI/UIFramework.iOS.framework/Modules $(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-6/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer";
+				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-3/bin/Lib $(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/UI/UIFramework.iOS.zip/Modules $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-3/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer";
+				"SWIFT_INCLUDE_PATHS[sdk=iphoneos*]" = "$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-6/bin/Lib $(BUILD_DIR)/bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/UI/UIFramework.iOS.zip/Modules $(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-6/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer";
 				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-3/bin/iOSApp/Source/iOSApp.library.rules_xcodeproj.swift.compile.params";
 				"SWIFT_PARAMS_FILE[sdk=iphoneos*]" = "$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-6/bin/iOSApp/Source/iOSApp.library.rules_xcodeproj.swift.compile.params";
 				TARGETED_DEVICE_FAMILY = 1;
@@ -25891,7 +25891,7 @@
 				SDKROOT = appletvos;
 				SUPPORTED_PLATFORMS = appletvsimulator;
 				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-opt-STABLE-11/bin/Lib $(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/UI/UIFramework.tvOS.framework/Modules $(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/tvOSApp/Source";
+				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-opt-STABLE-11/bin/Lib $(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/UI/UIFramework.tvOS.zip/Modules $(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/tvOSApp/Source";
 				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-opt-STABLE-11/bin/tvOSApp/Test/UnitTests/tvOSAppUnitTests.library.rules_xcodeproj.swift.compile.params";
 				TARGET_BUILD_DIR = "$(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/tvOSApp/Source$(TARGET_BUILD_SUBPATH)";
 				TARGET_NAME = tvOSAppUnitTests;
@@ -26570,8 +26570,8 @@
 				SDKROOT = watchos;
 				SUPPORTED_PLATFORMS = "watchsimulator watchos";
 				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-opt-STABLE-10/bin/Lib $(BUILD_DIR)/bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/UI/UIFramework.watchOS.framework/Modules";
-				"SWIFT_INCLUDE_PATHS[sdk=watchos*]" = "$(BUILD_DIR)/bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-opt-STABLE-13/bin/Lib $(BUILD_DIR)/bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-22/bin/UI/UIFramework.watchOS.framework/Modules";
+				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-opt-STABLE-10/bin/Lib $(BUILD_DIR)/bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/UI/UIFramework.watchOS.zip/Modules";
+				"SWIFT_INCLUDE_PATHS[sdk=watchos*]" = "$(BUILD_DIR)/bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-opt-STABLE-13/bin/Lib $(BUILD_DIR)/bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-22/bin/UI/UIFramework.watchOS.zip/Modules";
 				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-opt-STABLE-10/bin/watchOSAppExtension/watchOSAppExtension.library.rules_xcodeproj.swift.compile.params";
 				"SWIFT_PARAMS_FILE[sdk=watchos*]" = "$(BAZEL_OUT)/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-opt-STABLE-13/bin/watchOSAppExtension/watchOSAppExtension.library.rules_xcodeproj.swift.compile.params";
 				TARGET_NAME = watchOSAppExtension;
@@ -26831,8 +26831,8 @@
 				PRODUCT_NAME = tvOSApp;
 				SDKROOT = appletvos;
 				SUPPORTED_PLATFORMS = "appletvsimulator appletvos";
-				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-5/bin/Lib $(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/UI/UIFramework.tvOS.framework/Modules";
-				"SWIFT_INCLUDE_PATHS[sdk=appletvos*]" = "$(BUILD_DIR)/bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-8/bin/Lib $(BUILD_DIR)/bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-28/bin/UI/UIFramework.tvOS.framework/Modules";
+				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-5/bin/Lib $(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/UI/UIFramework.tvOS.zip/Modules";
+				"SWIFT_INCLUDE_PATHS[sdk=appletvos*]" = "$(BUILD_DIR)/bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-8/bin/Lib $(BUILD_DIR)/bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-28/bin/UI/UIFramework.tvOS.zip/Modules";
 				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-5/bin/tvOSApp/Source/tvOSApp.library.rules_xcodeproj.swift.compile.params";
 				"SWIFT_PARAMS_FILE[sdk=appletvos*]" = "$(BAZEL_OUT)/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-8/bin/tvOSApp/Source/tvOSApp.library.rules_xcodeproj.swift.compile.params";
 				TARGET_NAME = tvOSApp;
@@ -27182,8 +27182,8 @@
 				"OTHER_SWIFT_FLAGS[sdk=watchos*]" = "-Xcc -ivfsoverlay -Xcc $(DERIVED_FILE_DIR)/xcode-overlay.yaml -Xcc -ivfsoverlay -Xcc $(OBJROOT)/bazel-out-overlay.yaml -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml $(PREVIEWS_SWIFT_INCLUDE__$(ENABLE_PREVIEWS)) @$(DERIVED_FILE_DIR)/swift.compile.params -F$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k -Xcc -F -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(BAZEL_OUT)/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-7/bin/external/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(PROJECT_DIR) -Xcc -iquote -Xcc $(BAZEL_OUT)/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-7/bin -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k/CryptoSwift.framework/Modules/module.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all";
 				PREVIEWS_SWIFT_INCLUDE__ = "";
 				PREVIEWS_SWIFT_INCLUDE__NO = "";
-				PREVIEWS_SWIFT_INCLUDE__YES = "-I $(BUILD_DIR)/bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/UI/UIFramework.watchOS.framework/Modules";
-				"PREVIEWS_SWIFT_INCLUDE__YES[sdk=watchos*]" = "-I $(BUILD_DIR)/bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-20/bin/UI/UIFramework.watchOS.framework/Modules";
+				PREVIEWS_SWIFT_INCLUDE__YES = "-I $(BUILD_DIR)/bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/UI/UIFramework.watchOS.zip/Modules";
+				"PREVIEWS_SWIFT_INCLUDE__YES[sdk=watchos*]" = "-I $(BUILD_DIR)/bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-20/bin/UI/UIFramework.watchOS.zip/Modules";
 				PRODUCT_BUNDLE_IDENTIFIER = "rules-xcodeproj.UIFramework";
 				PRODUCT_MODULE_NAME = UI;
 				PRODUCT_NAME = UIFramework.watchOS;
@@ -27262,7 +27262,7 @@
 				SUPPORTED_PLATFORMS = iphonesimulator;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-9/bin/Lib $(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/UI/UIFramework.iOS.framework/Modules $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-9/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer $(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Source $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-9/bin/iOSApp/Test/TestingUtils";
+				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-9/bin/Lib $(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/UI/UIFramework.iOS.zip/Modules $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-9/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer $(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Source $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-9/bin/iOSApp/Test/TestingUtils";
 				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-9/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTestSuite.library.rules_xcodeproj.swift.compile.params";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TARGET_BUILD_DIR = "$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Source$(TARGET_BUILD_SUBPATH)";
@@ -27740,8 +27740,8 @@
 				"OTHER_SWIFT_FLAGS[sdk=appletvos*]" = "-Xcc -ivfsoverlay -Xcc $(DERIVED_FILE_DIR)/xcode-overlay.yaml -Xcc -ivfsoverlay -Xcc $(OBJROOT)/bazel-out-overlay.yaml -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml $(PREVIEWS_SWIFT_INCLUDE__$(ENABLE_PREVIEWS)) @$(DERIVED_FILE_DIR)/swift.compile.params -F$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64 -Xcc -F -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64 -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(BAZEL_OUT)/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-opt-STABLE-14/bin/external/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(PROJECT_DIR) -Xcc -iquote -Xcc $(BAZEL_OUT)/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-opt-STABLE-14/bin -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64/CryptoSwift.framework/Modules/module.modulemap -Xcc -Os -Xcc -DNDEBUG=1 -Xcc -Wno-unused-variable -Xcc -Winit-self -Xcc -Wno-extra";
 				PREVIEWS_SWIFT_INCLUDE__ = "";
 				PREVIEWS_SWIFT_INCLUDE__NO = "";
-				PREVIEWS_SWIFT_INCLUDE__YES = "-I $(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/UI/UIFramework.tvOS.framework/Modules";
-				"PREVIEWS_SWIFT_INCLUDE__YES[sdk=appletvos*]" = "-I $(BUILD_DIR)/bazel-out/applebin_tvos-tvos_arm64-opt-STABLE-30/bin/UI/UIFramework.tvOS.framework/Modules";
+				PREVIEWS_SWIFT_INCLUDE__YES = "-I $(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/UI/UIFramework.tvOS.zip/Modules";
+				"PREVIEWS_SWIFT_INCLUDE__YES[sdk=appletvos*]" = "-I $(BUILD_DIR)/bazel-out/applebin_tvos-tvos_arm64-opt-STABLE-30/bin/UI/UIFramework.tvOS.zip/Modules";
 				PRODUCT_BUNDLE_IDENTIFIER = "rules-xcodeproj.UIFramework";
 				PRODUCT_MODULE_NAME = UI;
 				PRODUCT_NAME = UIFramework.tvOS;
@@ -27834,7 +27834,7 @@
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphonesimulator;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
-				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-3/bin/Lib $(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/UI/UIFramework.iOS.framework/Modules $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-3/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer $(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Source $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-3/bin/iOSApp/Test/TestingUtils";
+				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-3/bin/Lib $(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/UI/UIFramework.iOS.zip/Modules $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-3/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer $(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Source $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-3/bin/iOSApp/Test/TestingUtils";
 				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-3/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTestSuite.library.rules_xcodeproj.swift.compile.params";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TARGET_BUILD_DIR = "$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Source$(TARGET_BUILD_SUBPATH)";
@@ -28264,8 +28264,8 @@
 				"OTHER_SWIFT_FLAGS[sdk=watchos*]" = "-Xcc -ivfsoverlay -Xcc $(DERIVED_FILE_DIR)/xcode-overlay.yaml -Xcc -ivfsoverlay -Xcc $(OBJROOT)/bazel-out-overlay.yaml -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml $(PREVIEWS_SWIFT_INCLUDE__$(ENABLE_PREVIEWS)) @$(DERIVED_FILE_DIR)/swift.compile.params -F$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k -Xcc -F -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(BAZEL_OUT)/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-opt-STABLE-13/bin/external/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(PROJECT_DIR) -Xcc -iquote -Xcc $(BAZEL_OUT)/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-opt-STABLE-13/bin -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k/CryptoSwift.framework/Modules/module.modulemap -Xcc -Os -Xcc -DNDEBUG=1 -Xcc -Wno-unused-variable -Xcc -Winit-self -Xcc -Wno-extra";
 				PREVIEWS_SWIFT_INCLUDE__ = "";
 				PREVIEWS_SWIFT_INCLUDE__NO = "";
-				PREVIEWS_SWIFT_INCLUDE__YES = "-I $(BUILD_DIR)/bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/UI/UIFramework.watchOS.framework/Modules";
-				"PREVIEWS_SWIFT_INCLUDE__YES[sdk=watchos*]" = "-I $(BUILD_DIR)/bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-22/bin/UI/UIFramework.watchOS.framework/Modules";
+				PREVIEWS_SWIFT_INCLUDE__YES = "-I $(BUILD_DIR)/bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/UI/UIFramework.watchOS.zip/Modules";
+				"PREVIEWS_SWIFT_INCLUDE__YES[sdk=watchos*]" = "-I $(BUILD_DIR)/bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-22/bin/UI/UIFramework.watchOS.zip/Modules";
 				PRODUCT_BUNDLE_IDENTIFIER = "rules-xcodeproj.UIFramework";
 				PRODUCT_MODULE_NAME = UI;
 				PRODUCT_NAME = UIFramework.watchOS;
@@ -28795,8 +28795,8 @@
 				PRODUCT_NAME = watchOSAppExtension;
 				SDKROOT = watchos;
 				SUPPORTED_PLATFORMS = "watchsimulator watchos";
-				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-4/bin/Lib $(BUILD_DIR)/bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/UI/UIFramework.watchOS.framework/Modules";
-				"SWIFT_INCLUDE_PATHS[sdk=watchos*]" = "$(BUILD_DIR)/bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-7/bin/Lib $(BUILD_DIR)/bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-20/bin/UI/UIFramework.watchOS.framework/Modules";
+				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-4/bin/Lib $(BUILD_DIR)/bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/UI/UIFramework.watchOS.zip/Modules";
+				"SWIFT_INCLUDE_PATHS[sdk=watchos*]" = "$(BUILD_DIR)/bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-7/bin/Lib $(BUILD_DIR)/bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-20/bin/UI/UIFramework.watchOS.zip/Modules";
 				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-4/bin/watchOSAppExtension/watchOSAppExtension.library.rules_xcodeproj.swift.compile.params";
 				"SWIFT_PARAMS_FILE[sdk=watchos*]" = "$(BAZEL_OUT)/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-7/bin/watchOSAppExtension/watchOSAppExtension.library.rules_xcodeproj.swift.compile.params";
 				TARGET_NAME = watchOSAppExtension;
@@ -28849,8 +28849,8 @@
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
-				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-3/bin/Lib $(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/UI/UIFramework.iOS.framework/Modules $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-3/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer $(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Source $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-3/bin/iOSApp/Test/TestingUtils";
-				"SWIFT_INCLUDE_PATHS[sdk=iphoneos*]" = "$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-6/bin/Lib $(BUILD_DIR)/bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/UI/UIFramework.iOS.framework/Modules $(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-6/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer $(BUILD_DIR)/bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Source $(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-6/bin/iOSApp/Test/TestingUtils";
+				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-3/bin/Lib $(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/UI/UIFramework.iOS.zip/Modules $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-3/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer $(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Source $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-3/bin/iOSApp/Test/TestingUtils";
+				"SWIFT_INCLUDE_PATHS[sdk=iphoneos*]" = "$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-6/bin/Lib $(BUILD_DIR)/bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/UI/UIFramework.iOS.zip/Modules $(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-6/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer $(BUILD_DIR)/bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Source $(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-6/bin/iOSApp/Test/TestingUtils";
 				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-3/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.library.rules_xcodeproj.swift.compile.params";
 				"SWIFT_PARAMS_FILE[sdk=iphoneos*]" = "$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-6/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.library.rules_xcodeproj.swift.compile.params";
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -29538,7 +29538,7 @@
 				PRODUCT_NAME = tvOSAppUnitTests;
 				SDKROOT = appletvos;
 				SUPPORTED_PLATFORMS = appletvsimulator;
-				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-5/bin/Lib $(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/UI/UIFramework.tvOS.framework/Modules $(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/tvOSApp/Source";
+				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-5/bin/Lib $(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/UI/UIFramework.tvOS.zip/Modules $(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/tvOSApp/Source";
 				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-5/bin/tvOSApp/Test/UnitTests/tvOSAppUnitTests.library.rules_xcodeproj.swift.compile.params";
 				TARGET_BUILD_DIR = "$(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/tvOSApp/Source$(TARGET_BUILD_SUBPATH)";
 				TARGET_NAME = tvOSAppUnitTests;
@@ -29697,8 +29697,8 @@
 				"OTHER_SWIFT_FLAGS[sdk=iphoneos*]" = "-Xcc -ivfsoverlay -Xcc $(DERIVED_FILE_DIR)/xcode-overlay.yaml -Xcc -ivfsoverlay -Xcc $(OBJROOT)/bazel-out-overlay.yaml -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml $(PREVIEWS_SWIFT_INCLUDE__$(ENABLE_PREVIEWS)) @$(DERIVED_FILE_DIR)/swift.compile.params -F$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7 -Xcc -F -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7 -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-6/bin/external/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(PROJECT_DIR) -Xcc -iquote -Xcc $(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-6/bin -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework/Modules/module.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all";
 				PREVIEWS_SWIFT_INCLUDE__ = "";
 				PREVIEWS_SWIFT_INCLUDE__NO = "";
-				PREVIEWS_SWIFT_INCLUDE__YES = "-I $(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/UI/UIFramework.iOS.framework/Modules";
-				"PREVIEWS_SWIFT_INCLUDE__YES[sdk=iphoneos*]" = "-I $(BUILD_DIR)/bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/UI/UIFramework.iOS.framework/Modules";
+				PREVIEWS_SWIFT_INCLUDE__YES = "-I $(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/UI/UIFramework.iOS.zip/Modules";
+				"PREVIEWS_SWIFT_INCLUDE__YES[sdk=iphoneos*]" = "-I $(BUILD_DIR)/bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/UI/UIFramework.iOS.zip/Modules";
 				PRODUCT_BUNDLE_IDENTIFIER = "rules-xcodeproj.UIFramework";
 				PRODUCT_MODULE_NAME = UI;
 				PRODUCT_NAME = UIFramework.iOS;

--- a/examples/integration/test/fixtures/bwx_targets_spec.json
+++ b/examples/integration/test/fixtures/bwx_targets_spec.json
@@ -794,7 +794,7 @@
             "e": "AppClip",
             "m": "AppClip",
             "n": "AppClip",
-            "p": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/AppClip/AppClip.app",
+            "p": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/AppClip/AppClip_archive-root/Payload/AppClip.app",
             "t": "com.apple.product-type.application.on-demand-install-capable"
         }
     },
@@ -928,7 +928,7 @@
             "e": "WidgetExtension",
             "m": "WidgetExtension",
             "n": "WidgetExtension",
-            "p": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/WidgetExtension/WidgetExtension.appex",
+            "p": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/WidgetExtension/WidgetExtension_archive-root/WidgetExtension.appex",
             "t": "com.apple.product-type.app-extension"
         }
     },
@@ -979,7 +979,7 @@
             "e": "CoreUtilsObjC",
             "m": "CoreUtilsObjC",
             "n": "CoreUtilsObjC",
-            "p": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Source/CoreUtilsObjC/CoreUtilsObjC.framework",
+            "p": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Source/CoreUtilsObjC/FrameworkCoreUtilsObjC_archive-root/CoreUtilsObjC.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -1023,7 +1023,7 @@
             "e": "LibFramework.iOS",
             "m": "LibFramework.iOS",
             "n": "LibFramework.iOS",
-            "p": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/Lib/LibFramework.iOS.framework",
+            "p": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/Lib/LibFramework.iOS_archive-root/LibFramework.iOS.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -1057,7 +1057,7 @@
             "OTHER_SWIFT_FLAGS": "-F$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator -Xcc -F -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-3/bin/external/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(PROJECT_DIR) -Xcc -iquote -Xcc $(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-3/bin -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all",
             "PREVIEWS_SWIFT_INCLUDE__": "",
             "PREVIEWS_SWIFT_INCLUDE__NO": "",
-            "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/UI/UIFramework.iOS.framework/Modules",
+            "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/UI/UIFramework.iOS.zip/Modules",
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.UIFramework",
             "PRODUCT_MODULE_NAME": "UI",
             "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-3/bin/Lib",
@@ -1092,7 +1092,7 @@
             "e": "UIFramework.iOS",
             "m": "UIFramework.iOS",
             "n": "UIFramework.iOS",
-            "p": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/UI/UIFramework.iOS.framework",
+            "p": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/UI/UIFramework.iOS_archive-root/UIFramework.iOS.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -1171,7 +1171,7 @@
             "e": "LibFramework.watchOS",
             "m": "LibFramework.watchOS",
             "n": "LibFramework.watchOS",
-            "p": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/Lib/LibFramework.watchOS.framework",
+            "p": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/Lib/LibFramework.watchOS_archive-root/LibFramework.watchOS.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -1205,7 +1205,7 @@
             "OTHER_SWIFT_FLAGS": "-F$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator -Xcc -F -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(BAZEL_OUT)/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-4/bin/external/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(PROJECT_DIR) -Xcc -iquote -Xcc $(BAZEL_OUT)/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-4/bin -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all",
             "PREVIEWS_SWIFT_INCLUDE__": "",
             "PREVIEWS_SWIFT_INCLUDE__NO": "",
-            "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/UI/UIFramework.watchOS.framework/Modules",
+            "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/UI/UIFramework.watchOS.zip/Modules",
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.UIFramework",
             "PRODUCT_MODULE_NAME": "UI",
             "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-4/bin/Lib"
@@ -1236,7 +1236,7 @@
             "e": "UIFramework.watchOS",
             "m": "UIFramework.watchOS",
             "n": "UIFramework.watchOS",
-            "p": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/UI/UIFramework.watchOS.framework",
+            "p": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/UI/UIFramework.watchOS_archive-root/UIFramework.watchOS.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -1274,7 +1274,7 @@
             "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/watchOSAppExtension",
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.example.watch.extension",
             "PRODUCT_MODULE_NAME": "watchOSAppExtension",
-            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-4/bin/Lib $(BUILD_DIR)/bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/UI/UIFramework.watchOS.framework/Modules"
+            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-4/bin/Lib $(BUILD_DIR)/bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/UI/UIFramework.watchOS.zip/Modules"
         },
         "c": "applebin_watchos-watchos_x86_64-dbg-STABLE-19",
         "d": [
@@ -1304,7 +1304,7 @@
             "e": "watchOSAppExtension",
             "m": "watchOSAppExtension",
             "n": "watchOSAppExtension",
-            "p": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/watchOSAppExtension/watchOSAppExtension.appex",
+            "p": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/watchOSAppExtension/watchOSAppExtension_archive-root/watchOSAppExtension.appex",
             "t": "com.apple.product-type.watchkit2-extension"
         }
     },
@@ -1341,7 +1341,7 @@
             "e": "watchOSApp",
             "m": "watchOSApp",
             "n": "watchOSApp",
-            "p": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-23/bin/watchOSApp/watchOSApp.app",
+            "p": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-23/bin/watchOSApp/watchOSApp_archive-root/Payload/watchOSApp.app",
             "t": "com.apple.product-type.application.watchapp2"
         }
     },
@@ -1388,7 +1388,7 @@
             "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Source",
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.example",
             "PRODUCT_MODULE_NAME": "iOSApp",
-            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-3/bin/Lib $(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/UI/UIFramework.iOS.framework/Modules $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-3/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer",
+            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-3/bin/Lib $(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/UI/UIFramework.iOS.zip/Modules $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-3/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer",
             "TARGETED_DEVICE_FAMILY": "1"
         },
         "c": "applebin_ios-ios_x86_64-dbg-STABLE-15",
@@ -1442,7 +1442,7 @@
             "e": "iOSApp_ExecutableName",
             "m": "iOSApp",
             "n": "iOSApp",
-            "p": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Source/iOSApp.app",
+            "p": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Source/iOSApp_archive-root/Payload/iOSApp.app",
             "t": "com.apple.product-type.application"
         },
         "r": [
@@ -1491,7 +1491,7 @@
             "e": "Lib",
             "m": "Lib",
             "n": "Lib",
-            "p": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/Lib/dist/dynamic/Lib.framework",
+            "p": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/Lib/dist/dynamic/iOS_archive-root/Lib.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -1570,7 +1570,7 @@
             "e": "Lib",
             "m": "Lib",
             "n": "Lib",
-            "p": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/Lib/dist/dynamic/Lib.framework",
+            "p": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/Lib/dist/dynamic/tvOS_archive-root/Lib.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -1613,7 +1613,7 @@
             "e": "Lib",
             "m": "Lib",
             "n": "Lib",
-            "p": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/Lib/dist/dynamic/Lib.framework",
+            "p": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/Lib/dist/dynamic/watchOS_archive-root/Lib.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -1656,7 +1656,7 @@
             "e": "LibFramework.tvOS",
             "m": "LibFramework.tvOS",
             "n": "LibFramework.tvOS",
-            "p": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/Lib/LibFramework.tvOS.framework",
+            "p": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/Lib/LibFramework.tvOS_archive-root/LibFramework.tvOS.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -1690,7 +1690,7 @@
             "OTHER_SWIFT_FLAGS": "-F$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator -Xcc -F -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-5/bin/external/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(PROJECT_DIR) -Xcc -iquote -Xcc $(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-5/bin -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all",
             "PREVIEWS_SWIFT_INCLUDE__": "",
             "PREVIEWS_SWIFT_INCLUDE__NO": "",
-            "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/UI/UIFramework.tvOS.framework/Modules",
+            "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/UI/UIFramework.tvOS.zip/Modules",
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.UIFramework",
             "PRODUCT_MODULE_NAME": "UI",
             "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-5/bin/Lib"
@@ -1721,7 +1721,7 @@
             "e": "UIFramework.tvOS",
             "m": "UIFramework.tvOS",
             "n": "UIFramework.tvOS",
-            "p": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/UI/UIFramework.tvOS.framework",
+            "p": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/UI/UIFramework.tvOS_archive-root/UIFramework.tvOS.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -1758,7 +1758,7 @@
             "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/tvOSApp/Source",
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.example",
             "PRODUCT_MODULE_NAME": "tvOSApp",
-            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-5/bin/Lib $(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/UI/UIFramework.tvOS.framework/Modules"
+            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-5/bin/Lib $(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/UI/UIFramework.tvOS.zip/Modules"
         },
         "c": "applebin_tvos-tvos_x86_64-dbg-STABLE-27",
         "d": [
@@ -1789,7 +1789,7 @@
             "e": "tvOSApp",
             "m": "tvOSApp",
             "n": "tvOSApp",
-            "p": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/tvOSApp/Source/tvOSApp.app",
+            "p": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/tvOSApp/Source/tvOSApp_archive-root/Payload/tvOSApp.app",
             "t": "com.apple.product-type.application"
         }
     },
@@ -1831,7 +1831,7 @@
             "e": "ABundle",
             "m": "ABundle",
             "n": "ABundle",
-            "p": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/Bundle/ABundle.aplugin",
+            "p": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/Bundle/Bundle_archive-root/ABundle.aplugin",
             "t": "com.apple.product-type.bundle"
         }
     },
@@ -1991,7 +1991,7 @@
             "e": "iOSAppObjCUnitTests",
             "m": "iOSAppObjCUnitTests",
             "n": "iOSAppObjCUnitTests",
-            "p": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.xctest",
+            "p": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.__internal__.__test_bundle_archive-root/iOSAppObjCUnitTests.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         },
         "r": [
@@ -2048,7 +2048,7 @@
             "e": "iOSAppUITests",
             "m": "iOSAppUITests",
             "n": "iOSAppUITests",
-            "p": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/UITests/iOSAppUITests.xctest",
+            "p": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/UITests/iOSAppUITests.__internal__.__test_bundle_archive-root/iOSAppUITests.xctest",
             "t": "com.apple.product-type.bundle.ui-testing"
         },
         "r": [
@@ -2155,7 +2155,7 @@
             "e": "iMessageAppExtension",
             "m": "iMessageAppExtension",
             "n": "iMessageAppExtension",
-            "p": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iMessageApp/iMessageAppExtension.appex",
+            "p": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iMessageApp/iMessageAppExtension_archive-root/iMessageAppExtension.appex",
             "t": "com.apple.product-type.app-extension.messages"
         }
     },
@@ -2193,7 +2193,7 @@
             "e": "iMessageApp",
             "m": "iMessageApp",
             "n": "iMessageApp",
-            "p": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iMessageApp/iMessageApp.app",
+            "p": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iMessageApp/iMessageApp_archive-root/Payload/iMessageApp.app",
             "t": "com.apple.product-type.application.messages"
         }
     },
@@ -2231,7 +2231,7 @@
             "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/SwiftUnitTests",
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.example.tests",
             "PRODUCT_MODULE_NAME": "iOSAppSwiftUnitTests",
-            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-3/bin/Lib $(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/UI/UIFramework.iOS.framework/Modules $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-3/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer $(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Source $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-3/bin/iOSApp/Test/TestingUtils",
+            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-3/bin/Lib $(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/UI/UIFramework.iOS.zip/Modules $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-3/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer $(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Source $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-3/bin/iOSApp/Test/TestingUtils",
             "TARGETED_DEVICE_FAMILY": "1,2"
         },
         "c": "applebin_ios-ios_x86_64-dbg-STABLE-15",
@@ -2268,7 +2268,7 @@
             "e": "iOSAppSwiftUnitTests",
             "m": "iOSAppSwiftUnitTests",
             "n": "iOSAppSwiftUnitTests",
-            "p": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.xctest",
+            "p": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.__internal__.__test_bundle_archive-root/iOSAppSwiftUnitTests.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         }
     },
@@ -2331,7 +2331,7 @@
             "e": "macOSApp",
             "m": "macOSApp",
             "n": "macOSApp",
-            "p": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/macOSApp/Source/macOSApp.app",
+            "p": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/macOSApp/Source/macOSApp_archive-root/Payload/macOSApp.app",
             "t": "com.apple.product-type.application"
         }
     },
@@ -2384,7 +2384,7 @@
             "e": "macOSAppUITests",
             "m": "macOSAppUITests",
             "n": "macOSAppUITests",
-            "p": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/macOSApp/Test/UITests/macOSAppUITests.xctest",
+            "p": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-33/bin/macOSApp/Test/UITests/macOSAppUITests.__internal__.__test_bundle_archive-root/macOSAppUITests.xctest",
             "t": "com.apple.product-type.bundle.ui-testing"
         }
     },
@@ -2437,7 +2437,7 @@
             "e": "tvOSAppUITests",
             "m": "tvOSAppUITests",
             "n": "tvOSAppUITests",
-            "p": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/tvOSApp/Test/UITests/tvOSAppUITests.xctest",
+            "p": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/tvOSApp/Test/UITests/tvOSAppUITests.__internal__.__test_bundle_archive-root/tvOSAppUITests.xctest",
             "t": "com.apple.product-type.bundle.ui-testing"
         }
     },
@@ -2474,7 +2474,7 @@
             "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/tvOSApp/Test/UnitTests",
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.example.tests",
             "PRODUCT_MODULE_NAME": "tvOSAppUnitTests",
-            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-5/bin/Lib $(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/UI/UIFramework.tvOS.framework/Modules $(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/tvOSApp/Source"
+            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-5/bin/Lib $(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/UI/UIFramework.tvOS.zip/Modules $(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/tvOSApp/Source"
         },
         "c": "applebin_tvos-tvos_x86_64-dbg-STABLE-27",
         "d": [
@@ -2502,7 +2502,7 @@
             "e": "tvOSAppUnitTests",
             "m": "tvOSAppUnitTests",
             "n": "tvOSAppUnitTests",
-            "p": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/tvOSApp/Test/UnitTests/tvOSAppUnitTests.xctest",
+            "p": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-27/bin/tvOSApp/Test/UnitTests/tvOSAppUnitTests.__internal__.__test_bundle_archive-root/tvOSAppUnitTests.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         }
     },
@@ -2555,7 +2555,7 @@
             "e": "watchOSAppUITests",
             "m": "watchOSAppUITests",
             "n": "watchOSAppUITests",
-            "p": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/watchOSApp/Test/UITests/watchOSAppUITests.xctest",
+            "p": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/watchOSApp/Test/UITests/watchOSAppUITests.__internal__.__test_bundle_archive-root/watchOSAppUITests.xctest",
             "t": "com.apple.product-type.bundle.ui-testing"
         }
     },
@@ -2592,7 +2592,7 @@
             "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/watchOSAppExtension/Test/UnitTests",
             "PRODUCT_BUNDLE_IDENTIFIER": "com.bazelbuild.rulesapple.Tests",
             "PRODUCT_MODULE_NAME": "watchOSAppExtensionUnitTestsLibrary",
-            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-4/bin/Lib $(BUILD_DIR)/bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/UI/UIFramework.watchOS.framework/Modules"
+            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-4/bin/Lib $(BUILD_DIR)/bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/UI/UIFramework.watchOS.zip/Modules"
         },
         "c": "applebin_watchos-watchos_x86_64-dbg-STABLE-19",
         "d": [
@@ -2619,7 +2619,7 @@
             "e": "watchOSAppExtensionUnitTests",
             "m": "watchOSAppExtensionUnitTests",
             "n": "watchOSAppExtensionUnitTests",
-            "p": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTests.xctest",
+            "p": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-19/bin/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTests.__internal__.__test_bundle_archive-root/watchOSAppExtensionUnitTests.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         }
     },
@@ -2673,7 +2673,7 @@
             "e": "iOSAppUITestSuite",
             "m": "iOSAppUITestSuite",
             "n": "iOSAppUITestSuite",
-            "p": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/UITests/iOSAppUITestSuite.xctest",
+            "p": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/UITests/iOSAppUITestSuite.__internal__.__test_bundle_archive-root/iOSAppUITestSuite.xctest",
             "t": "com.apple.product-type.bundle.ui-testing"
         },
         "r": [
@@ -2738,7 +2738,7 @@
             "e": "iOSAppObjCUnitTestSuite",
             "m": "iOSAppObjCUnitTestSuite",
             "n": "iOSAppObjCUnitTestSuite",
-            "p": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTestSuite.xctest",
+            "p": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTestSuite.__internal__.__test_bundle_archive-root/iOSAppObjCUnitTestSuite.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         },
         "r": [
@@ -2779,7 +2779,7 @@
             "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/SwiftUnitTests",
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.example.tests",
             "PRODUCT_MODULE_NAME": "iOSAppSwiftUnitTestSuite",
-            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-3/bin/Lib $(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/UI/UIFramework.iOS.framework/Modules $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-3/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer $(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Source $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-3/bin/iOSApp/Test/TestingUtils",
+            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-3/bin/Lib $(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/UI/UIFramework.iOS.zip/Modules $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-3/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer $(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Source $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-3/bin/iOSApp/Test/TestingUtils",
             "TARGETED_DEVICE_FAMILY": "1,2"
         },
         "c": "applebin_ios-ios_x86_64-dbg-STABLE-15",
@@ -2816,7 +2816,7 @@
             "e": "iOSAppSwiftUnitTestSuite",
             "m": "iOSAppSwiftUnitTestSuite",
             "n": "iOSAppSwiftUnitTestSuite",
-            "p": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTestSuite.xctest",
+            "p": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-15/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTestSuite.__internal__.__test_bundle_archive-root/iOSAppSwiftUnitTestSuite.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         }
     },
@@ -5907,7 +5907,7 @@
             "e": "CommandLineToolTests",
             "m": "CommandLineToolTests",
             "n": "CommandLineToolTests",
-            "p": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-45/bin/CommandLine/Tests/CommandLineToolTests.xctest",
+            "p": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-45/bin/CommandLine/Tests/CommandLineToolTests.__internal__.__test_bundle_archive-root/CommandLineToolTests.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         }
     },
@@ -6014,7 +6014,7 @@
             "e": "AppClip",
             "m": "AppClip",
             "n": "AppClip",
-            "p": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/AppClip/AppClip.app",
+            "p": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/AppClip/AppClip_archive-root/Payload/AppClip.app",
             "t": "com.apple.product-type.application.on-demand-install-capable"
         }
     },
@@ -6149,7 +6149,7 @@
             "e": "WidgetExtension",
             "m": "WidgetExtension",
             "n": "WidgetExtension",
-            "p": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/WidgetExtension/WidgetExtension.appex",
+            "p": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/WidgetExtension/WidgetExtension_archive-root/WidgetExtension.appex",
             "t": "com.apple.product-type.app-extension"
         }
     },
@@ -6200,7 +6200,7 @@
             "e": "CoreUtilsObjC",
             "m": "CoreUtilsObjC",
             "n": "CoreUtilsObjC",
-            "p": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Source/CoreUtilsObjC/CoreUtilsObjC.framework",
+            "p": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Source/CoreUtilsObjC/FrameworkCoreUtilsObjC_archive-root/CoreUtilsObjC.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -6244,7 +6244,7 @@
             "e": "LibFramework.iOS",
             "m": "LibFramework.iOS",
             "n": "LibFramework.iOS",
-            "p": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/Lib/LibFramework.iOS.framework",
+            "p": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/Lib/LibFramework.iOS_archive-root/LibFramework.iOS.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -6278,7 +6278,7 @@
             "OTHER_SWIFT_FLAGS": "-F$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7 -Xcc -F -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7 -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-6/bin/external/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(PROJECT_DIR) -Xcc -iquote -Xcc $(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-6/bin -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework/Modules/module.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all",
             "PREVIEWS_SWIFT_INCLUDE__": "",
             "PREVIEWS_SWIFT_INCLUDE__NO": "",
-            "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/UI/UIFramework.iOS.framework/Modules",
+            "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/UI/UIFramework.iOS.zip/Modules",
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.UIFramework",
             "PRODUCT_MODULE_NAME": "UI",
             "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-6/bin/Lib",
@@ -6313,7 +6313,7 @@
             "e": "UIFramework.iOS",
             "m": "UIFramework.iOS",
             "n": "UIFramework.iOS",
-            "p": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/UI/UIFramework.iOS.framework",
+            "p": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/UI/UIFramework.iOS_archive-root/UIFramework.iOS.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -6392,7 +6392,7 @@
             "e": "LibFramework.watchOS",
             "m": "LibFramework.watchOS",
             "n": "LibFramework.watchOS",
-            "p": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-20/bin/Lib/LibFramework.watchOS.framework",
+            "p": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-20/bin/Lib/LibFramework.watchOS_archive-root/LibFramework.watchOS.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -6426,7 +6426,7 @@
             "OTHER_SWIFT_FLAGS": "-F$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k -Xcc -F -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(BAZEL_OUT)/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-7/bin/external/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(PROJECT_DIR) -Xcc -iquote -Xcc $(BAZEL_OUT)/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-7/bin -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k/CryptoSwift.framework/Modules/module.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all",
             "PREVIEWS_SWIFT_INCLUDE__": "",
             "PREVIEWS_SWIFT_INCLUDE__NO": "",
-            "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-20/bin/UI/UIFramework.watchOS.framework/Modules",
+            "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-20/bin/UI/UIFramework.watchOS.zip/Modules",
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.UIFramework",
             "PRODUCT_MODULE_NAME": "UI",
             "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-7/bin/Lib"
@@ -6457,7 +6457,7 @@
             "e": "UIFramework.watchOS",
             "m": "UIFramework.watchOS",
             "n": "UIFramework.watchOS",
-            "p": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-20/bin/UI/UIFramework.watchOS.framework",
+            "p": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-20/bin/UI/UIFramework.watchOS_archive-root/UIFramework.watchOS.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -6496,7 +6496,7 @@
             "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-20/bin/watchOSAppExtension",
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.example.watch.extension",
             "PRODUCT_MODULE_NAME": "watchOSAppExtension",
-            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-7/bin/Lib $(BUILD_DIR)/bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-20/bin/UI/UIFramework.watchOS.framework/Modules"
+            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-7/bin/Lib $(BUILD_DIR)/bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-20/bin/UI/UIFramework.watchOS.zip/Modules"
         },
         "c": "applebin_watchos-watchos_arm64_32-dbg-STABLE-20",
         "d": [
@@ -6526,7 +6526,7 @@
             "e": "watchOSAppExtension",
             "m": "watchOSAppExtension",
             "n": "watchOSAppExtension",
-            "p": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-20/bin/watchOSAppExtension/watchOSAppExtension.appex",
+            "p": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-20/bin/watchOSAppExtension/watchOSAppExtension_archive-root/watchOSAppExtension.appex",
             "t": "com.apple.product-type.watchkit2-extension"
         }
     },
@@ -6564,7 +6564,7 @@
             "e": "watchOSApp",
             "m": "watchOSApp",
             "n": "watchOSApp",
-            "p": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-24/bin/watchOSApp/watchOSApp.app",
+            "p": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-24/bin/watchOSApp/watchOSApp_archive-root/Payload/watchOSApp.app",
             "t": "com.apple.product-type.application.watchapp2"
         }
     },
@@ -6612,7 +6612,7 @@
             "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Source",
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.example",
             "PRODUCT_MODULE_NAME": "iOSApp",
-            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-6/bin/Lib $(BUILD_DIR)/bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/UI/UIFramework.iOS.framework/Modules $(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-6/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer",
+            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-6/bin/Lib $(BUILD_DIR)/bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/UI/UIFramework.iOS.zip/Modules $(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-6/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer",
             "TARGETED_DEVICE_FAMILY": "1"
         },
         "c": "applebin_ios-ios_arm64-dbg-STABLE-16",
@@ -6666,7 +6666,7 @@
             "e": "iOSApp",
             "m": "iOSApp",
             "n": "iOSApp",
-            "p": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Source/iOSApp.app",
+            "p": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Source/iOSApp_archive-root/Payload/iOSApp.app",
             "t": "com.apple.product-type.application"
         },
         "r": [
@@ -6715,7 +6715,7 @@
             "e": "Lib",
             "m": "Lib",
             "n": "Lib",
-            "p": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/Lib/dist/dynamic/Lib.framework",
+            "p": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/Lib/dist/dynamic/iOS_archive-root/Lib.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -6794,7 +6794,7 @@
             "e": "Lib",
             "m": "Lib",
             "n": "Lib",
-            "p": "bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-28/bin/Lib/dist/dynamic/Lib.framework",
+            "p": "bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-28/bin/Lib/dist/dynamic/tvOS_archive-root/Lib.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -6837,7 +6837,7 @@
             "e": "Lib",
             "m": "Lib",
             "n": "Lib",
-            "p": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-20/bin/Lib/dist/dynamic/Lib.framework",
+            "p": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-20/bin/Lib/dist/dynamic/watchOS_archive-root/Lib.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -6880,7 +6880,7 @@
             "e": "LibFramework.tvOS",
             "m": "LibFramework.tvOS",
             "n": "LibFramework.tvOS",
-            "p": "bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-28/bin/Lib/LibFramework.tvOS.framework",
+            "p": "bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-28/bin/Lib/LibFramework.tvOS_archive-root/LibFramework.tvOS.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -6914,7 +6914,7 @@
             "OTHER_SWIFT_FLAGS": "-F$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64 -Xcc -F -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64 -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(BAZEL_OUT)/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-8/bin/external/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(PROJECT_DIR) -Xcc -iquote -Xcc $(BAZEL_OUT)/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-8/bin -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64/CryptoSwift.framework/Modules/module.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all",
             "PREVIEWS_SWIFT_INCLUDE__": "",
             "PREVIEWS_SWIFT_INCLUDE__NO": "",
-            "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-28/bin/UI/UIFramework.tvOS.framework/Modules",
+            "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-28/bin/UI/UIFramework.tvOS.zip/Modules",
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.UIFramework",
             "PRODUCT_MODULE_NAME": "UI",
             "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-8/bin/Lib"
@@ -6945,7 +6945,7 @@
             "e": "UIFramework.tvOS",
             "m": "UIFramework.tvOS",
             "n": "UIFramework.tvOS",
-            "p": "bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-28/bin/UI/UIFramework.tvOS.framework",
+            "p": "bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-28/bin/UI/UIFramework.tvOS_archive-root/UIFramework.tvOS.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -6983,7 +6983,7 @@
             "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-28/bin/tvOSApp/Source",
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.example",
             "PRODUCT_MODULE_NAME": "tvOSApp",
-            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-8/bin/Lib $(BUILD_DIR)/bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-28/bin/UI/UIFramework.tvOS.framework/Modules"
+            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-8/bin/Lib $(BUILD_DIR)/bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-28/bin/UI/UIFramework.tvOS.zip/Modules"
         },
         "c": "applebin_tvos-tvos_arm64-dbg-STABLE-28",
         "d": [
@@ -7014,7 +7014,7 @@
             "e": "tvOSApp",
             "m": "tvOSApp",
             "n": "tvOSApp",
-            "p": "bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-28/bin/tvOSApp/Source/tvOSApp.app",
+            "p": "bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-28/bin/tvOSApp/Source/tvOSApp_archive-root/Payload/tvOSApp.app",
             "t": "com.apple.product-type.application"
         }
     },
@@ -7174,7 +7174,7 @@
             "e": "iOSAppObjCUnitTests",
             "m": "iOSAppObjCUnitTests",
             "n": "iOSAppObjCUnitTests",
-            "p": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.xctest",
+            "p": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.__internal__.__test_bundle_archive-root/iOSAppObjCUnitTests.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         },
         "r": [
@@ -7231,7 +7231,7 @@
             "e": "iOSAppUITests",
             "m": "iOSAppUITests",
             "n": "iOSAppUITests",
-            "p": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Test/UITests/iOSAppUITests.xctest",
+            "p": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Test/UITests/iOSAppUITests.__internal__.__test_bundle_archive-root/iOSAppUITests.xctest",
             "t": "com.apple.product-type.bundle.ui-testing"
         },
         "r": [
@@ -7272,7 +7272,7 @@
             "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Test/SwiftUnitTests",
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.example.tests",
             "PRODUCT_MODULE_NAME": "iOSAppSwiftUnitTests",
-            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-6/bin/Lib $(BUILD_DIR)/bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/UI/UIFramework.iOS.framework/Modules $(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-6/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer $(BUILD_DIR)/bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Source $(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-6/bin/iOSApp/Test/TestingUtils",
+            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-6/bin/Lib $(BUILD_DIR)/bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/UI/UIFramework.iOS.zip/Modules $(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-6/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer $(BUILD_DIR)/bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Source $(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-6/bin/iOSApp/Test/TestingUtils",
             "TARGETED_DEVICE_FAMILY": "1,2"
         },
         "c": "applebin_ios-ios_arm64-dbg-STABLE-16",
@@ -7309,7 +7309,7 @@
             "e": "iOSAppSwiftUnitTests",
             "m": "iOSAppSwiftUnitTests",
             "n": "iOSAppSwiftUnitTests",
-            "p": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.xctest",
+            "p": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-16/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.__internal__.__test_bundle_archive-root/iOSAppSwiftUnitTests.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         }
     },
@@ -7581,7 +7581,7 @@
             "e": "AppClip",
             "m": "AppClip",
             "n": "AppClip",
-            "p": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/AppClip/AppClip.app",
+            "p": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/AppClip/AppClip_archive-root/Payload/AppClip.app",
             "t": "com.apple.product-type.application.on-demand-install-capable"
         },
         "x": [
@@ -7726,7 +7726,7 @@
             "e": "WidgetExtension",
             "m": "WidgetExtension",
             "n": "WidgetExtension",
-            "p": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/WidgetExtension/WidgetExtension.appex",
+            "p": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/WidgetExtension/WidgetExtension_archive-root/WidgetExtension.appex",
             "t": "com.apple.product-type.app-extension"
         },
         "x": [
@@ -7780,7 +7780,7 @@
             "e": "CoreUtilsObjC",
             "m": "CoreUtilsObjC",
             "n": "CoreUtilsObjC",
-            "p": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Source/CoreUtilsObjC/CoreUtilsObjC.framework",
+            "p": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Source/CoreUtilsObjC/FrameworkCoreUtilsObjC_archive-root/CoreUtilsObjC.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -7827,7 +7827,7 @@
             "e": "LibFramework.iOS",
             "m": "LibFramework.iOS",
             "n": "LibFramework.iOS",
-            "p": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/Lib/LibFramework.iOS.framework",
+            "p": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/Lib/LibFramework.iOS_archive-root/LibFramework.iOS.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -7864,7 +7864,7 @@
             "OTHER_SWIFT_FLAGS": "-F$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator -Xcc -F -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-9/bin/external/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(PROJECT_DIR) -Xcc -iquote -Xcc $(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-9/bin -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap -Xcc -Os -Xcc -DNDEBUG=1 -Xcc -Wno-unused-variable -Xcc -Winit-self -Xcc -Wno-extra",
             "PREVIEWS_SWIFT_INCLUDE__": "",
             "PREVIEWS_SWIFT_INCLUDE__NO": "",
-            "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/UI/UIFramework.iOS.framework/Modules",
+            "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/UI/UIFramework.iOS.zip/Modules",
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.UIFramework",
             "PRODUCT_MODULE_NAME": "UI",
             "SWIFT_COMPILATION_MODE": "wholemodule",
@@ -7900,7 +7900,7 @@
             "e": "UIFramework.iOS",
             "m": "UIFramework.iOS",
             "n": "UIFramework.iOS",
-            "p": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/UI/UIFramework.iOS.framework",
+            "p": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/UI/UIFramework.iOS_archive-root/UIFramework.iOS.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -7986,7 +7986,7 @@
             "e": "LibFramework.watchOS",
             "m": "LibFramework.watchOS",
             "n": "LibFramework.watchOS",
-            "p": "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/Lib/LibFramework.watchOS.framework",
+            "p": "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/Lib/LibFramework.watchOS_archive-root/LibFramework.watchOS.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -8023,7 +8023,7 @@
             "OTHER_SWIFT_FLAGS": "-F$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator -Xcc -F -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(BAZEL_OUT)/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-opt-STABLE-10/bin/external/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(PROJECT_DIR) -Xcc -iquote -Xcc $(BAZEL_OUT)/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-opt-STABLE-10/bin -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap -Xcc -Os -Xcc -DNDEBUG=1 -Xcc -Wno-unused-variable -Xcc -Winit-self -Xcc -Wno-extra",
             "PREVIEWS_SWIFT_INCLUDE__": "",
             "PREVIEWS_SWIFT_INCLUDE__NO": "",
-            "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/UI/UIFramework.watchOS.framework/Modules",
+            "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/UI/UIFramework.watchOS.zip/Modules",
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.UIFramework",
             "PRODUCT_MODULE_NAME": "UI",
             "SWIFT_COMPILATION_MODE": "wholemodule",
@@ -8055,7 +8055,7 @@
             "e": "UIFramework.watchOS",
             "m": "UIFramework.watchOS",
             "n": "UIFramework.watchOS",
-            "p": "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/UI/UIFramework.watchOS.framework",
+            "p": "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/UI/UIFramework.watchOS_archive-root/UIFramework.watchOS.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -8097,7 +8097,7 @@
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.example.watch.extension",
             "PRODUCT_MODULE_NAME": "watchOSAppExtension",
             "SWIFT_COMPILATION_MODE": "wholemodule",
-            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-opt-STABLE-10/bin/Lib $(BUILD_DIR)/bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/UI/UIFramework.watchOS.framework/Modules"
+            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-opt-STABLE-10/bin/Lib $(BUILD_DIR)/bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/UI/UIFramework.watchOS.zip/Modules"
         },
         "c": "applebin_watchos-watchos_x86_64-opt-STABLE-21",
         "d": [
@@ -8127,7 +8127,7 @@
             "e": "watchOSAppExtension",
             "m": "watchOSAppExtension",
             "n": "watchOSAppExtension",
-            "p": "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/watchOSAppExtension/watchOSAppExtension.appex",
+            "p": "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/watchOSAppExtension/watchOSAppExtension_archive-root/watchOSAppExtension.appex",
             "t": "com.apple.product-type.watchkit2-extension"
         },
         "x": [
@@ -8167,7 +8167,7 @@
             "e": "watchOSApp",
             "m": "watchOSApp",
             "n": "watchOSApp",
-            "p": "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-25/bin/watchOSApp/watchOSApp.app",
+            "p": "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-25/bin/watchOSApp/watchOSApp_archive-root/Payload/watchOSApp.app",
             "t": "com.apple.product-type.application.watchapp2"
         },
         "x": [
@@ -8214,7 +8214,7 @@
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.example",
             "PRODUCT_MODULE_NAME": "iOSApp",
             "SWIFT_COMPILATION_MODE": "wholemodule",
-            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-9/bin/Lib $(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/UI/UIFramework.iOS.framework/Modules $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-9/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer",
+            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-9/bin/Lib $(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/UI/UIFramework.iOS.zip/Modules $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-9/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer",
             "TARGETED_DEVICE_FAMILY": "1"
         },
         "c": "applebin_ios-ios_x86_64-opt-STABLE-17",
@@ -8267,7 +8267,7 @@
             "e": "iOSApp_ExecutableName",
             "m": "iOSApp",
             "n": "iOSApp",
-            "p": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Source/iOSApp.app",
+            "p": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Source/iOSApp_archive-root/Payload/iOSApp.app",
             "t": "com.apple.product-type.application"
         },
         "r": [
@@ -8319,7 +8319,7 @@
             "e": "Lib",
             "m": "Lib",
             "n": "Lib",
-            "p": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/Lib/dist/dynamic/Lib.framework",
+            "p": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/Lib/dist/dynamic/iOS_archive-root/Lib.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -8405,7 +8405,7 @@
             "e": "Lib",
             "m": "Lib",
             "n": "Lib",
-            "p": "bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/Lib/dist/dynamic/Lib.framework",
+            "p": "bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/Lib/dist/dynamic/tvOS_archive-root/Lib.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -8451,7 +8451,7 @@
             "e": "Lib",
             "m": "Lib",
             "n": "Lib",
-            "p": "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/Lib/dist/dynamic/Lib.framework",
+            "p": "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/Lib/dist/dynamic/watchOS_archive-root/Lib.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -8497,7 +8497,7 @@
             "e": "LibFramework.tvOS",
             "m": "LibFramework.tvOS",
             "n": "LibFramework.tvOS",
-            "p": "bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/Lib/LibFramework.tvOS.framework",
+            "p": "bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/Lib/LibFramework.tvOS_archive-root/LibFramework.tvOS.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -8534,7 +8534,7 @@
             "OTHER_SWIFT_FLAGS": "-F$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator -Xcc -F -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-opt-STABLE-11/bin/external/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(PROJECT_DIR) -Xcc -iquote -Xcc $(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-opt-STABLE-11/bin -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap -Xcc -Os -Xcc -DNDEBUG=1 -Xcc -Wno-unused-variable -Xcc -Winit-self -Xcc -Wno-extra",
             "PREVIEWS_SWIFT_INCLUDE__": "",
             "PREVIEWS_SWIFT_INCLUDE__NO": "",
-            "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/UI/UIFramework.tvOS.framework/Modules",
+            "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/UI/UIFramework.tvOS.zip/Modules",
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.UIFramework",
             "PRODUCT_MODULE_NAME": "UI",
             "SWIFT_COMPILATION_MODE": "wholemodule",
@@ -8566,7 +8566,7 @@
             "e": "UIFramework.tvOS",
             "m": "UIFramework.tvOS",
             "n": "UIFramework.tvOS",
-            "p": "bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/UI/UIFramework.tvOS.framework",
+            "p": "bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/UI/UIFramework.tvOS_archive-root/UIFramework.tvOS.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -8607,7 +8607,7 @@
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.example",
             "PRODUCT_MODULE_NAME": "tvOSApp",
             "SWIFT_COMPILATION_MODE": "wholemodule",
-            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-opt-STABLE-11/bin/Lib $(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/UI/UIFramework.tvOS.framework/Modules"
+            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-opt-STABLE-11/bin/Lib $(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/UI/UIFramework.tvOS.zip/Modules"
         },
         "c": "applebin_tvos-tvos_x86_64-opt-STABLE-29",
         "d": [
@@ -8637,7 +8637,7 @@
             "e": "tvOSApp",
             "m": "tvOSApp",
             "n": "tvOSApp",
-            "p": "bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/tvOSApp/Source/tvOSApp.app",
+            "p": "bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/tvOSApp/Source/tvOSApp_archive-root/Payload/tvOSApp.app",
             "t": "com.apple.product-type.application"
         },
         "x": [
@@ -8682,7 +8682,7 @@
             "e": "ABundle",
             "m": "ABundle",
             "n": "ABundle",
-            "p": "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-34/bin/Bundle/ABundle.aplugin",
+            "p": "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-34/bin/Bundle/Bundle_archive-root/ABundle.aplugin",
             "t": "com.apple.product-type.bundle"
         },
         "x": [
@@ -8855,7 +8855,7 @@
             "e": "iOSAppObjCUnitTests",
             "m": "iOSAppObjCUnitTests",
             "n": "iOSAppObjCUnitTests",
-            "p": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.xctest",
+            "p": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.__internal__.__test_bundle_archive-root/iOSAppObjCUnitTests.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         },
         "r": [
@@ -8916,7 +8916,7 @@
             "e": "iOSAppUITests",
             "m": "iOSAppUITests",
             "n": "iOSAppUITests",
-            "p": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/UITests/iOSAppUITests.xctest",
+            "p": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/UITests/iOSAppUITests.__internal__.__test_bundle_archive-root/iOSAppUITests.xctest",
             "t": "com.apple.product-type.bundle.ui-testing"
         },
         "r": [
@@ -9031,7 +9031,7 @@
             "e": "iMessageAppExtension",
             "m": "iMessageAppExtension",
             "n": "iMessageAppExtension",
-            "p": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iMessageApp/iMessageAppExtension.appex",
+            "p": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iMessageApp/iMessageAppExtension_archive-root/iMessageAppExtension.appex",
             "t": "com.apple.product-type.app-extension.messages"
         },
         "x": [
@@ -9072,7 +9072,7 @@
             "e": "iMessageApp",
             "m": "iMessageApp",
             "n": "iMessageApp",
-            "p": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iMessageApp/iMessageApp.app",
+            "p": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iMessageApp/iMessageApp_archive-root/Payload/iMessageApp.app",
             "t": "com.apple.product-type.application.messages"
         },
         "x": [
@@ -9114,7 +9114,7 @@
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.example.tests",
             "PRODUCT_MODULE_NAME": "iOSAppSwiftUnitTests",
             "SWIFT_COMPILATION_MODE": "wholemodule",
-            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-9/bin/Lib $(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/UI/UIFramework.iOS.framework/Modules $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-9/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer $(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Source $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-9/bin/iOSApp/Test/TestingUtils",
+            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-9/bin/Lib $(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/UI/UIFramework.iOS.zip/Modules $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-9/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer $(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Source $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-9/bin/iOSApp/Test/TestingUtils",
             "TARGETED_DEVICE_FAMILY": "1,2"
         },
         "c": "applebin_ios-ios_x86_64-opt-STABLE-17",
@@ -9151,7 +9151,7 @@
             "e": "iOSAppSwiftUnitTests",
             "m": "iOSAppSwiftUnitTests",
             "n": "iOSAppSwiftUnitTests",
-            "p": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.xctest",
+            "p": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.__internal__.__test_bundle_archive-root/iOSAppSwiftUnitTests.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         },
         "x": [
@@ -9217,7 +9217,7 @@
             "e": "macOSApp",
             "m": "macOSApp",
             "n": "macOSApp",
-            "p": "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-34/bin/macOSApp/Source/macOSApp.app",
+            "p": "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-34/bin/macOSApp/Source/macOSApp_archive-root/Payload/macOSApp.app",
             "t": "com.apple.product-type.application"
         },
         "x": [
@@ -9274,7 +9274,7 @@
             "e": "macOSAppUITests",
             "m": "macOSAppUITests",
             "n": "macOSAppUITests",
-            "p": "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-34/bin/macOSApp/Test/UITests/macOSAppUITests.xctest",
+            "p": "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-34/bin/macOSApp/Test/UITests/macOSAppUITests.__internal__.__test_bundle_archive-root/macOSAppUITests.xctest",
             "t": "com.apple.product-type.bundle.ui-testing"
         },
         "x": [
@@ -9331,7 +9331,7 @@
             "e": "tvOSAppUITests",
             "m": "tvOSAppUITests",
             "n": "tvOSAppUITests",
-            "p": "bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/tvOSApp/Test/UITests/tvOSAppUITests.xctest",
+            "p": "bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/tvOSApp/Test/UITests/tvOSAppUITests.__internal__.__test_bundle_archive-root/tvOSAppUITests.xctest",
             "t": "com.apple.product-type.bundle.ui-testing"
         },
         "x": [
@@ -9372,7 +9372,7 @@
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.example.tests",
             "PRODUCT_MODULE_NAME": "tvOSAppUnitTests",
             "SWIFT_COMPILATION_MODE": "wholemodule",
-            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-opt-STABLE-11/bin/Lib $(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/UI/UIFramework.tvOS.framework/Modules $(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/tvOSApp/Source"
+            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-opt-STABLE-11/bin/Lib $(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/UI/UIFramework.tvOS.zip/Modules $(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/tvOSApp/Source"
         },
         "c": "applebin_tvos-tvos_x86_64-opt-STABLE-29",
         "d": [
@@ -9400,7 +9400,7 @@
             "e": "tvOSAppUnitTests",
             "m": "tvOSAppUnitTests",
             "n": "tvOSAppUnitTests",
-            "p": "bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/tvOSApp/Test/UnitTests/tvOSAppUnitTests.xctest",
+            "p": "bazel-out/applebin_tvos-tvos_x86_64-opt-STABLE-29/bin/tvOSApp/Test/UnitTests/tvOSAppUnitTests.__internal__.__test_bundle_archive-root/tvOSAppUnitTests.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         },
         "x": [
@@ -9457,7 +9457,7 @@
             "e": "watchOSAppUITests",
             "m": "watchOSAppUITests",
             "n": "watchOSAppUITests",
-            "p": "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/watchOSApp/Test/UITests/watchOSAppUITests.xctest",
+            "p": "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/watchOSApp/Test/UITests/watchOSAppUITests.__internal__.__test_bundle_archive-root/watchOSAppUITests.xctest",
             "t": "com.apple.product-type.bundle.ui-testing"
         },
         "x": [
@@ -9498,7 +9498,7 @@
             "PRODUCT_BUNDLE_IDENTIFIER": "com.bazelbuild.rulesapple.Tests",
             "PRODUCT_MODULE_NAME": "watchOSAppExtensionUnitTestsLibrary",
             "SWIFT_COMPILATION_MODE": "wholemodule",
-            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-opt-STABLE-10/bin/Lib $(BUILD_DIR)/bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/UI/UIFramework.watchOS.framework/Modules"
+            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-opt-STABLE-10/bin/Lib $(BUILD_DIR)/bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/UI/UIFramework.watchOS.zip/Modules"
         },
         "c": "applebin_watchos-watchos_x86_64-opt-STABLE-21",
         "d": [
@@ -9525,7 +9525,7 @@
             "e": "watchOSAppExtensionUnitTests",
             "m": "watchOSAppExtensionUnitTests",
             "n": "watchOSAppExtensionUnitTests",
-            "p": "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTests.xctest",
+            "p": "bazel-out/applebin_watchos-watchos_x86_64-opt-STABLE-21/bin/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTests.__internal__.__test_bundle_archive-root/watchOSAppExtensionUnitTests.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         },
         "x": [
@@ -9583,7 +9583,7 @@
             "e": "iOSAppUITestSuite",
             "m": "iOSAppUITestSuite",
             "n": "iOSAppUITestSuite",
-            "p": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/UITests/iOSAppUITestSuite.xctest",
+            "p": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/UITests/iOSAppUITestSuite.__internal__.__test_bundle_archive-root/iOSAppUITestSuite.xctest",
             "t": "com.apple.product-type.bundle.ui-testing"
         },
         "r": [
@@ -9651,7 +9651,7 @@
             "e": "iOSAppObjCUnitTestSuite",
             "m": "iOSAppObjCUnitTestSuite",
             "n": "iOSAppObjCUnitTestSuite",
-            "p": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTestSuite.xctest",
+            "p": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTestSuite.__internal__.__test_bundle_archive-root/iOSAppObjCUnitTestSuite.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         },
         "r": [
@@ -9696,7 +9696,7 @@
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.example.tests",
             "PRODUCT_MODULE_NAME": "iOSAppSwiftUnitTestSuite",
             "SWIFT_COMPILATION_MODE": "wholemodule",
-            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-9/bin/Lib $(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/UI/UIFramework.iOS.framework/Modules $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-9/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer $(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Source $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-9/bin/iOSApp/Test/TestingUtils",
+            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-9/bin/Lib $(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/UI/UIFramework.iOS.zip/Modules $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-9/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer $(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Source $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-opt-STABLE-9/bin/iOSApp/Test/TestingUtils",
             "TARGETED_DEVICE_FAMILY": "1,2"
         },
         "c": "applebin_ios-ios_x86_64-opt-STABLE-17",
@@ -9733,7 +9733,7 @@
             "e": "iOSAppSwiftUnitTestSuite",
             "m": "iOSAppSwiftUnitTestSuite",
             "n": "iOSAppSwiftUnitTestSuite",
-            "p": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTestSuite.xctest",
+            "p": "bazel-out/applebin_ios-ios_x86_64-opt-STABLE-17/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTestSuite.__internal__.__test_bundle_archive-root/iOSAppSwiftUnitTestSuite.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         },
         "x": [
@@ -13021,7 +13021,7 @@
             "e": "CommandLineToolTests",
             "m": "CommandLineToolTests",
             "n": "CommandLineToolTests",
-            "p": "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-46/bin/CommandLine/Tests/CommandLineToolTests.xctest",
+            "p": "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-46/bin/CommandLine/Tests/CommandLineToolTests.__internal__.__test_bundle_archive-root/CommandLineToolTests.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         },
         "x": [
@@ -13135,7 +13135,7 @@
             "e": "AppClip",
             "m": "AppClip",
             "n": "AppClip",
-            "p": "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/AppClip/AppClip.app",
+            "p": "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/AppClip/AppClip_archive-root/Payload/AppClip.app",
             "t": "com.apple.product-type.application.on-demand-install-capable"
         },
         "x": [
@@ -13281,7 +13281,7 @@
             "e": "WidgetExtension",
             "m": "WidgetExtension",
             "n": "WidgetExtension",
-            "p": "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/WidgetExtension/WidgetExtension.appex",
+            "p": "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/WidgetExtension/WidgetExtension_archive-root/WidgetExtension.appex",
             "t": "com.apple.product-type.app-extension"
         },
         "x": [
@@ -13335,7 +13335,7 @@
             "e": "CoreUtilsObjC",
             "m": "CoreUtilsObjC",
             "n": "CoreUtilsObjC",
-            "p": "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Source/CoreUtilsObjC/CoreUtilsObjC.framework",
+            "p": "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Source/CoreUtilsObjC/FrameworkCoreUtilsObjC_archive-root/CoreUtilsObjC.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -13382,7 +13382,7 @@
             "e": "LibFramework.iOS",
             "m": "LibFramework.iOS",
             "n": "LibFramework.iOS",
-            "p": "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/Lib/LibFramework.iOS.framework",
+            "p": "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/Lib/LibFramework.iOS_archive-root/LibFramework.iOS.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -13419,7 +13419,7 @@
             "OTHER_SWIFT_FLAGS": "-F$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7 -Xcc -F -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7 -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-12/bin/external/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(PROJECT_DIR) -Xcc -iquote -Xcc $(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-12/bin -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework/Modules/module.modulemap -Xcc -Os -Xcc -DNDEBUG=1 -Xcc -Wno-unused-variable -Xcc -Winit-self -Xcc -Wno-extra",
             "PREVIEWS_SWIFT_INCLUDE__": "",
             "PREVIEWS_SWIFT_INCLUDE__NO": "",
-            "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/UI/UIFramework.iOS.framework/Modules",
+            "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/UI/UIFramework.iOS.zip/Modules",
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.UIFramework",
             "PRODUCT_MODULE_NAME": "UI",
             "SWIFT_COMPILATION_MODE": "wholemodule",
@@ -13455,7 +13455,7 @@
             "e": "UIFramework.iOS",
             "m": "UIFramework.iOS",
             "n": "UIFramework.iOS",
-            "p": "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/UI/UIFramework.iOS.framework",
+            "p": "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/UI/UIFramework.iOS_archive-root/UIFramework.iOS.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -13541,7 +13541,7 @@
             "e": "LibFramework.watchOS",
             "m": "LibFramework.watchOS",
             "n": "LibFramework.watchOS",
-            "p": "bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-22/bin/Lib/LibFramework.watchOS.framework",
+            "p": "bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-22/bin/Lib/LibFramework.watchOS_archive-root/LibFramework.watchOS.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -13578,7 +13578,7 @@
             "OTHER_SWIFT_FLAGS": "-F$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k -Xcc -F -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(BAZEL_OUT)/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-opt-STABLE-13/bin/external/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(PROJECT_DIR) -Xcc -iquote -Xcc $(BAZEL_OUT)/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-opt-STABLE-13/bin -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k/CryptoSwift.framework/Modules/module.modulemap -Xcc -Os -Xcc -DNDEBUG=1 -Xcc -Wno-unused-variable -Xcc -Winit-self -Xcc -Wno-extra",
             "PREVIEWS_SWIFT_INCLUDE__": "",
             "PREVIEWS_SWIFT_INCLUDE__NO": "",
-            "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-22/bin/UI/UIFramework.watchOS.framework/Modules",
+            "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-22/bin/UI/UIFramework.watchOS.zip/Modules",
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.UIFramework",
             "PRODUCT_MODULE_NAME": "UI",
             "SWIFT_COMPILATION_MODE": "wholemodule",
@@ -13610,7 +13610,7 @@
             "e": "UIFramework.watchOS",
             "m": "UIFramework.watchOS",
             "n": "UIFramework.watchOS",
-            "p": "bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-22/bin/UI/UIFramework.watchOS.framework",
+            "p": "bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-22/bin/UI/UIFramework.watchOS_archive-root/UIFramework.watchOS.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -13653,7 +13653,7 @@
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.example.watch.extension",
             "PRODUCT_MODULE_NAME": "watchOSAppExtension",
             "SWIFT_COMPILATION_MODE": "wholemodule",
-            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-opt-STABLE-13/bin/Lib $(BUILD_DIR)/bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-22/bin/UI/UIFramework.watchOS.framework/Modules"
+            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-opt-STABLE-13/bin/Lib $(BUILD_DIR)/bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-22/bin/UI/UIFramework.watchOS.zip/Modules"
         },
         "c": "applebin_watchos-watchos_arm64_32-opt-STABLE-22",
         "d": [
@@ -13683,7 +13683,7 @@
             "e": "watchOSAppExtension",
             "m": "watchOSAppExtension",
             "n": "watchOSAppExtension",
-            "p": "bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-22/bin/watchOSAppExtension/watchOSAppExtension.appex",
+            "p": "bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-22/bin/watchOSAppExtension/watchOSAppExtension_archive-root/watchOSAppExtension.appex",
             "t": "com.apple.product-type.watchkit2-extension"
         },
         "x": [
@@ -13724,7 +13724,7 @@
             "e": "watchOSApp",
             "m": "watchOSApp",
             "n": "watchOSApp",
-            "p": "bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-26/bin/watchOSApp/watchOSApp.app",
+            "p": "bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-26/bin/watchOSApp/watchOSApp_archive-root/Payload/watchOSApp.app",
             "t": "com.apple.product-type.application.watchapp2"
         },
         "x": [
@@ -13772,7 +13772,7 @@
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.example",
             "PRODUCT_MODULE_NAME": "iOSApp",
             "SWIFT_COMPILATION_MODE": "wholemodule",
-            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-12/bin/Lib $(BUILD_DIR)/bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/UI/UIFramework.iOS.framework/Modules $(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-12/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer",
+            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-12/bin/Lib $(BUILD_DIR)/bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/UI/UIFramework.iOS.zip/Modules $(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-12/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer",
             "TARGETED_DEVICE_FAMILY": "1"
         },
         "c": "applebin_ios-ios_arm64-opt-STABLE-18",
@@ -13825,7 +13825,7 @@
             "e": "iOSApp",
             "m": "iOSApp",
             "n": "iOSApp",
-            "p": "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Source/iOSApp.app",
+            "p": "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Source/iOSApp_archive-root/Payload/iOSApp.app",
             "t": "com.apple.product-type.application"
         },
         "r": [
@@ -13877,7 +13877,7 @@
             "e": "Lib",
             "m": "Lib",
             "n": "Lib",
-            "p": "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/Lib/dist/dynamic/Lib.framework",
+            "p": "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/Lib/dist/dynamic/iOS_archive-root/Lib.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -13963,7 +13963,7 @@
             "e": "Lib",
             "m": "Lib",
             "n": "Lib",
-            "p": "bazel-out/applebin_tvos-tvos_arm64-opt-STABLE-30/bin/Lib/dist/dynamic/Lib.framework",
+            "p": "bazel-out/applebin_tvos-tvos_arm64-opt-STABLE-30/bin/Lib/dist/dynamic/tvOS_archive-root/Lib.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -14009,7 +14009,7 @@
             "e": "Lib",
             "m": "Lib",
             "n": "Lib",
-            "p": "bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-22/bin/Lib/dist/dynamic/Lib.framework",
+            "p": "bazel-out/applebin_watchos-watchos_arm64_32-opt-STABLE-22/bin/Lib/dist/dynamic/watchOS_archive-root/Lib.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -14055,7 +14055,7 @@
             "e": "LibFramework.tvOS",
             "m": "LibFramework.tvOS",
             "n": "LibFramework.tvOS",
-            "p": "bazel-out/applebin_tvos-tvos_arm64-opt-STABLE-30/bin/Lib/LibFramework.tvOS.framework",
+            "p": "bazel-out/applebin_tvos-tvos_arm64-opt-STABLE-30/bin/Lib/LibFramework.tvOS_archive-root/LibFramework.tvOS.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -14092,7 +14092,7 @@
             "OTHER_SWIFT_FLAGS": "-F$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64 -Xcc -F -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64 -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(BAZEL_OUT)/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-opt-STABLE-14/bin/external/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(PROJECT_DIR) -Xcc -iquote -Xcc $(BAZEL_OUT)/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-opt-STABLE-14/bin -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64/CryptoSwift.framework/Modules/module.modulemap -Xcc -Os -Xcc -DNDEBUG=1 -Xcc -Wno-unused-variable -Xcc -Winit-self -Xcc -Wno-extra",
             "PREVIEWS_SWIFT_INCLUDE__": "",
             "PREVIEWS_SWIFT_INCLUDE__NO": "",
-            "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/applebin_tvos-tvos_arm64-opt-STABLE-30/bin/UI/UIFramework.tvOS.framework/Modules",
+            "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/applebin_tvos-tvos_arm64-opt-STABLE-30/bin/UI/UIFramework.tvOS.zip/Modules",
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.UIFramework",
             "PRODUCT_MODULE_NAME": "UI",
             "SWIFT_COMPILATION_MODE": "wholemodule",
@@ -14124,7 +14124,7 @@
             "e": "UIFramework.tvOS",
             "m": "UIFramework.tvOS",
             "n": "UIFramework.tvOS",
-            "p": "bazel-out/applebin_tvos-tvos_arm64-opt-STABLE-30/bin/UI/UIFramework.tvOS.framework",
+            "p": "bazel-out/applebin_tvos-tvos_arm64-opt-STABLE-30/bin/UI/UIFramework.tvOS_archive-root/UIFramework.tvOS.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -14166,7 +14166,7 @@
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.example",
             "PRODUCT_MODULE_NAME": "tvOSApp",
             "SWIFT_COMPILATION_MODE": "wholemodule",
-            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-opt-STABLE-14/bin/Lib $(BUILD_DIR)/bazel-out/applebin_tvos-tvos_arm64-opt-STABLE-30/bin/UI/UIFramework.tvOS.framework/Modules"
+            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-opt-STABLE-14/bin/Lib $(BUILD_DIR)/bazel-out/applebin_tvos-tvos_arm64-opt-STABLE-30/bin/UI/UIFramework.tvOS.zip/Modules"
         },
         "c": "applebin_tvos-tvos_arm64-opt-STABLE-30",
         "d": [
@@ -14196,7 +14196,7 @@
             "e": "tvOSApp",
             "m": "tvOSApp",
             "n": "tvOSApp",
-            "p": "bazel-out/applebin_tvos-tvos_arm64-opt-STABLE-30/bin/tvOSApp/Source/tvOSApp.app",
+            "p": "bazel-out/applebin_tvos-tvos_arm64-opt-STABLE-30/bin/tvOSApp/Source/tvOSApp_archive-root/Payload/tvOSApp.app",
             "t": "com.apple.product-type.application"
         },
         "x": [
@@ -14369,7 +14369,7 @@
             "e": "iOSAppObjCUnitTests",
             "m": "iOSAppObjCUnitTests",
             "n": "iOSAppObjCUnitTests",
-            "p": "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.xctest",
+            "p": "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.__internal__.__test_bundle_archive-root/iOSAppObjCUnitTests.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         },
         "r": [
@@ -14430,7 +14430,7 @@
             "e": "iOSAppUITests",
             "m": "iOSAppUITests",
             "n": "iOSAppUITests",
-            "p": "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Test/UITests/iOSAppUITests.xctest",
+            "p": "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Test/UITests/iOSAppUITests.__internal__.__test_bundle_archive-root/iOSAppUITests.xctest",
             "t": "com.apple.product-type.bundle.ui-testing"
         },
         "r": [
@@ -14475,7 +14475,7 @@
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.example.tests",
             "PRODUCT_MODULE_NAME": "iOSAppSwiftUnitTests",
             "SWIFT_COMPILATION_MODE": "wholemodule",
-            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-12/bin/Lib $(BUILD_DIR)/bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/UI/UIFramework.iOS.framework/Modules $(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-12/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer $(BUILD_DIR)/bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Source $(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-12/bin/iOSApp/Test/TestingUtils",
+            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-12/bin/Lib $(BUILD_DIR)/bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/UI/UIFramework.iOS.zip/Modules $(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-12/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer $(BUILD_DIR)/bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Source $(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-opt-STABLE-12/bin/iOSApp/Test/TestingUtils",
             "TARGETED_DEVICE_FAMILY": "1,2"
         },
         "c": "applebin_ios-ios_arm64-opt-STABLE-18",
@@ -14512,7 +14512,7 @@
             "e": "iOSAppSwiftUnitTests",
             "m": "iOSAppSwiftUnitTests",
             "n": "iOSAppSwiftUnitTests",
-            "p": "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.xctest",
+            "p": "bazel-out/applebin_ios-ios_arm64-opt-STABLE-18/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.__internal__.__test_bundle_archive-root/iOSAppSwiftUnitTests.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         },
         "x": [

--- a/examples/integration/xcodeproj.bazelrc
+++ b/examples/integration/xcodeproj.bazelrc
@@ -1,5 +1,5 @@
 # Import parent workspace settings
 import %workspace%/../../xcodeproj.bazelrc
 
-# Disabling archived bundles for fixture coverage
-build:rules_xcodeproj --define=apple.experimental.tree_artifact_outputs=1
+# Disabling tree artifact bundles for fixture coverage
+build:rules_xcodeproj --define=apple.experimental.tree_artifact_outputs=0


### PR DESCRIPTION
We enable it by default in `templates/xcodeproj.bazelrc`, so to actually have more coverage we should disable it. Plus, it doesn’t work with rules_apple 3.0’s macOS imported versioned frameworks.