### PR TITLE
Upgrade development versions of rules_apple and rules_swift

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -55,12 +55,12 @@ bazel_dep(
 # To support Bazel 7 tests
 single_version_override(
     module_name = "rules_apple",
-    version = "2.5.0",
+    version = "3.0.0-rc2",
 )
 
 single_version_override(
     module_name = "rules_swift",
-    version = "1.9.1",
+    version = "1.11.0",
 )
 
 # For Stardoc

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,5 +1,14 @@
 workspace(name = "rules_xcodeproj")
 
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+# Remove override once `xcodeproj/repositories.bzl` updates to use `rules_apple` 3.0.0+
+http_archive(
+    name = "build_bazel_rules_apple",
+    sha256 = "2c6ab2f5903a4487f2cf31ec3f2f3a71244ec159dd94c3fde339ee23193df791",
+    url = "https://github.com/bazelbuild/rules_apple/releases/download/3.0.0-rc2/rules_apple.3.0.0-rc2.tar.gz",
+)
+
 load(
     "//xcodeproj:repositories.bzl",
     "xcodeproj_rules_dependencies",
@@ -46,8 +55,6 @@ load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 bazel_skylib_workspace()
 
 # Buildifier
-
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "buildifier_prebuilt",

--- a/test/fixtures/generator/bazel-6/bwb_replacements.txt
+++ b/test/fixtures/generator/bazel-6/bwb_replacements.txt
@@ -1,5 +1,3 @@
 darwin_x86_64-dbg-STABLE-0 darwin_x86_64-dbg-ST-fb246a0fc873
-macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1 macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-9ea119188318
-macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2 macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-ST-92b12c3a181f
-applebin_macos-darwin_x86_64-dbg-STABLE-3 applebin_macos-darwin_x86_64-dbg-ST-9ea119188318
-applebin_macos-darwin_x86_64-opt-STABLE-4 applebin_macos-darwin_x86_64-opt-ST-92b12c3a181f
+macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1 macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-223aa264b5c1
+macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2 macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-ST-9ea2151e74a8

--- a/test/fixtures/generator/bazel-6/bwx_replacements.txt
+++ b/test/fixtures/generator/bazel-6/bwx_replacements.txt
@@ -1,5 +1,3 @@
 darwin_x86_64-dbg-STABLE-0 darwin_x86_64-dbg-ST-fb246a0fc873
-macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1 macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-9ea119188318
-macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2 macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-ST-92b12c3a181f
-applebin_macos-darwin_x86_64-dbg-STABLE-3 applebin_macos-darwin_x86_64-dbg-ST-9ea119188318
-applebin_macos-darwin_x86_64-opt-STABLE-4 applebin_macos-darwin_x86_64-opt-ST-92b12c3a181f
+macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1 macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-223aa264b5c1
+macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2 macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-ST-9ea2151e74a8

--- a/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
@@ -626,7 +626,6 @@
 		5BE070D9781D6B77B2683AC4 /* PBXCopyFilesBuildPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXCopyFilesBuildPhase.swift; sourceTree = "<group>"; };
 		5C430A0507269479E384ABA8 /* XCScheme+CommandLineArguments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCScheme+CommandLineArguments.swift"; sourceTree = "<group>"; };
 		5C617A96AA2CCB43B5A0091A /* CustomDumpRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomDumpRepresentable.swift; sourceTree = "<group>"; };
-		5C6E9E7C3135454001612B4D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		5C7789EE6302CB13CB188CAB /* OrderedSet+Partial SetAlgebra+Predicates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderedSet+Partial SetAlgebra+Predicates.swift"; sourceTree = "<group>"; };
 		5C88CDFBE298CE4246EDCF65 /* ParsableCommand+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ParsableCommand+Extensions.swift"; sourceTree = "<group>"; };
 		5CF908C0E77612D34EA9E0A9 /* OrderedSet+Partial MutableCollection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderedSet+Partial MutableCollection.swift"; sourceTree = "<group>"; };
@@ -751,7 +750,6 @@
 		A7A48D730D4F30044A4EDC84 /* XCScheme+EnvironmentVariable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCScheme+EnvironmentVariable.swift"; sourceTree = "<group>"; };
 		A7BDD717A33A96A229C177B1 /* CoreLocation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreLocation.swift; sourceTree = "<group>"; };
 		A952722F65B7419585B1B350 /* XCSchemeInfo+TestActionInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCSchemeInfo+TestActionInfoTests.swift"; sourceTree = "<group>"; };
-		AA313C2415B7402625634AF7 /* DefaultTestBundle.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = DefaultTestBundle.plist; sourceTree = "<group>"; };
 		AA7B45ABDF18A4874EC58F85 /* Bool+Extras.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bool+Extras.swift"; sourceTree = "<group>"; };
 		AA823FB63040E3B95F398281 /* Platform.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Platform.swift; sourceTree = "<group>"; };
 		AB1A5A35984CEB50A5C3CEAC /* OrderedDictionary+ExpressibleByDictionaryLiteral.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderedDictionary+ExpressibleByDictionaryLiteral.swift"; sourceTree = "<group>"; };
@@ -771,9 +769,11 @@
 		B473DA99016CA4C41B5D9800 /* HelpGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelpGenerator.swift; sourceTree = "<group>"; };
 		B4E97230254B35A23EAE9050 /* RandomAccessCollection+Offsets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RandomAccessCollection+Offsets.swift"; sourceTree = "<group>"; };
 		B6EB7D82139922F56275625A /* XCSchemeManagement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCSchemeManagement.swift; sourceTree = "<group>"; };
+		B7670183A78817EAE5A305EB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		B85429EF95F37D1D26FA680D /* AnyType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyType.swift; sourceTree = "<group>"; };
 		B881977DCED685324AEC5ABF /* PBXTargetDependency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXTargetDependency.swift; sourceTree = "<group>"; };
 		B8A6DACA1C2105871343B97A /* XcodeScheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcodeScheme.swift; sourceTree = "<group>"; };
+		BB0A6EEF8A2AE95800B08005 /* DefaultTestBundle.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = DefaultTestBundle.plist; sourceTree = "<group>"; };
 		BB3FF798D71A31AAE9690F88 /* CreateXCUserDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateXCUserDataTests.swift; sourceTree = "<group>"; };
 		BC28B824693894C1F6928CB1 /* ArgumentDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArgumentDecoder.swift; sourceTree = "<group>"; };
 		BCE1D41692794D2864474176 /* XCSchemeInfo+BuildActionInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCSchemeInfo+BuildActionInfo.swift"; sourceTree = "<group>"; };
@@ -815,6 +815,7 @@
 		D5349AAE2DF288928D978108 /* FishCompletionsGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FishCompletionsGenerator.swift; sourceTree = "<group>"; };
 		D5D1FD7CF7B3A75B4595060C /* XCBuildConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCBuildConfiguration.swift; sourceTree = "<group>"; };
 		D5E5E615A113FFB8B140036C /* XcodeScheme+ExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XcodeScheme+ExtensionsTests.swift"; sourceTree = "<group>"; };
+		D64CACB3BC498B6654964C8E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		D6CDCB366A3A8DEF77206FD2 /* _HashTable+UnsafeHandle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "_HashTable+UnsafeHandle.swift"; sourceTree = "<group>"; };
 		D6EACDD72E253E7DA520F992 /* Array+Extras.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Extras.swift"; sourceTree = "<group>"; };
 		D707A379373ABF6913737C92 /* XCSchemeInfo+BuildActionInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCSchemeInfo+BuildActionInfoTests.swift"; sourceTree = "<group>"; };
@@ -880,7 +881,6 @@
 		FEACA49DF99058FFC18210C7 /* Path+Extras.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Path+Extras.swift"; sourceTree = "<group>"; };
 		FECD586FE1B817B41DACAD6B /* JSONDecoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONDecoding.swift; sourceTree = "<group>"; };
 		FEF2EFB7DAB07E70728C1B44 /* PBXTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXTarget.swift; sourceTree = "<group>"; };
-		FF270A44CAD39AF36B085558 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXGroup section */
@@ -965,9 +965,18 @@
 		0AEE3C7703E1CA78CC93537E /* test */ = {
 			isa = PBXGroup;
 			children = (
+				CC2B05A9F1C6E621112C60E9 /* rules_xcodeproj */,
 				F7D44872AC5A1D69EAB382F9 /* tests.library.rules_xcodeproj.swift.compile.params */,
 			);
 			path = test;
+			sourceTree = "<group>";
+		};
+		0E7E181F78CFA89E9B521549 /* testing */ = {
+			isa = PBXGroup;
+			children = (
+				BB0A6EEF8A2AE95800B08005 /* DefaultTestBundle.plist */,
+			);
+			path = testing;
 			sourceTree = "<group>";
 		};
 		0F1B8D9BDE1B13E7166E7ADC /* Targets */ = {
@@ -1023,14 +1032,6 @@
 			path = "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2";
 			sourceTree = "<group>";
 		};
-		21B866434BE8CCE8B8AD75B3 /* rules_xcodeproj */ = {
-			isa = PBXGroup;
-			children = (
-				70F649E63B3CD9C18B2A85C2 /* tests.__internal__.__test_bundle */,
-			);
-			path = rules_xcodeproj;
-			sourceTree = "<group>";
-		};
 		228469FDAD737A1830C596EC /* _main~internal~rules_xcodeproj_generated */ = {
 			isa = PBXGroup;
 			children = (
@@ -1051,14 +1052,6 @@
 				0F1B8D9BDE1B13E7166E7ADC /* Targets */,
 			);
 			path = Objects;
-			sourceTree = "<group>";
-		};
-		252AA09E1F8144D182EBED3F /* applebin_macos-darwin_x86_64-opt-STABLE-4 */ = {
-			isa = PBXGroup;
-			children = (
-				2A9C4B959DB72FA58DF637BC /* bin */,
-			);
-			path = "applebin_macos-darwin_x86_64-opt-STABLE-4";
 			sourceTree = "<group>";
 		};
 		25B5C6F709CACAFE4486C58F /* src */ = {
@@ -1171,20 +1164,20 @@
 			path = test;
 			sourceTree = "<group>";
 		};
-		2A9C4B959DB72FA58DF637BC /* bin */ = {
-			isa = PBXGroup;
-			children = (
-				DA56333831A06A4495B5F6E8 /* tools */,
-			);
-			path = bin;
-			sourceTree = "<group>";
-		};
 		2BC27CCFBADC9110F85C3625 /* ArgumentParserToolInfo */ = {
 			isa = PBXGroup;
 			children = (
 				83EC040C3735CA33CD34DB7E /* ToolInfo.swift */,
 			);
 			path = ArgumentParserToolInfo;
+			sourceTree = "<group>";
+		};
+		3028B9ECF807CD6E459FD3F2 /* rules_apple~3.0.0-rc2 */ = {
+			isa = PBXGroup;
+			children = (
+				F0695EAE951F2B68B675C509 /* apple */,
+			);
+			path = "rules_apple~3.0.0-rc2";
 			sourceTree = "<group>";
 		};
 		321788B13AACB7C433ABA337 /* Completions */ = {
@@ -1198,14 +1191,6 @@
 			path = Completions;
 			sourceTree = "<group>";
 		};
-		33435D88F19E20B3E5A23E9A /* applebin_macos-darwin_x86_64-dbg-STABLE-3 */ = {
-			isa = PBXGroup;
-			children = (
-				3482671A9DA5204C896FB34C /* bin */,
-			);
-			path = "applebin_macos-darwin_x86_64-dbg-STABLE-3";
-			sourceTree = "<group>";
-		};
 		33BAAE70DB8081EEDDE0AFD1 /* Sourcery */ = {
 			isa = PBXGroup;
 			children = (
@@ -1213,14 +1198,6 @@
 				43503B2DED4595C2A2B237DD /* Sourcery.swift */,
 			);
 			path = Sourcery;
-			sourceTree = "<group>";
-		};
-		3482671A9DA5204C896FB34C /* bin */ = {
-			isa = PBXGroup;
-			children = (
-				B335F74E012F1A8ACCCBA2F1 /* tools */,
-			);
-			path = bin;
 			sourceTree = "<group>";
 		};
 		37F775C1CBC98221E8ABA078 /* OrderedSet */ = {
@@ -1256,8 +1233,6 @@
 		38D12FD81F17842A5E5276F9 /* Bazel Generated Files */ = {
 			isa = PBXGroup;
 			children = (
-				33435D88F19E20B3E5A23E9A /* applebin_macos-darwin_x86_64-dbg-STABLE-3 */,
-				252AA09E1F8144D182EBED3F /* applebin_macos-darwin_x86_64-opt-STABLE-4 */,
 				EE297CCC0A7F8A721EA38521 /* darwin_x86_64-dbg-STABLE-0 */,
 				E867720C8D92A07E91C12350 /* macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1 */,
 				210812BB66D9256E553B16F2 /* macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2 */,
@@ -1389,6 +1364,22 @@
 			path = fixtures;
 			sourceTree = "<group>";
 		};
+		52E719A148AC45CD1E76E1C1 /* tests.__internal__.__test_bundle */ = {
+			isa = PBXGroup;
+			children = (
+				D64CACB3BC498B6654964C8E /* Info.plist */,
+			);
+			path = tests.__internal__.__test_bundle;
+			sourceTree = "<group>";
+		};
+		5342815A4AF36E8EE1CB7709 /* tests.__internal__.__test_bundle */ = {
+			isa = PBXGroup;
+			children = (
+				B7670183A78817EAE5A305EB /* Info.plist */,
+			);
+			path = tests.__internal__.__test_bundle;
+			sourceTree = "<group>";
+		};
 		53EFC84B94B5385F208B2BDD /* test */ = {
 			isa = PBXGroup;
 			children = (
@@ -1447,14 +1438,6 @@
 				7DA13C8D11F56CEE790D94FA /* xcodeproj_bwb */,
 			);
 			path = generator;
-			sourceTree = "<group>";
-		};
-		610344B4697DCFDF54061D54 /* testing */ = {
-			isa = PBXGroup;
-			children = (
-				AA313C2415B7402625634AF7 /* DefaultTestBundle.plist */,
-			);
-			path = testing;
 			sourceTree = "<group>";
 		};
 		62468B1793F1051EEE269F38 /* Vendor */ = {
@@ -1541,14 +1524,6 @@
 			path = external;
 			sourceTree = "<group>";
 		};
-		70F649E63B3CD9C18B2A85C2 /* tests.__internal__.__test_bundle */ = {
-			isa = PBXGroup;
-			children = (
-				FF270A44CAD39AF36B085558 /* Info.plist */,
-			);
-			path = tests.__internal__.__test_bundle;
-			sourceTree = "<group>";
-		};
 		75AC80F376BF6A92501F2945 /* legacy */ = {
 			isa = PBXGroup;
 			children = (
@@ -1564,14 +1539,6 @@
 				8B656F04CF5DC780CBFBE9CA /* XcodeProj.rules_xcodeproj.swift.compile.params */,
 			);
 			path = "_main~non_module_deps~com_github_tuist_xcodeproj";
-			sourceTree = "<group>";
-		};
-		7CBDA19A3A934A200A591E01 /* generators */ = {
-			isa = PBXGroup;
-			children = (
-				F8FD0316ED497CF4B77C8DB2 /* legacy */,
-			);
-			path = generators;
 			sourceTree = "<group>";
 		};
 		7DA13C8D11F56CEE790D94FA /* xcodeproj_bwb */ = {
@@ -1635,14 +1602,6 @@
 				C3B23B0AEE29FBCD2AB77592 /* Unordered.swift */,
 			);
 			path = Internal;
-			sourceTree = "<group>";
-		};
-		876225B2B9110B4B2218FDC4 /* apple */ = {
-			isa = PBXGroup;
-			children = (
-				610344B4697DCFDF54061D54 /* testing */,
-			);
-			path = apple;
 			sourceTree = "<group>";
 		};
 		891FF4EFB55BD0CCB8B61ED5 /* Products */ = {
@@ -1798,28 +1757,12 @@
 			path = ../../../../..;
 			sourceTree = "<group>";
 		};
-		A0D1C22FF3AD5C1EAB74C79B /* test */ = {
-			isa = PBXGroup;
-			children = (
-				21B866434BE8CCE8B8AD75B3 /* rules_xcodeproj */,
-			);
-			path = test;
-			sourceTree = "<group>";
-		};
 		A1126B546172ED807029842B /* _main~non_module_deps~com_github_michaeleisel_zippyjsoncfamily */ = {
 			isa = PBXGroup;
 			children = (
 				1B668480703B6D851F1C7721 /* ZippyJSONCFamily.rules_xcodeproj.cxx.compile.params */,
 			);
 			path = "_main~non_module_deps~com_github_michaeleisel_zippyjsoncfamily";
-			sourceTree = "<group>";
-		};
-		A288FAF9852E460C0828650E /* rules_apple~2.5.0 */ = {
-			isa = PBXGroup;
-			children = (
-				876225B2B9110B4B2218FDC4 /* apple */,
-			);
-			path = "rules_apple~2.5.0";
 			sourceTree = "<group>";
 		};
 		A322674DDDA4C08515E6E55F /* _main~dev_non_module_deps~com_github_pointfreeco_xctest_dynamic_overlay */ = {
@@ -1939,14 +1882,6 @@
 			path = generator;
 			sourceTree = "<group>";
 		};
-		B335F74E012F1A8ACCCBA2F1 /* tools */ = {
-			isa = PBXGroup;
-			children = (
-				7CBDA19A3A934A200A591E01 /* generators */,
-			);
-			path = tools;
-			sourceTree = "<group>";
-		};
 		B4ECE17402E9D24B93FA1222 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
@@ -1962,14 +1897,6 @@
 				8D8BD2E240F0BCE57A50B76B /* String+Utils.swift */,
 			);
 			path = Extensions;
-			sourceTree = "<group>";
-		};
-		B5AE60E02B1F4A8EA9691D62 /* generators */ = {
-			isa = PBXGroup;
-			children = (
-				C8872F3D3844EA31E27D97B9 /* legacy */,
-			);
-			path = generators;
 			sourceTree = "<group>";
 		};
 		B6B0A10D2345BC57163DDFC6 /* Parsable Types */ = {
@@ -2053,14 +1980,6 @@
 			path = SwiftPackage;
 			sourceTree = "<group>";
 		};
-		C73962C962DED5A90A9DE344 /* test */ = {
-			isa = PBXGroup;
-			children = (
-				F4DE122E1B2FEA1DA5B7CBC7 /* rules_xcodeproj */,
-			);
-			path = test;
-			sourceTree = "<group>";
-		};
 		C813B871D7EEA00D586EE80E /* _main~non_module_deps~com_github_kylef_pathkit */ = {
 			isa = PBXGroup;
 			children = (
@@ -2069,12 +1988,12 @@
 			path = "_main~non_module_deps~com_github_kylef_pathkit";
 			sourceTree = "<group>";
 		};
-		C8872F3D3844EA31E27D97B9 /* legacy */ = {
+		CC2B05A9F1C6E621112C60E9 /* rules_xcodeproj */ = {
 			isa = PBXGroup;
 			children = (
-				A0D1C22FF3AD5C1EAB74C79B /* test */,
+				52E719A148AC45CD1E76E1C1 /* tests.__internal__.__test_bundle */,
 			);
-			path = legacy;
+			path = rules_xcodeproj;
 			sourceTree = "<group>";
 		};
 		CC9D70B3157CD0E7D85C6183 /* Scheme */ = {
@@ -2134,22 +2053,6 @@
 				16B5551ACB57DD727C445292 /* String+Extensions.swift */,
 			);
 			path = src;
-			sourceTree = "<group>";
-		};
-		DA274BAFE16372A4F6BA982C /* tests.__internal__.__test_bundle */ = {
-			isa = PBXGroup;
-			children = (
-				5C6E9E7C3135454001612B4D /* Info.plist */,
-			);
-			path = tests.__internal__.__test_bundle;
-			sourceTree = "<group>";
-		};
-		DA56333831A06A4495B5F6E8 /* tools */ = {
-			isa = PBXGroup;
-			children = (
-				B5AE60E02B1F4A8EA9691D62 /* generators */,
-			);
-			path = tools;
 			sourceTree = "<group>";
 		};
 		DD5E83F87D43755BAC630B79 /* ArgumentParser */ = {
@@ -2221,7 +2124,7 @@
 				BFF815E6BF45DDE0C8C44BB2 /* _main~non_module_deps~com_github_michaeleisel_zippyjson */,
 				DFD561954A13C0D6106D6667 /* _main~non_module_deps~com_github_michaeleisel_zippyjsoncfamily */,
 				82BCCE074CEB533AA68C3F7C /* _main~non_module_deps~com_github_tuist_xcodeproj */,
-				A288FAF9852E460C0828650E /* rules_apple~2.5.0 */,
+				3028B9ECF807CD6E459FD3F2 /* rules_apple~3.0.0-rc2 */,
 			);
 			name = "Bazel External Repositories";
 			path = ../../external;
@@ -2306,9 +2209,18 @@
 		EE434CFF81AB72C7922EE130 /* test */ = {
 			isa = PBXGroup;
 			children = (
+				FECE85E6CBDAE82E65020477 /* rules_xcodeproj */,
 				93AF596055F92A6BA96C2819 /* tests.library.rules_xcodeproj.swift.compile.params */,
 			);
 			path = test;
+			sourceTree = "<group>";
+		};
+		F0695EAE951F2B68B675C509 /* apple */ = {
+			isa = PBXGroup;
+			children = (
+				0E7E181F78CFA89E9B521549 /* testing */,
+			);
+			path = apple;
 			sourceTree = "<group>";
 		};
 		F09E46D6AFE1A3A41D005BCC /* _main~non_module_deps~com_github_apple_swift_collections */ = {
@@ -2349,14 +2261,6 @@
 			);
 			name = rules_xcodeproj;
 			path = test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj;
-			sourceTree = "<group>";
-		};
-		F4DE122E1B2FEA1DA5B7CBC7 /* rules_xcodeproj */ = {
-			isa = PBXGroup;
-			children = (
-				DA274BAFE16372A4F6BA982C /* tests.__internal__.__test_bundle */,
-			);
-			path = rules_xcodeproj;
 			sourceTree = "<group>";
 		};
 		F4E404F9D7F8B81F26D31454 /* _main~non_module_deps~com_github_apple_swift_argument_parser */ = {
@@ -2404,14 +2308,6 @@
 			path = OrderedDictionary;
 			sourceTree = "<group>";
 		};
-		F8FD0316ED497CF4B77C8DB2 /* legacy */ = {
-			isa = PBXGroup;
-			children = (
-				C73962C962DED5A90A9DE344 /* test */,
-			);
-			path = legacy;
-			sourceTree = "<group>";
-		};
 		F989E9AC68245D6CCA90E8A0 /* _main~non_module_deps~com_github_tuist_xcodeproj */ = {
 			isa = PBXGroup;
 			children = (
@@ -2441,6 +2337,14 @@
 				AEACEA030D3F3B5430051907 /* lib */,
 			);
 			path = generators;
+			sourceTree = "<group>";
+		};
+		FECE85E6CBDAE82E65020477 /* rules_xcodeproj */ = {
+			isa = PBXGroup;
+			children = (
+				5342815A4AF36E8EE1CB7709 /* tests.__internal__.__test_bundle */,
+			);
+			path = rules_xcodeproj;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -3979,11 +3883,11 @@
 			buildSettings = {
 				ARCHS = x86_64;
 				BAZEL_LABEL = "@@//tools/generators/legacy:generator";
-				BAZEL_OUTPUTS_DSYM = "\"bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/generators/legacy/generator.dSYM\"";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/generators/legacy/generator_codesigned";
+				BAZEL_OUTPUTS_DSYM = "\"bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/legacy/generator.dSYM\"";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/legacy/generator_codesigned";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = generator_codesigned;
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/generators/legacy";
-				BAZEL_TARGET_ID = "@@//tools/generators/legacy:generator applebin_macos-darwin_x86_64-opt-STABLE-4";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/legacy";
+				BAZEL_TARGET_ID = "@@//tools/generators/legacy:generator macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2";
 				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				COMPILE_TARGET_NAME = generator;
@@ -4007,18 +3911,18 @@
 				BAZEL_COMPILE_TARGET_IDS = "@@//tools/generators/legacy/test:tests.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2";
 				"BAZEL_COMPILE_TARGET_IDS[sdk=macosx*]" = "$(BAZEL_COMPILE_TARGET_IDS)";
 				BAZEL_LABEL = "@@//tools/generators/legacy/test:tests";
-				BAZEL_OUTPUTS_DSYM = "\"bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/generators/legacy/test/tests.xctest.dSYM\"";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/generators/legacy/test/tests.__internal__.__test_bundle.zip";
+				BAZEL_OUTPUTS_DSYM = "\"bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/legacy/test/tests.xctest.dSYM\"";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/legacy/test/tests.__internal__.__test_bundle.zip";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = tests.xctest;
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/generators/legacy/test";
-				BAZEL_TARGET_ID = "@@//tools/generators/legacy/test:tests.__internal__.__test_bundle applebin_macos-darwin_x86_64-opt-STABLE-4";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/legacy/test";
+				BAZEL_TARGET_ID = "@@//tools/generators/legacy/test:tests.__internal__.__test_bundle macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2";
 				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				CODE_SIGN_STYLE = Manual;
 				COMPILE_TARGET_NAME = tests.library;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEPLOYMENT_LOCATION = NO;
-				INFOPLIST_FILE = "$(BAZEL_OUT)/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/generators/legacy/test/rules_xcodeproj/tests.__internal__.__test_bundle/Info.plist";
+				INFOPLIST_FILE = "$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/legacy/test/rules_xcodeproj/tests.__internal__.__test_bundle/Info.plist";
 				LINK_PARAMS_FILE = "$(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-0/bin/external/_main~internal~rules_xcodeproj_generated/generator/test/fixtures/generator/xcodeproj_bwb/xcodeproj_bwb-params/tests.26.link.params";
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "@$(DERIVED_FILE_DIR)/link.params";
@@ -4240,11 +4144,11 @@
 				BAZEL_COMPILE_TARGET_IDS = "@@//tools/swiftc_stub:swiftc_stub.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2";
 				"BAZEL_COMPILE_TARGET_IDS[sdk=macosx*]" = "$(BAZEL_COMPILE_TARGET_IDS)";
 				BAZEL_LABEL = "@@//tools/swiftc_stub:swiftc";
-				BAZEL_OUTPUTS_DSYM = "\"bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/swiftc_stub/swiftc.dSYM\"";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/swiftc_stub/swiftc_codesigned";
+				BAZEL_OUTPUTS_DSYM = "\"bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/swiftc_stub/swiftc.dSYM\"";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/swiftc_stub/swiftc_codesigned";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = swiftc_codesigned;
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/swiftc_stub";
-				BAZEL_TARGET_ID = "@@//tools/swiftc_stub:swiftc applebin_macos-darwin_x86_64-opt-STABLE-4";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/swiftc_stub";
+				BAZEL_TARGET_ID = "@@//tools/swiftc_stub:swiftc macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2";
 				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				COMPILE_TARGET_NAME = swiftc_stub.library;
@@ -4464,10 +4368,10 @@
 				BAZEL_COMPILE_TARGET_IDS = "@@//tools/swiftc_stub:swiftc_stub.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1";
 				"BAZEL_COMPILE_TARGET_IDS[sdk=macosx*]" = "$(BAZEL_COMPILE_TARGET_IDS)";
 				BAZEL_LABEL = "@@//tools/swiftc_stub:swiftc";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-3/bin/tools/swiftc_stub/swiftc_codesigned";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/swiftc_stub/swiftc_codesigned";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = swiftc_codesigned;
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-3/bin/tools/swiftc_stub";
-				BAZEL_TARGET_ID = "@@//tools/swiftc_stub:swiftc applebin_macos-darwin_x86_64-dbg-STABLE-3";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/swiftc_stub";
+				BAZEL_TARGET_ID = "@@//tools/swiftc_stub:swiftc macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1";
 				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				COMPILE_TARGET_NAME = swiftc_stub.library;
@@ -4620,10 +4524,10 @@
 			buildSettings = {
 				ARCHS = x86_64;
 				BAZEL_LABEL = "@@//tools/generators/legacy:generator";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-3/bin/tools/generators/legacy/generator_codesigned";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generators/legacy/generator_codesigned";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = generator_codesigned;
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-3/bin/tools/generators/legacy";
-				BAZEL_TARGET_ID = "@@//tools/generators/legacy:generator applebin_macos-darwin_x86_64-dbg-STABLE-3";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generators/legacy";
+				BAZEL_TARGET_ID = "@@//tools/generators/legacy:generator macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1";
 				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				COMPILE_TARGET_NAME = generator;
@@ -4812,11 +4716,11 @@
 			buildSettings = {
 				ARCHS = x86_64;
 				BAZEL_LABEL = "@@//tools/generators/legacy:generator";
-				BAZEL_OUTPUTS_DSYM = "\"bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/generators/legacy/generator.dSYM\"";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/generators/legacy/generator_codesigned";
+				BAZEL_OUTPUTS_DSYM = "\"bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/legacy/generator.dSYM\"";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/legacy/generator_codesigned";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = generator_codesigned;
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/generators/legacy";
-				BAZEL_TARGET_ID = "@@//tools/generators/legacy:generator applebin_macos-darwin_x86_64-opt-STABLE-4";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/legacy";
+				BAZEL_TARGET_ID = "@@//tools/generators/legacy:generator macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2";
 				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				COMPILE_TARGET_NAME = generator;
@@ -4926,18 +4830,18 @@
 				BAZEL_COMPILE_TARGET_IDS = "@@//tools/generators/legacy/test:tests.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2";
 				"BAZEL_COMPILE_TARGET_IDS[sdk=macosx*]" = "$(BAZEL_COMPILE_TARGET_IDS)";
 				BAZEL_LABEL = "@@//tools/generators/legacy/test:tests";
-				BAZEL_OUTPUTS_DSYM = "\"bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/generators/legacy/test/tests.xctest.dSYM\"";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/generators/legacy/test/tests.__internal__.__test_bundle.zip";
+				BAZEL_OUTPUTS_DSYM = "\"bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/legacy/test/tests.xctest.dSYM\"";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/legacy/test/tests.__internal__.__test_bundle.zip";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = tests.xctest;
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/generators/legacy/test";
-				BAZEL_TARGET_ID = "@@//tools/generators/legacy/test:tests.__internal__.__test_bundle applebin_macos-darwin_x86_64-opt-STABLE-4";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/legacy/test";
+				BAZEL_TARGET_ID = "@@//tools/generators/legacy/test:tests.__internal__.__test_bundle macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2";
 				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				CODE_SIGN_STYLE = Manual;
 				COMPILE_TARGET_NAME = tests.library;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEPLOYMENT_LOCATION = NO;
-				INFOPLIST_FILE = "$(BAZEL_OUT)/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/generators/legacy/test/rules_xcodeproj/tests.__internal__.__test_bundle/Info.plist";
+				INFOPLIST_FILE = "$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/legacy/test/rules_xcodeproj/tests.__internal__.__test_bundle/Info.plist";
 				LINK_PARAMS_FILE = "$(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-0/bin/external/_main~internal~rules_xcodeproj_generated/generator/test/fixtures/generator/xcodeproj_bwb/xcodeproj_bwb-params/tests.26.link.params";
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "@$(DERIVED_FILE_DIR)/link.params";
@@ -4963,16 +4867,16 @@
 				BAZEL_COMPILE_TARGET_IDS = "@@//tools/generators/legacy/test:tests.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1";
 				"BAZEL_COMPILE_TARGET_IDS[sdk=macosx*]" = "$(BAZEL_COMPILE_TARGET_IDS)";
 				BAZEL_LABEL = "@@//tools/generators/legacy/test:tests";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-3/bin/tools/generators/legacy/test/tests.__internal__.__test_bundle.zip";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generators/legacy/test/tests.__internal__.__test_bundle.zip";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = tests.xctest;
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-3/bin/tools/generators/legacy/test";
-				BAZEL_TARGET_ID = "@@//tools/generators/legacy/test:tests.__internal__.__test_bundle applebin_macos-darwin_x86_64-dbg-STABLE-3";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generators/legacy/test";
+				BAZEL_TARGET_ID = "@@//tools/generators/legacy/test:tests.__internal__.__test_bundle macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1";
 				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				CODE_SIGN_STYLE = Manual;
 				COMPILE_TARGET_NAME = tests.library;
 				DEPLOYMENT_LOCATION = NO;
-				INFOPLIST_FILE = "$(BAZEL_OUT)/applebin_macos-darwin_x86_64-dbg-STABLE-3/bin/tools/generators/legacy/test/rules_xcodeproj/tests.__internal__.__test_bundle/Info.plist";
+				INFOPLIST_FILE = "$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generators/legacy/test/rules_xcodeproj/tests.__internal__.__test_bundle/Info.plist";
 				LINK_PARAMS_FILE = "$(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-0/bin/external/_main~internal~rules_xcodeproj_generated/generator/test/fixtures/generator/xcodeproj_bwb/xcodeproj_bwb-params/tests.13.link.params";
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "@$(DERIVED_FILE_DIR)/link.params";
@@ -5106,11 +5010,11 @@
 				BAZEL_COMPILE_TARGET_IDS = "@@//tools/swiftc_stub:swiftc_stub.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2";
 				"BAZEL_COMPILE_TARGET_IDS[sdk=macosx*]" = "$(BAZEL_COMPILE_TARGET_IDS)";
 				BAZEL_LABEL = "@@//tools/swiftc_stub:swiftc";
-				BAZEL_OUTPUTS_DSYM = "\"bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/swiftc_stub/swiftc.dSYM\"";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/swiftc_stub/swiftc_codesigned";
+				BAZEL_OUTPUTS_DSYM = "\"bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/swiftc_stub/swiftc.dSYM\"";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/swiftc_stub/swiftc_codesigned";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = swiftc_codesigned;
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/swiftc_stub";
-				BAZEL_TARGET_ID = "@@//tools/swiftc_stub:swiftc applebin_macos-darwin_x86_64-opt-STABLE-4";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/swiftc_stub";
+				BAZEL_TARGET_ID = "@@//tools/swiftc_stub:swiftc macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2";
 				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				COMPILE_TARGET_NAME = swiftc_stub.library;

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/external.xcfilelist
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/external.xcfilelist
@@ -227,4 +227,4 @@ $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_tuist_xcodeproj/Sources/Xcode
 $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_tuist_xcodeproj/Sources/XcodeProj/Workspace/XCWorkspaceDataElementLocationType.swift
 $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_tuist_xcodeproj/Sources/XcodeProj/Workspace/XCWorkspaceDataFileRef.swift
 $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_tuist_xcodeproj/Sources/XcodeProj/Workspace/XCWorkspaceDataGroup.swift
-$(BAZEL_EXTERNAL)/rules_apple~2.5.0/apple/testing/DefaultTestBundle.plist
+$(BAZEL_EXTERNAL)/rules_apple~3.0.0-rc2/apple/testing/DefaultTestBundle.plist

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/generated.xcfilelist
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/generated.xcfilelist
@@ -1,5 +1,3 @@
-$(BAZEL_OUT)/applebin_macos-darwin_x86_64-dbg-STABLE-3/bin/tools/generators/legacy/test/rules_xcodeproj/tests.__internal__.__test_bundle/Info.plist
-$(BAZEL_OUT)/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/generators/legacy/test/rules_xcodeproj/tests.__internal__.__test_bundle/Info.plist
 $(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-0/bin/external/_main~internal~rules_xcodeproj_generated/generator/test/fixtures/generator/xcodeproj_bwb/xcodeproj_bwb-params/generator.10.link.params
 $(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-0/bin/external/_main~internal~rules_xcodeproj_generated/generator/test/fixtures/generator/xcodeproj_bwb/xcodeproj_bwb-params/generator.25.link.params
 $(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-0/bin/external/_main~internal~rules_xcodeproj_generated/generator/test/fixtures/generator/xcodeproj_bwb/xcodeproj_bwb-params/swiftc.14.link.params
@@ -17,6 +15,7 @@ $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/
 $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/_main~non_module_deps~com_github_michaeleisel_zippyjsoncfamily/ZippyJSONCFamily.rules_xcodeproj.cxx.compile.params
 $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/_main~non_module_deps~com_github_tuist_xcodeproj/XcodeProj.rules_xcodeproj.swift.compile.params
 $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generators/legacy/generator.library.rules_xcodeproj.swift.compile.params
+$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generators/legacy/test/rules_xcodeproj/tests.__internal__.__test_bundle/Info.plist
 $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generators/legacy/test/tests.library.rules_xcodeproj.swift.compile.params
 $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generators/lib/GeneratorCommon/GeneratorCommon.rules_xcodeproj.swift.compile.params
 $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/swiftc_stub/swiftc_stub.library.rules_xcodeproj.swift.compile.params
@@ -29,6 +28,7 @@ $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/
 $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/_main~non_module_deps~com_github_michaeleisel_zippyjsoncfamily/ZippyJSONCFamily.rules_xcodeproj.cxx.compile.params
 $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/_main~non_module_deps~com_github_tuist_xcodeproj/XcodeProj.rules_xcodeproj.swift.compile.params
 $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/legacy/generator.library.rules_xcodeproj.swift.compile.params
+$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/legacy/test/rules_xcodeproj/tests.__internal__.__test_bundle/Info.plist
 $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/legacy/test/tests.library.rules_xcodeproj.swift.compile.params
 $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/lib/GeneratorCommon/GeneratorCommon.rules_xcodeproj.swift.compile.params
 $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/swiftc_stub/swiftc_stub.library.rules_xcodeproj.swift.compile.params

--- a/test/fixtures/generator/bwb_project_spec.json
+++ b/test/fixtures/generator/bwb_project_spec.json
@@ -1,17 +1,17 @@
 {
     "B": "rules_xcodeproj",
     "E": [
-        "@@//tools/generators/legacy/test:tests.__internal__.__test_bundle applebin_macos-darwin_x86_64-dbg-STABLE-3",
+        "@@//tools/generators/legacy/test:tests.__internal__.__test_bundle macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
         {},
-        "@@//tools/generators/legacy/test:tests.__internal__.__test_bundle applebin_macos-darwin_x86_64-opt-STABLE-4",
+        "@@//tools/generators/legacy/test:tests.__internal__.__test_bundle macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2",
         {}
     ],
     "R": "@@//test/fixtures/generator:xcodeproj_bwb",
     "T": "fixture-target-ids-file",
     "e": [
-        "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-3/bin/tools/generators/legacy/test/rules_xcodeproj/tests.__internal__.__test_bundle/Info.plist",
-        "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/generators/legacy/test/rules_xcodeproj/tests.__internal__.__test_bundle/Info.plist",
-        "external/rules_apple~2.5.0/apple/testing/DefaultTestBundle.plist",
+        "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generators/legacy/test/rules_xcodeproj/tests.__internal__.__test_bundle/Info.plist",
+        "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/legacy/test/rules_xcodeproj/tests.__internal__.__test_bundle/Info.plist",
+        "external/rules_apple~3.0.0-rc2/apple/testing/DefaultTestBundle.plist",
         "test/fixtures/generator/BUILD",
         "tools/generators/legacy/BUILD",
         "tools/generators/legacy/test/BUILD",

--- a/test/fixtures/generator/bwb_targets_spec.json
+++ b/test/fixtures/generator/bwb_targets_spec.json
@@ -571,9 +571,9 @@
             "t": "com.apple.product-type.library.static"
         }
     },
-    "@@//tools/generators/legacy:generator applebin_macos-darwin_x86_64-dbg-STABLE-3",
+    "@@//tools/generators/legacy:generator macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
     {
-        "1": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-3/bin/tools/generators/legacy",
+        "1": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generators/legacy",
         "2": {
             "a": "x86_64",
             "m": "12.0",
@@ -581,16 +581,16 @@
         },
         "6": "bazel-out/darwin_x86_64-dbg-STABLE-0/bin/external/_main~internal~rules_xcodeproj_generated/generator/test/fixtures/generator/xcodeproj_bwb/xcodeproj_bwb-params/generator.10.link.params",
         "b": {
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-3/bin/tools/generators/legacy/generator_codesigned",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generators/legacy/generator_codesigned",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "generator_codesigned"
         },
-        "c": "applebin_macos-darwin_x86_64-dbg-STABLE-3",
+        "c": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
         "l": "@@//tools/generators/legacy:generator",
         "n": "generator",
         "p": {
             "e": "generator",
             "n": "generator",
-            "p": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-3/bin/tools/generators/legacy/generator",
+            "p": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generators/legacy/generator",
             "t": "com.apple.product-type.tool"
         }
     },
@@ -685,10 +685,10 @@
             "t": "com.apple.product-type.library.static"
         }
     },
-    "@@//tools/generators/legacy/test:tests.__internal__.__test_bundle applebin_macos-darwin_x86_64-dbg-STABLE-3",
+    "@@//tools/generators/legacy/test:tests.__internal__.__test_bundle macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
     {
         "0": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generators/legacy/test/tests.library.rules_xcodeproj.swift.compile.params",
-        "1": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-3/bin/tools/generators/legacy/test",
+        "1": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generators/legacy/test",
         "2": {
             "a": "x86_64",
             "m": "12.0",
@@ -702,10 +702,10 @@
         ],
         "6": "bazel-out/darwin_x86_64-dbg-STABLE-0/bin/external/_main~internal~rules_xcodeproj_generated/generator/test/fixtures/generator/xcodeproj_bwb/xcodeproj_bwb-params/tests.13.link.params",
         "b": {
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-3/bin/tools/generators/legacy/test/tests.__internal__.__test_bundle.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generators/legacy/test/tests.__internal__.__test_bundle.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "tests.xctest",
             "CODE_SIGN_STYLE": "Manual",
-            "INFOPLIST_FILE": "$(BAZEL_OUT)/applebin_macos-darwin_x86_64-dbg-STABLE-3/bin/tools/generators/legacy/test/rules_xcodeproj/tests.__internal__.__test_bundle/Info.plist",
+            "INFOPLIST_FILE": "$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generators/legacy/test/rules_xcodeproj/tests.__internal__.__test_bundle/Info.plist",
             "OTHER_SWIFT_FLAGS": "-F$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/Library/Frameworks -I$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/usr/lib -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/_main~non_module_deps~com_github_apple_swift_argument_parser -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generators/lib/GeneratorCommon -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/_main~non_module_deps~com_github_apple_swift_collections -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/_main~non_module_deps~com_github_kylef_pathkit -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/_main~non_module_deps~com_github_michaeleisel_zippyjson -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/_main~non_module_deps~com_github_tadija_aexml -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/_main~non_module_deps~com_github_tuist_xcodeproj -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generators/legacy -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/_main~dev_non_module_deps~com_github_pointfreeco_xctest_dynamic_overlay -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/_main~dev_non_module_deps~com_github_pointfreeco_swift_custom_dump -Xcc -I -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_michaeleisel_jjliso8601dateformatter/Sources/JJLISO8601DateFormatter/include -Xcc -I -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/_main~non_module_deps~com_github_michaeleisel_jjliso8601dateformatter/Sources/JJLISO8601DateFormatter/include -Xcc -I -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_michaeleisel_zippyjsoncfamily/Sources/ZippyJSONCFamily/include -Xcc -I -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/_main~non_module_deps~com_github_michaeleisel_zippyjsoncfamily/Sources/ZippyJSONCFamily/include -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_michaeleisel_jjliso8601dateformatter -Xcc -iquote -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/_main~non_module_deps~com_github_michaeleisel_jjliso8601dateformatter -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_michaeleisel_zippyjsoncfamily -Xcc -iquote -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/_main~non_module_deps~com_github_michaeleisel_zippyjsoncfamily -Xcc -iquote -Xcc $(PROJECT_DIR) -Xcc -iquote -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin -Xcc -fmodule-map-file=$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/_main~non_module_deps~com_github_michaeleisel_jjliso8601dateformatter/JJLISO8601DateFormatter.swift.modulemap -Xcc -fmodule-map-file=$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/_main~non_module_deps~com_github_michaeleisel_zippyjsoncfamily/ZippyJSONCFamily.swift.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all",
             "PREVIEWS_SWIFT_INCLUDE__": "",
             "PREVIEWS_SWIFT_INCLUDE__NO": "",
@@ -713,7 +713,7 @@
             "PRODUCT_BUNDLE_IDENTIFIER": "com.bazelbuild.rulesapple.Tests",
             "PRODUCT_MODULE_NAME": "tests"
         },
-        "c": "applebin_macos-darwin_x86_64-dbg-STABLE-3",
+        "c": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
         "i": {
             "s": [
                 "tools/generators/legacy/test/AddTargetsTests.swift",
@@ -780,14 +780,14 @@
             "e": "tests",
             "m": "tests",
             "n": "tests",
-            "p": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-3/bin/tools/generators/legacy/test/tests.__internal__.__test_bundle_archive-root/tests.xctest",
+            "p": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generators/legacy/test/tests.__internal__.__test_bundle_archive-root/tests.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         }
     },
-    "@@//tools/swiftc_stub:swiftc applebin_macos-darwin_x86_64-dbg-STABLE-3",
+    "@@//tools/swiftc_stub:swiftc macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
     {
         "0": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/swiftc_stub/swiftc_stub.library.rules_xcodeproj.swift.compile.params",
-        "1": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-3/bin/tools/swiftc_stub",
+        "1": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/swiftc_stub",
         "2": {
             "a": "x86_64",
             "m": "12.0",
@@ -801,12 +801,12 @@
         ],
         "6": "bazel-out/darwin_x86_64-dbg-STABLE-0/bin/external/_main~internal~rules_xcodeproj_generated/generator/test/fixtures/generator/xcodeproj_bwb/xcodeproj_bwb-params/swiftc.14.link.params",
         "b": {
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-3/bin/tools/swiftc_stub/swiftc_codesigned",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/swiftc_stub/swiftc_codesigned",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "swiftc_codesigned",
             "OTHER_SWIFT_FLAGS": "-Xcc -iquote -Xcc $(PROJECT_DIR) -Xcc -iquote -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all",
             "PRODUCT_MODULE_NAME": "tools_swiftc_stub_swiftc_stub_library"
         },
-        "c": "applebin_macos-darwin_x86_64-dbg-STABLE-3",
+        "c": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
         "i": {
             "s": [
                 "tools/swiftc_stub/main.swift"
@@ -825,7 +825,7 @@
             ],
             "e": "swiftc",
             "n": "swiftc",
-            "p": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-3/bin/tools/swiftc_stub/swiftc",
+            "p": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/swiftc_stub/swiftc",
             "t": "com.apple.product-type.tool"
         }
     },
@@ -1463,9 +1463,9 @@
             "Release"
         ]
     },
-    "@@//tools/generators/legacy:generator applebin_macos-darwin_x86_64-opt-STABLE-4",
+    "@@//tools/generators/legacy:generator macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2",
     {
-        "1": "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/generators/legacy",
+        "1": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/legacy",
         "2": {
             "a": "x86_64",
             "m": "12.0",
@@ -1474,19 +1474,19 @@
         "6": "bazel-out/darwin_x86_64-dbg-STABLE-0/bin/external/_main~internal~rules_xcodeproj_generated/generator/test/fixtures/generator/xcodeproj_bwb/xcodeproj_bwb-params/generator.25.link.params",
         "b": {
             "BAZEL_OUTPUTS_DSYM": [
-                "\"bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/generators/legacy/generator.dSYM\""
+                "\"bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/legacy/generator.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/generators/legacy/generator_codesigned",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/legacy/generator_codesigned",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "generator_codesigned",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym"
         },
-        "c": "applebin_macos-darwin_x86_64-opt-STABLE-4",
+        "c": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2",
         "l": "@@//tools/generators/legacy:generator",
         "n": "generator",
         "p": {
             "e": "generator",
             "n": "generator",
-            "p": "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/generators/legacy/generator",
+            "p": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/legacy/generator",
             "t": "com.apple.product-type.tool"
         },
         "x": [
@@ -1494,10 +1494,10 @@
             "Release"
         ]
     },
-    "@@//tools/generators/legacy/test:tests.__internal__.__test_bundle applebin_macos-darwin_x86_64-opt-STABLE-4",
+    "@@//tools/generators/legacy/test:tests.__internal__.__test_bundle macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2",
     {
         "0": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/legacy/test/tests.library.rules_xcodeproj.swift.compile.params",
-        "1": "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/generators/legacy/test",
+        "1": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/legacy/test",
         "2": {
             "a": "x86_64",
             "m": "12.0",
@@ -1512,13 +1512,13 @@
         "6": "bazel-out/darwin_x86_64-dbg-STABLE-0/bin/external/_main~internal~rules_xcodeproj_generated/generator/test/fixtures/generator/xcodeproj_bwb/xcodeproj_bwb-params/tests.26.link.params",
         "b": {
             "BAZEL_OUTPUTS_DSYM": [
-                "\"bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/generators/legacy/test/tests.xctest.dSYM\""
+                "\"bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/legacy/test/tests.xctest.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/generators/legacy/test/tests.__internal__.__test_bundle.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/legacy/test/tests.__internal__.__test_bundle.zip",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "tests.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
-            "INFOPLIST_FILE": "$(BAZEL_OUT)/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/generators/legacy/test/rules_xcodeproj/tests.__internal__.__test_bundle/Info.plist",
+            "INFOPLIST_FILE": "$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/legacy/test/rules_xcodeproj/tests.__internal__.__test_bundle/Info.plist",
             "OTHER_SWIFT_FLAGS": "-F$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/Library/Frameworks -I$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/usr/lib -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/_main~non_module_deps~com_github_apple_swift_argument_parser -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/lib/GeneratorCommon -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/_main~non_module_deps~com_github_apple_swift_collections -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/_main~non_module_deps~com_github_kylef_pathkit -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/_main~non_module_deps~com_github_michaeleisel_zippyjson -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/_main~non_module_deps~com_github_tadija_aexml -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/_main~non_module_deps~com_github_tuist_xcodeproj -I$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/legacy -Xcc -I -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_michaeleisel_jjliso8601dateformatter/Sources/JJLISO8601DateFormatter/include -Xcc -I -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/_main~non_module_deps~com_github_michaeleisel_jjliso8601dateformatter/Sources/JJLISO8601DateFormatter/include -Xcc -I -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_michaeleisel_zippyjsoncfamily/Sources/ZippyJSONCFamily/include -Xcc -I -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/_main~non_module_deps~com_github_michaeleisel_zippyjsoncfamily/Sources/ZippyJSONCFamily/include -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_michaeleisel_jjliso8601dateformatter -Xcc -iquote -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/_main~non_module_deps~com_github_michaeleisel_jjliso8601dateformatter -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_michaeleisel_zippyjsoncfamily -Xcc -iquote -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/_main~non_module_deps~com_github_michaeleisel_zippyjsoncfamily -Xcc -iquote -Xcc $(PROJECT_DIR) -Xcc -iquote -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin -Xcc -fmodule-map-file=$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/_main~non_module_deps~com_github_michaeleisel_jjliso8601dateformatter/JJLISO8601DateFormatter.swift.modulemap -Xcc -fmodule-map-file=$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/_main~non_module_deps~com_github_michaeleisel_zippyjsoncfamily/ZippyJSONCFamily.swift.modulemap -Xcc -Os -Xcc -DNDEBUG=1 -Xcc -Wno-unused-variable -Xcc -Winit-self -Xcc -Wno-extra",
             "PREVIEWS_SWIFT_INCLUDE__": "",
             "PREVIEWS_SWIFT_INCLUDE__NO": "",
@@ -1527,7 +1527,7 @@
             "PRODUCT_MODULE_NAME": "tests",
             "SWIFT_COMPILATION_MODE": "wholemodule"
         },
-        "c": "applebin_macos-darwin_x86_64-opt-STABLE-4",
+        "c": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2",
         "i": {
             "s": [
                 "tools/generators/legacy/test/AddTargetsTests.swift",
@@ -1594,7 +1594,7 @@
             "e": "tests",
             "m": "tests",
             "n": "tests",
-            "p": "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/generators/legacy/test/tests.__internal__.__test_bundle_archive-root/tests.xctest",
+            "p": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/legacy/test/tests.__internal__.__test_bundle_archive-root/tests.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         },
         "x": [
@@ -1602,10 +1602,10 @@
             "Release"
         ]
     },
-    "@@//tools/swiftc_stub:swiftc applebin_macos-darwin_x86_64-opt-STABLE-4",
+    "@@//tools/swiftc_stub:swiftc macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2",
     {
         "0": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/swiftc_stub/swiftc_stub.library.rules_xcodeproj.swift.compile.params",
-        "1": "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/swiftc_stub",
+        "1": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/swiftc_stub",
         "2": {
             "a": "x86_64",
             "m": "12.0",
@@ -1620,16 +1620,16 @@
         "6": "bazel-out/darwin_x86_64-dbg-STABLE-0/bin/external/_main~internal~rules_xcodeproj_generated/generator/test/fixtures/generator/xcodeproj_bwb/xcodeproj_bwb-params/swiftc.27.link.params",
         "b": {
             "BAZEL_OUTPUTS_DSYM": [
-                "\"bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/swiftc_stub/swiftc.dSYM\""
+                "\"bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/swiftc_stub/swiftc.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/swiftc_stub/swiftc_codesigned",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/swiftc_stub/swiftc_codesigned",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "swiftc_codesigned",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
             "OTHER_SWIFT_FLAGS": "-Xcc -iquote -Xcc $(PROJECT_DIR) -Xcc -iquote -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin -Xcc -Os -Xcc -DNDEBUG=1 -Xcc -Wno-unused-variable -Xcc -Winit-self -Xcc -Wno-extra",
             "PRODUCT_MODULE_NAME": "tools_swiftc_stub_swiftc_stub_library",
             "SWIFT_COMPILATION_MODE": "wholemodule"
         },
-        "c": "applebin_macos-darwin_x86_64-opt-STABLE-4",
+        "c": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2",
         "i": {
             "s": [
                 "tools/swiftc_stub/main.swift"
@@ -1648,7 +1648,7 @@
             ],
             "e": "swiftc",
             "n": "swiftc",
-            "p": "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/swiftc_stub/swiftc",
+            "p": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/swiftc_stub/swiftc",
             "t": "com.apple.product-type.tool"
         },
         "x": [

--- a/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
@@ -704,13 +704,13 @@
 		2479A60DF1FB71A18BA5D751 /* Parsed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Parsed.swift; sourceTree = "<group>"; };
 		24960C7AD11271830BB4700A /* XCScheme+TestAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCScheme+TestAction.swift"; sourceTree = "<group>"; };
 		26837558C66B51EF5B64F70E /* Box.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Box.swift; sourceTree = "<group>"; };
-		268B2292C7B0E759694F7CF1 /* DefaultTestBundle.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = DefaultTestBundle.plist; sourceTree = "<group>"; };
 		26FAE31E67E00BFAB31F523F /* PBXBatchUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXBatchUpdater.swift; sourceTree = "<group>"; };
 		27ECE65F79F21FFEC7209981 /* OrderedDictionary+Hashable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderedDictionary+Hashable.swift"; sourceTree = "<group>"; };
 		28DF6DF446940A172625029B /* Array+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Extensions.swift"; sourceTree = "<group>"; };
 		28F39AD1852BC6601D088626 /* XCScheme+Runnable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCScheme+Runnable.swift"; sourceTree = "<group>"; };
 		2A4AC80DDC42014A1944A3BD /* ArgumentParserToolInfo.rules_xcodeproj.swift.compile.params */ = {isa = PBXFileReference; lastKnownFileType = file; path = ArgumentParserToolInfo.rules_xcodeproj.swift.compile.params; sourceTree = "<group>"; };
 		2AD126ED98BDB2BF3AB66D81 /* ArgumentDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArgumentDecoder.swift; sourceTree = "<group>"; };
+		2AD6B989904EC5C1DF4267DC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		2BF0D32C95482D2A85F6011F /* ArgumentParser.rules_xcodeproj.swift.compile.params */ = {isa = PBXFileReference; lastKnownFileType = file; path = ArgumentParser.rules_xcodeproj.swift.compile.params; sourceTree = "<group>"; };
 		2C1CD9F6C833027DFC916B4E /* HelpGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelpGenerator.swift; sourceTree = "<group>"; };
 		2D065C91C8B0ED57303C2830 /* XCWorkspaceDataElementLocationType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCWorkspaceDataElementLocationType.swift; sourceTree = "<group>"; };
@@ -867,7 +867,6 @@
 		85FE4063FA8D06E24ED05DA3 /* CreateXCSharedData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateXCSharedData.swift; sourceTree = "<group>"; };
 		86533ABBA2385CFBB26D3AFB /* libXcodeProj.a */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = libXcodeProj.a; path = "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/_main~non_module_deps~com_github_tuist_xcodeproj/libXcodeProj.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		86E72903C7302BA34362E683 /* TargetIDTargetDictionary+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TargetIDTargetDictionary+Extensions.swift"; sourceTree = "<group>"; };
-		86F5A0F4DD229D381C75D6FD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		88332D6F929E182C1D9B3A87 /* OrderedSet+Partial MutableCollection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderedSet+Partial MutableCollection.swift"; sourceTree = "<group>"; };
 		890614E50689716BEBE9FF32 /* OrderedDictionary+Partial RangeReplaceableCollection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderedDictionary+Partial RangeReplaceableCollection.swift"; sourceTree = "<group>"; };
 		8938D2FA216169EE6F7E92CB /* OrderedDictionary+Sequence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderedDictionary+Sequence.swift"; sourceTree = "<group>"; };
@@ -893,7 +892,6 @@
 		97969A03FF4D1B01BDCEF822 /* TargetIDConsolidatedTargetKeyDictionary+ExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TargetIDConsolidatedTargetKeyDictionary+ExtensionsTests.swift"; sourceTree = "<group>"; };
 		97ADD1F2E430AEECD8AC6E60 /* Dump.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Dump.swift; sourceTree = "<group>"; };
 		97C301C1B2D79920967CD049 /* Bool+Extras.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bool+Extras.swift"; sourceTree = "<group>"; };
-		990B3F490CB85EB138084143 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		99117AA57D50A3AF1AA4CF51 /* Platform.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Platform.swift; sourceTree = "<group>"; };
 		9964A0199561742D95F788E1 /* XCScheme+AnalyzeAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCScheme+AnalyzeAction.swift"; sourceTree = "<group>"; };
 		99BD8A127C55D15372178128 /* TargetResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TargetResolver.swift; sourceTree = "<group>"; };
@@ -939,6 +937,7 @@
 		B35201CBAC17BE6FAC78C18E /* ZippyJSON.rules_xcodeproj.swift.compile.params */ = {isa = PBXFileReference; lastKnownFileType = file; path = ZippyJSON.rules_xcodeproj.swift.compile.params; sourceTree = "<group>"; };
 		B36D138602E323333D47F780 /* XCScheme+PathRunnable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCScheme+PathRunnable.swift"; sourceTree = "<group>"; };
 		B3A21B5F3276E683BFC22B9D /* Array+ExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+ExtensionsTests.swift"; sourceTree = "<group>"; };
+		B3C631BE2F205CC0D80838CD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		B40B2B14AF1FE78E7A9CF402 /* ArgumentParserToolInfo.rules_xcodeproj.swift.compile.params */ = {isa = PBXFileReference; lastKnownFileType = file; path = ArgumentParserToolInfo.rules_xcodeproj.swift.compile.params; sourceTree = "<group>"; };
 		B48E03750EC3AE1541BB1BC4 /* String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
 		B4C0DDE422C48F43E19B1AAB /* Project.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Project.swift; sourceTree = "<group>"; };
@@ -978,6 +977,7 @@
 		CC78FEF74411885EA8C1208D /* XCScheme+StoreKitConfigurationFileReference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCScheme+StoreKitConfigurationFileReference.swift"; sourceTree = "<group>"; };
 		CCA45916E3D163DABE70B124 /* swiftc */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = swiftc; sourceTree = BUILT_PRODUCTS_DIR; };
 		CD10C396F368643717E59EF9 /* CommandParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandParser.swift; sourceTree = "<group>"; };
+		CDCA95F5BA3C5DAA16D4CF84 /* DefaultTestBundle.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = DefaultTestBundle.plist; sourceTree = "<group>"; };
 		CDCD01FBB71DC4B06667E43B /* XCScheme+AditionalOption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCScheme+AditionalOption.swift"; sourceTree = "<group>"; };
 		CE48D1E2B4C8970EC6758873 /* TargetIDTargetDictionary+ExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TargetIDTargetDictionary+ExtensionsTests.swift"; sourceTree = "<group>"; };
 		CE87BCAD1967BC3B6A5A44E6 /* tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1122,12 +1122,12 @@
 			path = ArgumentParser;
 			sourceTree = "<group>";
 		};
-		0B3E8411EEC7B0FF7FE6E627 /* generators */ = {
+		10F8072D6AE66596F0E4883D /* rules_xcodeproj */ = {
 			isa = PBXGroup;
 			children = (
-				2271FE78121CEC4099780D85 /* legacy */,
+				135B9717D82954C00B4F11BE /* tests.__internal__.__test_bundle */,
 			);
-			path = generators;
+			path = rules_xcodeproj;
 			sourceTree = "<group>";
 		};
 		11104EC3C5051BF793D0A5B9 /* _main~non_module_deps~com_github_kylef_pathkit */ = {
@@ -1145,6 +1145,14 @@
 				57A570D53AB09A147498953C /* swiftc_stub */,
 			);
 			path = tools;
+			sourceTree = "<group>";
+		};
+		135B9717D82954C00B4F11BE /* tests.__internal__.__test_bundle */ = {
+			isa = PBXGroup;
+			children = (
+				B3C631BE2F205CC0D80838CD /* Info.plist */,
+			);
+			path = tests.__internal__.__test_bundle;
 			sourceTree = "<group>";
 		};
 		14194626385934D7B9A639E0 /* ZippyJSONCFamily */ = {
@@ -1243,14 +1251,6 @@
 			path = "_main~non_module_deps~com_github_michaeleisel_zippyjsoncfamily";
 			sourceTree = "<group>";
 		};
-		2271FE78121CEC4099780D85 /* legacy */ = {
-			isa = PBXGroup;
-			children = (
-				2F4C5DBA44ECD25D7633CB18 /* test */,
-			);
-			path = legacy;
-			sourceTree = "<group>";
-		};
 		2402B1A814917D587DDBCD54 /* Internal */ = {
 			isa = PBXGroup;
 			children = (
@@ -1300,14 +1300,6 @@
 			path = Extensions;
 			sourceTree = "<group>";
 		};
-		25DD13928EEC997C924FC8F6 /* test */ = {
-			isa = PBXGroup;
-			children = (
-				FAD93611E914EDA5928EC42B /* rules_xcodeproj */,
-			);
-			path = test;
-			sourceTree = "<group>";
-		};
 		29CFFE07E6D74CFE2F61B31F /* Bazel External Repositories */ = {
 			isa = PBXGroup;
 			children = (
@@ -1320,7 +1312,7 @@
 				A83FD2C474E757BD74E5CA93 /* _main~non_module_deps~com_github_michaeleisel_zippyjson */,
 				F1A7D9A35425136B75574C68 /* _main~non_module_deps~com_github_michaeleisel_zippyjsoncfamily */,
 				F4A8F825C6205E30BFFDD41A /* _main~non_module_deps~com_github_tuist_xcodeproj */,
-				2B03B941E95CB234F6988113 /* rules_apple~2.5.0 */,
+				6D136988122AB17492515BFF /* rules_apple~3.0.0-rc2 */,
 			);
 			name = "Bazel External Repositories";
 			path = ../../external;
@@ -1341,12 +1333,12 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		2B03B941E95CB234F6988113 /* rules_apple~2.5.0 */ = {
+		2C67B935500A476F2115B621 /* apple */ = {
 			isa = PBXGroup;
 			children = (
-				ED2B9E53F4338B3EC1AC0241 /* apple */,
+				6581621DE3FA1E6EE25C16C0 /* testing */,
 			);
-			path = "rules_apple~2.5.0";
+			path = apple;
 			sourceTree = "<group>";
 		};
 		2ECEE41C264BC9E50A954669 /* test */ = {
@@ -1404,14 +1396,6 @@
 			path = test;
 			sourceTree = "<group>";
 		};
-		2F4C5DBA44ECD25D7633CB18 /* test */ = {
-			isa = PBXGroup;
-			children = (
-				9857CAFF0BB9DEA7727BCF5C /* rules_xcodeproj */,
-			);
-			path = test;
-			sourceTree = "<group>";
-		};
 		3056D54E79D9406116D80181 /* ArgumentParserToolInfo */ = {
 			isa = PBXGroup;
 			children = (
@@ -1448,22 +1432,6 @@
 				69FAD6F6D5146DB845B70AF2 /* UsageGenerator.swift */,
 			);
 			path = Usage;
-			sourceTree = "<group>";
-		};
-		3B014DB6D0644BE9C1AA9AA4 /* testing */ = {
-			isa = PBXGroup;
-			children = (
-				268B2292C7B0E759694F7CF1 /* DefaultTestBundle.plist */,
-			);
-			path = testing;
-			sourceTree = "<group>";
-		};
-		3E1FDAC97DFCCFE883DD2E89 /* bin */ = {
-			isa = PBXGroup;
-			children = (
-				70DF4D5486F53FEB26965FCB /* tools */,
-			);
-			path = bin;
 			sourceTree = "<group>";
 		};
 		3ECF5CA3EEE80594C24D4F4E /* macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2 */ = {
@@ -1511,14 +1479,6 @@
 			path = Vendor;
 			sourceTree = "<group>";
 		};
-		493AD52660F6B98A5F9C84D4 /* applebin_macos-darwin_x86_64-opt-STABLE-4 */ = {
-			isa = PBXGroup;
-			children = (
-				537B1D0BD903525D6E3457D1 /* bin */,
-			);
-			path = "applebin_macos-darwin_x86_64-opt-STABLE-4";
-			sourceTree = "<group>";
-		};
 		4F689DE6D5C9BE67C431A037 /* include */ = {
 			isa = PBXGroup;
 			children = (
@@ -1553,14 +1513,6 @@
 			path = generators;
 			sourceTree = "<group>";
 		};
-		537B1D0BD903525D6E3457D1 /* bin */ = {
-			isa = PBXGroup;
-			children = (
-				D873A77C2D1DFB0C11158CC1 /* tools */,
-			);
-			path = bin;
-			sourceTree = "<group>";
-		};
 		55B8202B8B652260C06BBD80 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
@@ -1574,14 +1526,6 @@
 				2DD5984A41349F384E965B7C /* XCConfig.swift */,
 			);
 			path = Utils;
-			sourceTree = "<group>";
-		};
-		5638208C10679F39E3D0813D /* applebin_macos-darwin_x86_64-dbg-STABLE-3 */ = {
-			isa = PBXGroup;
-			children = (
-				3E1FDAC97DFCCFE883DD2E89 /* bin */,
-			);
-			path = "applebin_macos-darwin_x86_64-dbg-STABLE-3";
 			sourceTree = "<group>";
 		};
 		57A570D53AB09A147498953C /* swiftc_stub */ = {
@@ -1715,6 +1659,14 @@
 			path = tools;
 			sourceTree = "<group>";
 		};
+		6581621DE3FA1E6EE25C16C0 /* testing */ = {
+			isa = PBXGroup;
+			children = (
+				CDCA95F5BA3C5DAA16D4CF84 /* DefaultTestBundle.plist */,
+			);
+			path = testing;
+			sourceTree = "<group>";
+		};
 		6B93558DD8600392E2B68984 /* JJLISO8601DateFormatter */ = {
 			isa = PBXGroup;
 			children = (
@@ -1735,12 +1687,12 @@
 			path = "_main~non_module_deps~com_github_michaeleisel_jjliso8601dateformatter";
 			sourceTree = "<group>";
 		};
-		6C1C66DDDEA6FF124751DD97 /* legacy */ = {
+		6D136988122AB17492515BFF /* rules_apple~3.0.0-rc2 */ = {
 			isa = PBXGroup;
 			children = (
-				25DD13928EEC997C924FC8F6 /* test */,
+				2C67B935500A476F2115B621 /* apple */,
 			);
-			path = legacy;
+			path = "rules_apple~3.0.0-rc2";
 			sourceTree = "<group>";
 		};
 		6D2C7326C5A8AC6AF1DC6F60 /* tzdb */ = {
@@ -1756,8 +1708,6 @@
 		6DEE7775A87F3AD8AD281743 /* Bazel Generated Files */ = {
 			isa = PBXGroup;
 			children = (
-				5638208C10679F39E3D0813D /* applebin_macos-darwin_x86_64-dbg-STABLE-3 */,
-				493AD52660F6B98A5F9C84D4 /* applebin_macos-darwin_x86_64-opt-STABLE-4 */,
 				E9FB62E17E9CD717293583B0 /* darwin_x86_64-dbg-STABLE-0 */,
 				E4883963ED2A9D50413831EB /* macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1 */,
 				3ECF5CA3EEE80594C24D4F4E /* macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2 */,
@@ -1794,14 +1744,6 @@
 				84127ADD733D527B3E6CE1BB /* generator */,
 			);
 			path = "_main~internal~rules_xcodeproj_generated";
-			sourceTree = "<group>";
-		};
-		70DF4D5486F53FEB26965FCB /* tools */ = {
-			isa = PBXGroup;
-			children = (
-				0B3E8411EEC7B0FF7FE6E627 /* generators */,
-			);
-			path = tools;
 			sourceTree = "<group>";
 		};
 		73582CA6C39D54F95119E26B /* _main~non_module_deps~com_github_apple_swift_collections */ = {
@@ -1935,6 +1877,7 @@
 		876324EA9491567D696231BC /* test */ = {
 			isa = PBXGroup;
 			children = (
+				10F8072D6AE66596F0E4883D /* rules_xcodeproj */,
 				BDAF6072614303A34094F6E3 /* tests.library.rules_xcodeproj.swift.compile.params */,
 			);
 			path = test;
@@ -2015,14 +1958,6 @@
 				C26B17E90C5C7F6D26DE5834 /* OptionGroup.swift */,
 			);
 			path = "Parsable Properties";
-			sourceTree = "<group>";
-		};
-		9857CAFF0BB9DEA7727BCF5C /* rules_xcodeproj */ = {
-			isa = PBXGroup;
-			children = (
-				FD9502FC124EDF519711C855 /* tests.__internal__.__test_bundle */,
-			);
-			path = rules_xcodeproj;
 			sourceTree = "<group>";
 		};
 		99D7C2109107265D881C7BCC /* generator */ = {
@@ -2190,6 +2125,7 @@
 		B3C2C9A08FCB9029F9CF659D /* test */ = {
 			isa = PBXGroup;
 			children = (
+				CDF1AA9348293722A1107712 /* rules_xcodeproj */,
 				6B3537839B19E6D2E22D9F42 /* tests.library.rules_xcodeproj.swift.compile.params */,
 			);
 			path = test;
@@ -2302,14 +2238,6 @@
 			path = "_main~dev_non_module_deps~com_github_pointfreeco_xctest_dynamic_overlay";
 			sourceTree = "<group>";
 		};
-		C8EB3895DC12DF9E939090F0 /* generators */ = {
-			isa = PBXGroup;
-			children = (
-				6C1C66DDDEA6FF124751DD97 /* legacy */,
-			);
-			path = generators;
-			sourceTree = "<group>";
-		};
 		CA82710C70E0E3BEF2EA697E /* Project */ = {
 			isa = PBXGroup;
 			children = (
@@ -2331,6 +2259,14 @@
 				5C55FAE92F9A5D5C8EDFBC01 /* fixtures */,
 			);
 			path = test;
+			sourceTree = "<group>";
+		};
+		CDF1AA9348293722A1107712 /* rules_xcodeproj */ = {
+			isa = PBXGroup;
+			children = (
+				D1E9C0506230FE7218360562 /* tests.__internal__.__test_bundle */,
+			);
+			path = rules_xcodeproj;
 			sourceTree = "<group>";
 		};
 		CDFE73A843D59690D7A25988 /* bin */ = {
@@ -2382,6 +2318,14 @@
 			path = XCTestDynamicOverlay;
 			sourceTree = "<group>";
 		};
+		D1E9C0506230FE7218360562 /* tests.__internal__.__test_bundle */ = {
+			isa = PBXGroup;
+			children = (
+				2AD6B989904EC5C1DF4267DC /* Info.plist */,
+			);
+			path = tests.__internal__.__test_bundle;
+			sourceTree = "<group>";
+		};
 		D7E8BC84F4AAFE3D73C15A93 /* Project */ = {
 			isa = PBXGroup;
 			children = (
@@ -2418,14 +2362,6 @@
 				C36F061C702AF42A616D6214 /* OrderedDictionary+Values.swift */,
 			);
 			path = OrderedDictionary;
-			sourceTree = "<group>";
-		};
-		D873A77C2D1DFB0C11158CC1 /* tools */ = {
-			isa = PBXGroup;
-			children = (
-				C8EB3895DC12DF9E939090F0 /* generators */,
-			);
-			path = tools;
 			sourceTree = "<group>";
 		};
 		D91A4F57A8B801A0F6762F3C /* OrderedCollections */ = {
@@ -2513,14 +2449,6 @@
 			path = legacy;
 			sourceTree = "<group>";
 		};
-		E6C6F17E62BFE6CAEA454F1E /* tests.__internal__.__test_bundle */ = {
-			isa = PBXGroup;
-			children = (
-				990B3F490CB85EB138084143 /* Info.plist */,
-			);
-			path = tests.__internal__.__test_bundle;
-			sourceTree = "<group>";
-		};
 		E9FB62E17E9CD717293583B0 /* darwin_x86_64-dbg-STABLE-0 */ = {
 			isa = PBXGroup;
 			children = (
@@ -2551,14 +2479,6 @@
 				F913EFD02029758047E8CAFE /* XcodeProj.rules_xcodeproj.swift.compile.params */,
 			);
 			path = "_main~non_module_deps~com_github_tuist_xcodeproj";
-			sourceTree = "<group>";
-		};
-		ED2B9E53F4338B3EC1AC0241 /* apple */ = {
-			isa = PBXGroup;
-			children = (
-				3B014DB6D0644BE9C1AA9AA4 /* testing */,
-			);
-			path = apple;
 			sourceTree = "<group>";
 		};
 		ED30B6F425F1DEFDD7FE525A /* Errors */ = {
@@ -2600,22 +2520,6 @@
 				F2FFAED2AFB58D63065A924D /* JJLISO8601DateFormatter.h */,
 			);
 			path = include;
-			sourceTree = "<group>";
-		};
-		FAD93611E914EDA5928EC42B /* rules_xcodeproj */ = {
-			isa = PBXGroup;
-			children = (
-				E6C6F17E62BFE6CAEA454F1E /* tests.__internal__.__test_bundle */,
-			);
-			path = rules_xcodeproj;
-			sourceTree = "<group>";
-		};
-		FD9502FC124EDF519711C855 /* tests.__internal__.__test_bundle */ = {
-			isa = PBXGroup;
-			children = (
-				86F5A0F4DD229D381C75D6FD /* Info.plist */,
-			);
-			path = tests.__internal__.__test_bundle;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -4098,8 +4002,8 @@
 				BAZEL_COMPILE_TARGET_IDS = "@@//tools/swiftc_stub:swiftc_stub.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2";
 				"BAZEL_COMPILE_TARGET_IDS[sdk=macosx*]" = "$(BAZEL_COMPILE_TARGET_IDS)";
 				BAZEL_LABEL = "@@//tools/swiftc_stub:swiftc";
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/swiftc_stub";
-				BAZEL_TARGET_ID = "@@//tools/swiftc_stub:swiftc applebin_macos-darwin_x86_64-opt-STABLE-4";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/swiftc_stub";
+				BAZEL_TARGET_ID = "@@//tools/swiftc_stub:swiftc macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2";
 				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				COMPILE_TARGET_NAME = swiftc_stub.library;
@@ -4125,8 +4029,8 @@
 			buildSettings = {
 				ARCHS = x86_64;
 				BAZEL_LABEL = "@@//tools/generators/legacy:generator";
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/generators/legacy";
-				BAZEL_TARGET_ID = "@@//tools/generators/legacy:generator applebin_macos-darwin_x86_64-opt-STABLE-4";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/legacy";
+				BAZEL_TARGET_ID = "@@//tools/generators/legacy:generator macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2";
 				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				COMPILE_TARGET_NAME = generator;
@@ -4172,8 +4076,8 @@
 				BAZEL_COMPILE_TARGET_IDS = "@@//tools/swiftc_stub:swiftc_stub.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2";
 				"BAZEL_COMPILE_TARGET_IDS[sdk=macosx*]" = "$(BAZEL_COMPILE_TARGET_IDS)";
 				BAZEL_LABEL = "@@//tools/swiftc_stub:swiftc";
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/swiftc_stub";
-				BAZEL_TARGET_ID = "@@//tools/swiftc_stub:swiftc applebin_macos-darwin_x86_64-opt-STABLE-4";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/swiftc_stub";
+				BAZEL_TARGET_ID = "@@//tools/swiftc_stub:swiftc macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2";
 				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				COMPILE_TARGET_NAME = swiftc_stub.library;
@@ -4485,8 +4389,8 @@
 			buildSettings = {
 				ARCHS = x86_64;
 				BAZEL_LABEL = "@@//tools/generators/legacy:generator";
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-3/bin/tools/generators/legacy";
-				BAZEL_TARGET_ID = "@@//tools/generators/legacy:generator applebin_macos-darwin_x86_64-dbg-STABLE-3";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generators/legacy";
+				BAZEL_TARGET_ID = "@@//tools/generators/legacy:generator macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1";
 				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				COMPILE_TARGET_NAME = generator;
@@ -4509,21 +4413,21 @@
 				BAZEL_COMPILE_TARGET_IDS = "@@//tools/generators/legacy/test:tests.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1";
 				"BAZEL_COMPILE_TARGET_IDS[sdk=macosx*]" = "$(BAZEL_COMPILE_TARGET_IDS)";
 				BAZEL_LABEL = "@@//tools/generators/legacy/test:tests";
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-3/bin/tools/generators/legacy/test";
-				BAZEL_TARGET_ID = "@@//tools/generators/legacy/test:tests.__internal__.__test_bundle applebin_macos-darwin_x86_64-dbg-STABLE-3";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generators/legacy/test";
+				BAZEL_TARGET_ID = "@@//tools/generators/legacy/test:tests.__internal__.__test_bundle macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1";
 				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				CODE_SIGN_STYLE = Manual;
 				COMPILE_TARGET_NAME = tests.library;
 				DEPLOYMENT_LOCATION = NO;
-				INFOPLIST_FILE = "$(BAZEL_OUT)/applebin_macos-darwin_x86_64-dbg-STABLE-3/bin/tools/generators/legacy/test/rules_xcodeproj/tests.__internal__.__test_bundle/Info.plist";
+				INFOPLIST_FILE = "$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generators/legacy/test/rules_xcodeproj/tests.__internal__.__test_bundle/Info.plist";
 				LINK_PARAMS_FILE = "$(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-0/bin/external/_main~internal~rules_xcodeproj_generated/generator/test/fixtures/generator/xcodeproj_bwx/xcodeproj_bwx-params/tests.13.link.params";
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "@$(DERIVED_FILE_DIR)/link.params";
 				OTHER_SWIFT_FLAGS = "-Xcc -ivfsoverlay -Xcc $(DERIVED_FILE_DIR)/xcode-overlay.yaml -Xcc -ivfsoverlay -Xcc $(OBJROOT)/bazel-out-overlay.yaml -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml $(PREVIEWS_SWIFT_INCLUDE__$(ENABLE_PREVIEWS)) @$(DERIVED_FILE_DIR)/swift.compile.params -F$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/Library/Frameworks -I$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/usr/lib -Xcc -I -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_michaeleisel_jjliso8601dateformatter/Sources/JJLISO8601DateFormatter/include -Xcc -I -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/_main~non_module_deps~com_github_michaeleisel_jjliso8601dateformatter/Sources/JJLISO8601DateFormatter/include -Xcc -I -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_michaeleisel_zippyjsoncfamily/Sources/ZippyJSONCFamily/include -Xcc -I -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/_main~non_module_deps~com_github_michaeleisel_zippyjsoncfamily/Sources/ZippyJSONCFamily/include -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_michaeleisel_jjliso8601dateformatter -Xcc -iquote -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/_main~non_module_deps~com_github_michaeleisel_jjliso8601dateformatter -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_michaeleisel_zippyjsoncfamily -Xcc -iquote -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/_main~non_module_deps~com_github_michaeleisel_zippyjsoncfamily -Xcc -iquote -Xcc $(PROJECT_DIR) -Xcc -iquote -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin -Xcc -fmodule-map-file=$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/_main~non_module_deps~com_github_michaeleisel_jjliso8601dateformatter/JJLISO8601DateFormatter.swift.modulemap -Xcc -fmodule-map-file=$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/_main~non_module_deps~com_github_michaeleisel_zippyjsoncfamily/ZippyJSONCFamily.swift.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all";
 				PREVIEWS_SWIFT_INCLUDE__ = "";
 				PREVIEWS_SWIFT_INCLUDE__NO = "";
-				PREVIEWS_SWIFT_INCLUDE__YES = "-I $(BUILD_DIR)/bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-3/bin/tools/generators/legacy/test";
+				PREVIEWS_SWIFT_INCLUDE__YES = "-I $(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generators/legacy/test";
 				PRODUCT_BUNDLE_IDENTIFIER = com.bazelbuild.rulesapple.Tests;
 				PRODUCT_MODULE_NAME = tests;
 				PRODUCT_NAME = tests;
@@ -4791,8 +4695,8 @@
 				BAZEL_COMPILE_TARGET_IDS = "@@//tools/swiftc_stub:swiftc_stub.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1";
 				"BAZEL_COMPILE_TARGET_IDS[sdk=macosx*]" = "$(BAZEL_COMPILE_TARGET_IDS)";
 				BAZEL_LABEL = "@@//tools/swiftc_stub:swiftc";
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-3/bin/tools/swiftc_stub";
-				BAZEL_TARGET_ID = "@@//tools/swiftc_stub:swiftc applebin_macos-darwin_x86_64-dbg-STABLE-3";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/swiftc_stub";
+				BAZEL_TARGET_ID = "@@//tools/swiftc_stub:swiftc macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1";
 				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				COMPILE_TARGET_NAME = swiftc_stub.library;
@@ -4818,22 +4722,22 @@
 				BAZEL_COMPILE_TARGET_IDS = "@@//tools/generators/legacy/test:tests.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2";
 				"BAZEL_COMPILE_TARGET_IDS[sdk=macosx*]" = "$(BAZEL_COMPILE_TARGET_IDS)";
 				BAZEL_LABEL = "@@//tools/generators/legacy/test:tests";
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/generators/legacy/test";
-				BAZEL_TARGET_ID = "@@//tools/generators/legacy/test:tests.__internal__.__test_bundle applebin_macos-darwin_x86_64-opt-STABLE-4";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/legacy/test";
+				BAZEL_TARGET_ID = "@@//tools/generators/legacy/test:tests.__internal__.__test_bundle macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2";
 				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				CODE_SIGN_STYLE = Manual;
 				COMPILE_TARGET_NAME = tests.library;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEPLOYMENT_LOCATION = NO;
-				INFOPLIST_FILE = "$(BAZEL_OUT)/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/generators/legacy/test/rules_xcodeproj/tests.__internal__.__test_bundle/Info.plist";
+				INFOPLIST_FILE = "$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/legacy/test/rules_xcodeproj/tests.__internal__.__test_bundle/Info.plist";
 				LINK_PARAMS_FILE = "$(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-0/bin/external/_main~internal~rules_xcodeproj_generated/generator/test/fixtures/generator/xcodeproj_bwx/xcodeproj_bwx-params/tests.26.link.params";
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "@$(DERIVED_FILE_DIR)/link.params";
 				OTHER_SWIFT_FLAGS = "-Xcc -ivfsoverlay -Xcc $(DERIVED_FILE_DIR)/xcode-overlay.yaml -Xcc -ivfsoverlay -Xcc $(OBJROOT)/bazel-out-overlay.yaml -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml $(PREVIEWS_SWIFT_INCLUDE__$(ENABLE_PREVIEWS)) @$(DERIVED_FILE_DIR)/swift.compile.params -F$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/Library/Frameworks -I$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/usr/lib -Xcc -I -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_michaeleisel_jjliso8601dateformatter/Sources/JJLISO8601DateFormatter/include -Xcc -I -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/_main~non_module_deps~com_github_michaeleisel_jjliso8601dateformatter/Sources/JJLISO8601DateFormatter/include -Xcc -I -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_michaeleisel_zippyjsoncfamily/Sources/ZippyJSONCFamily/include -Xcc -I -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/_main~non_module_deps~com_github_michaeleisel_zippyjsoncfamily/Sources/ZippyJSONCFamily/include -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_michaeleisel_jjliso8601dateformatter -Xcc -iquote -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/_main~non_module_deps~com_github_michaeleisel_jjliso8601dateformatter -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_michaeleisel_zippyjsoncfamily -Xcc -iquote -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/_main~non_module_deps~com_github_michaeleisel_zippyjsoncfamily -Xcc -iquote -Xcc $(PROJECT_DIR) -Xcc -iquote -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin -Xcc -fmodule-map-file=$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/_main~non_module_deps~com_github_michaeleisel_jjliso8601dateformatter/JJLISO8601DateFormatter.swift.modulemap -Xcc -fmodule-map-file=$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/_main~non_module_deps~com_github_michaeleisel_zippyjsoncfamily/ZippyJSONCFamily.swift.modulemap -Xcc -Os -Xcc -DNDEBUG=1 -Xcc -Wno-unused-variable -Xcc -Winit-self -Xcc -Wno-extra";
 				PREVIEWS_SWIFT_INCLUDE__ = "";
 				PREVIEWS_SWIFT_INCLUDE__NO = "";
-				PREVIEWS_SWIFT_INCLUDE__YES = "-I $(BUILD_DIR)/bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/generators/legacy/test";
+				PREVIEWS_SWIFT_INCLUDE__YES = "-I $(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/legacy/test";
 				PRODUCT_BUNDLE_IDENTIFIER = com.bazelbuild.rulesapple.Tests;
 				PRODUCT_MODULE_NAME = tests;
 				PRODUCT_NAME = tests;
@@ -4853,22 +4757,22 @@
 				BAZEL_COMPILE_TARGET_IDS = "@@//tools/generators/legacy/test:tests.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2";
 				"BAZEL_COMPILE_TARGET_IDS[sdk=macosx*]" = "$(BAZEL_COMPILE_TARGET_IDS)";
 				BAZEL_LABEL = "@@//tools/generators/legacy/test:tests";
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/generators/legacy/test";
-				BAZEL_TARGET_ID = "@@//tools/generators/legacy/test:tests.__internal__.__test_bundle applebin_macos-darwin_x86_64-opt-STABLE-4";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/legacy/test";
+				BAZEL_TARGET_ID = "@@//tools/generators/legacy/test:tests.__internal__.__test_bundle macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2";
 				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				CODE_SIGN_STYLE = Manual;
 				COMPILE_TARGET_NAME = tests.library;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEPLOYMENT_LOCATION = NO;
-				INFOPLIST_FILE = "$(BAZEL_OUT)/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/generators/legacy/test/rules_xcodeproj/tests.__internal__.__test_bundle/Info.plist";
+				INFOPLIST_FILE = "$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/legacy/test/rules_xcodeproj/tests.__internal__.__test_bundle/Info.plist";
 				LINK_PARAMS_FILE = "$(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-0/bin/external/_main~internal~rules_xcodeproj_generated/generator/test/fixtures/generator/xcodeproj_bwx/xcodeproj_bwx-params/tests.26.link.params";
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "@$(DERIVED_FILE_DIR)/link.params";
 				OTHER_SWIFT_FLAGS = "-Xcc -ivfsoverlay -Xcc $(DERIVED_FILE_DIR)/xcode-overlay.yaml -Xcc -ivfsoverlay -Xcc $(OBJROOT)/bazel-out-overlay.yaml -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml $(PREVIEWS_SWIFT_INCLUDE__$(ENABLE_PREVIEWS)) @$(DERIVED_FILE_DIR)/swift.compile.params -F$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/Library/Frameworks -I$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/usr/lib -Xcc -I -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_michaeleisel_jjliso8601dateformatter/Sources/JJLISO8601DateFormatter/include -Xcc -I -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/_main~non_module_deps~com_github_michaeleisel_jjliso8601dateformatter/Sources/JJLISO8601DateFormatter/include -Xcc -I -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_michaeleisel_zippyjsoncfamily/Sources/ZippyJSONCFamily/include -Xcc -I -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/_main~non_module_deps~com_github_michaeleisel_zippyjsoncfamily/Sources/ZippyJSONCFamily/include -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_michaeleisel_jjliso8601dateformatter -Xcc -iquote -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/_main~non_module_deps~com_github_michaeleisel_jjliso8601dateformatter -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_michaeleisel_zippyjsoncfamily -Xcc -iquote -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/_main~non_module_deps~com_github_michaeleisel_zippyjsoncfamily -Xcc -iquote -Xcc $(PROJECT_DIR) -Xcc -iquote -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin -Xcc -fmodule-map-file=$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/_main~non_module_deps~com_github_michaeleisel_jjliso8601dateformatter/JJLISO8601DateFormatter.swift.modulemap -Xcc -fmodule-map-file=$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/_main~non_module_deps~com_github_michaeleisel_zippyjsoncfamily/ZippyJSONCFamily.swift.modulemap -Xcc -Os -Xcc -DNDEBUG=1 -Xcc -Wno-unused-variable -Xcc -Winit-self -Xcc -Wno-extra";
 				PREVIEWS_SWIFT_INCLUDE__ = "";
 				PREVIEWS_SWIFT_INCLUDE__NO = "";
-				PREVIEWS_SWIFT_INCLUDE__YES = "-I $(BUILD_DIR)/bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/generators/legacy/test";
+				PREVIEWS_SWIFT_INCLUDE__YES = "-I $(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/legacy/test";
 				PRODUCT_BUNDLE_IDENTIFIER = com.bazelbuild.rulesapple.Tests;
 				PRODUCT_MODULE_NAME = tests;
 				PRODUCT_NAME = tests;
@@ -4888,21 +4792,21 @@
 				BAZEL_COMPILE_TARGET_IDS = "@@//tools/generators/legacy/test:tests.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1";
 				"BAZEL_COMPILE_TARGET_IDS[sdk=macosx*]" = "$(BAZEL_COMPILE_TARGET_IDS)";
 				BAZEL_LABEL = "@@//tools/generators/legacy/test:tests";
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-3/bin/tools/generators/legacy/test";
-				BAZEL_TARGET_ID = "@@//tools/generators/legacy/test:tests.__internal__.__test_bundle applebin_macos-darwin_x86_64-dbg-STABLE-3";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generators/legacy/test";
+				BAZEL_TARGET_ID = "@@//tools/generators/legacy/test:tests.__internal__.__test_bundle macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1";
 				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				CODE_SIGN_STYLE = Manual;
 				COMPILE_TARGET_NAME = tests.library;
 				DEPLOYMENT_LOCATION = NO;
-				INFOPLIST_FILE = "$(BAZEL_OUT)/applebin_macos-darwin_x86_64-dbg-STABLE-3/bin/tools/generators/legacy/test/rules_xcodeproj/tests.__internal__.__test_bundle/Info.plist";
+				INFOPLIST_FILE = "$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generators/legacy/test/rules_xcodeproj/tests.__internal__.__test_bundle/Info.plist";
 				LINK_PARAMS_FILE = "$(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-0/bin/external/_main~internal~rules_xcodeproj_generated/generator/test/fixtures/generator/xcodeproj_bwx/xcodeproj_bwx-params/tests.13.link.params";
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "@$(DERIVED_FILE_DIR)/link.params";
 				OTHER_SWIFT_FLAGS = "-Xcc -ivfsoverlay -Xcc $(DERIVED_FILE_DIR)/xcode-overlay.yaml -Xcc -ivfsoverlay -Xcc $(OBJROOT)/bazel-out-overlay.yaml -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml $(PREVIEWS_SWIFT_INCLUDE__$(ENABLE_PREVIEWS)) @$(DERIVED_FILE_DIR)/swift.compile.params -F$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/Library/Frameworks -I$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/usr/lib -Xcc -I -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_michaeleisel_jjliso8601dateformatter/Sources/JJLISO8601DateFormatter/include -Xcc -I -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/_main~non_module_deps~com_github_michaeleisel_jjliso8601dateformatter/Sources/JJLISO8601DateFormatter/include -Xcc -I -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_michaeleisel_zippyjsoncfamily/Sources/ZippyJSONCFamily/include -Xcc -I -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/_main~non_module_deps~com_github_michaeleisel_zippyjsoncfamily/Sources/ZippyJSONCFamily/include -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_michaeleisel_jjliso8601dateformatter -Xcc -iquote -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/_main~non_module_deps~com_github_michaeleisel_jjliso8601dateformatter -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_michaeleisel_zippyjsoncfamily -Xcc -iquote -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/_main~non_module_deps~com_github_michaeleisel_zippyjsoncfamily -Xcc -iquote -Xcc $(PROJECT_DIR) -Xcc -iquote -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin -Xcc -fmodule-map-file=$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/_main~non_module_deps~com_github_michaeleisel_jjliso8601dateformatter/JJLISO8601DateFormatter.swift.modulemap -Xcc -fmodule-map-file=$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/_main~non_module_deps~com_github_michaeleisel_zippyjsoncfamily/ZippyJSONCFamily.swift.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all";
 				PREVIEWS_SWIFT_INCLUDE__ = "";
 				PREVIEWS_SWIFT_INCLUDE__NO = "";
-				PREVIEWS_SWIFT_INCLUDE__YES = "-I $(BUILD_DIR)/bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-3/bin/tools/generators/legacy/test";
+				PREVIEWS_SWIFT_INCLUDE__YES = "-I $(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generators/legacy/test";
 				PRODUCT_BUNDLE_IDENTIFIER = com.bazelbuild.rulesapple.Tests;
 				PRODUCT_MODULE_NAME = tests;
 				PRODUCT_NAME = tests;
@@ -4979,21 +4883,21 @@
 				BAZEL_COMPILE_TARGET_IDS = "@@//tools/generators/legacy/test:tests.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1";
 				"BAZEL_COMPILE_TARGET_IDS[sdk=macosx*]" = "$(BAZEL_COMPILE_TARGET_IDS)";
 				BAZEL_LABEL = "@@//tools/generators/legacy/test:tests";
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-3/bin/tools/generators/legacy/test";
-				BAZEL_TARGET_ID = "@@//tools/generators/legacy/test:tests.__internal__.__test_bundle applebin_macos-darwin_x86_64-dbg-STABLE-3";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generators/legacy/test";
+				BAZEL_TARGET_ID = "@@//tools/generators/legacy/test:tests.__internal__.__test_bundle macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1";
 				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				CODE_SIGN_STYLE = Manual;
 				COMPILE_TARGET_NAME = tests.library;
 				DEPLOYMENT_LOCATION = NO;
-				INFOPLIST_FILE = "$(BAZEL_OUT)/applebin_macos-darwin_x86_64-dbg-STABLE-3/bin/tools/generators/legacy/test/rules_xcodeproj/tests.__internal__.__test_bundle/Info.plist";
+				INFOPLIST_FILE = "$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generators/legacy/test/rules_xcodeproj/tests.__internal__.__test_bundle/Info.plist";
 				LINK_PARAMS_FILE = "$(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-0/bin/external/_main~internal~rules_xcodeproj_generated/generator/test/fixtures/generator/xcodeproj_bwx/xcodeproj_bwx-params/tests.13.link.params";
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "@$(DERIVED_FILE_DIR)/link.params";
 				OTHER_SWIFT_FLAGS = "-Xcc -ivfsoverlay -Xcc $(DERIVED_FILE_DIR)/xcode-overlay.yaml -Xcc -ivfsoverlay -Xcc $(OBJROOT)/bazel-out-overlay.yaml -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml $(PREVIEWS_SWIFT_INCLUDE__$(ENABLE_PREVIEWS)) @$(DERIVED_FILE_DIR)/swift.compile.params -F$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/Library/Frameworks -I$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/usr/lib -Xcc -I -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_michaeleisel_jjliso8601dateformatter/Sources/JJLISO8601DateFormatter/include -Xcc -I -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/_main~non_module_deps~com_github_michaeleisel_jjliso8601dateformatter/Sources/JJLISO8601DateFormatter/include -Xcc -I -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_michaeleisel_zippyjsoncfamily/Sources/ZippyJSONCFamily/include -Xcc -I -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/_main~non_module_deps~com_github_michaeleisel_zippyjsoncfamily/Sources/ZippyJSONCFamily/include -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_michaeleisel_jjliso8601dateformatter -Xcc -iquote -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/_main~non_module_deps~com_github_michaeleisel_jjliso8601dateformatter -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_michaeleisel_zippyjsoncfamily -Xcc -iquote -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/_main~non_module_deps~com_github_michaeleisel_zippyjsoncfamily -Xcc -iquote -Xcc $(PROJECT_DIR) -Xcc -iquote -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin -Xcc -fmodule-map-file=$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/_main~non_module_deps~com_github_michaeleisel_jjliso8601dateformatter/JJLISO8601DateFormatter.swift.modulemap -Xcc -fmodule-map-file=$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/_main~non_module_deps~com_github_michaeleisel_zippyjsoncfamily/ZippyJSONCFamily.swift.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all";
 				PREVIEWS_SWIFT_INCLUDE__ = "";
 				PREVIEWS_SWIFT_INCLUDE__NO = "";
-				PREVIEWS_SWIFT_INCLUDE__YES = "-I $(BUILD_DIR)/bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-3/bin/tools/generators/legacy/test";
+				PREVIEWS_SWIFT_INCLUDE__YES = "-I $(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generators/legacy/test";
 				PRODUCT_BUNDLE_IDENTIFIER = com.bazelbuild.rulesapple.Tests;
 				PRODUCT_MODULE_NAME = tests;
 				PRODUCT_NAME = tests;
@@ -5162,22 +5066,22 @@
 				BAZEL_COMPILE_TARGET_IDS = "@@//tools/generators/legacy/test:tests.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2";
 				"BAZEL_COMPILE_TARGET_IDS[sdk=macosx*]" = "$(BAZEL_COMPILE_TARGET_IDS)";
 				BAZEL_LABEL = "@@//tools/generators/legacy/test:tests";
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/generators/legacy/test";
-				BAZEL_TARGET_ID = "@@//tools/generators/legacy/test:tests.__internal__.__test_bundle applebin_macos-darwin_x86_64-opt-STABLE-4";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/legacy/test";
+				BAZEL_TARGET_ID = "@@//tools/generators/legacy/test:tests.__internal__.__test_bundle macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2";
 				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				CODE_SIGN_STYLE = Manual;
 				COMPILE_TARGET_NAME = tests.library;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEPLOYMENT_LOCATION = NO;
-				INFOPLIST_FILE = "$(BAZEL_OUT)/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/generators/legacy/test/rules_xcodeproj/tests.__internal__.__test_bundle/Info.plist";
+				INFOPLIST_FILE = "$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/legacy/test/rules_xcodeproj/tests.__internal__.__test_bundle/Info.plist";
 				LINK_PARAMS_FILE = "$(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-0/bin/external/_main~internal~rules_xcodeproj_generated/generator/test/fixtures/generator/xcodeproj_bwx/xcodeproj_bwx-params/tests.26.link.params";
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = "@$(DERIVED_FILE_DIR)/link.params";
 				OTHER_SWIFT_FLAGS = "-Xcc -ivfsoverlay -Xcc $(DERIVED_FILE_DIR)/xcode-overlay.yaml -Xcc -ivfsoverlay -Xcc $(OBJROOT)/bazel-out-overlay.yaml -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml $(PREVIEWS_SWIFT_INCLUDE__$(ENABLE_PREVIEWS)) @$(DERIVED_FILE_DIR)/swift.compile.params -F$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/Library/Frameworks -I$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/usr/lib -Xcc -I -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_michaeleisel_jjliso8601dateformatter/Sources/JJLISO8601DateFormatter/include -Xcc -I -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/_main~non_module_deps~com_github_michaeleisel_jjliso8601dateformatter/Sources/JJLISO8601DateFormatter/include -Xcc -I -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_michaeleisel_zippyjsoncfamily/Sources/ZippyJSONCFamily/include -Xcc -I -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/_main~non_module_deps~com_github_michaeleisel_zippyjsoncfamily/Sources/ZippyJSONCFamily/include -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_michaeleisel_jjliso8601dateformatter -Xcc -iquote -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/_main~non_module_deps~com_github_michaeleisel_jjliso8601dateformatter -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_michaeleisel_zippyjsoncfamily -Xcc -iquote -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/_main~non_module_deps~com_github_michaeleisel_zippyjsoncfamily -Xcc -iquote -Xcc $(PROJECT_DIR) -Xcc -iquote -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin -Xcc -fmodule-map-file=$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/_main~non_module_deps~com_github_michaeleisel_jjliso8601dateformatter/JJLISO8601DateFormatter.swift.modulemap -Xcc -fmodule-map-file=$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/_main~non_module_deps~com_github_michaeleisel_zippyjsoncfamily/ZippyJSONCFamily.swift.modulemap -Xcc -Os -Xcc -DNDEBUG=1 -Xcc -Wno-unused-variable -Xcc -Winit-self -Xcc -Wno-extra";
 				PREVIEWS_SWIFT_INCLUDE__ = "";
 				PREVIEWS_SWIFT_INCLUDE__NO = "";
-				PREVIEWS_SWIFT_INCLUDE__YES = "-I $(BUILD_DIR)/bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/generators/legacy/test";
+				PREVIEWS_SWIFT_INCLUDE__YES = "-I $(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/legacy/test";
 				PRODUCT_BUNDLE_IDENTIFIER = com.bazelbuild.rulesapple.Tests;
 				PRODUCT_MODULE_NAME = tests;
 				PRODUCT_NAME = tests;
@@ -5218,8 +5122,8 @@
 			buildSettings = {
 				ARCHS = x86_64;
 				BAZEL_LABEL = "@@//tools/generators/legacy:generator";
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/generators/legacy";
-				BAZEL_TARGET_ID = "@@//tools/generators/legacy:generator applebin_macos-darwin_x86_64-opt-STABLE-4";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/legacy";
+				BAZEL_TARGET_ID = "@@//tools/generators/legacy:generator macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2";
 				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				COMPILE_TARGET_NAME = generator;

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/external.xcfilelist
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/external.xcfilelist
@@ -227,4 +227,4 @@ $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_tuist_xcodeproj/Sources/Xcode
 $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_tuist_xcodeproj/Sources/XcodeProj/Workspace/XCWorkspaceDataElementLocationType.swift
 $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_tuist_xcodeproj/Sources/XcodeProj/Workspace/XCWorkspaceDataFileRef.swift
 $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_tuist_xcodeproj/Sources/XcodeProj/Workspace/XCWorkspaceDataGroup.swift
-$(BAZEL_EXTERNAL)/rules_apple~2.5.0/apple/testing/DefaultTestBundle.plist
+$(BAZEL_EXTERNAL)/rules_apple~3.0.0-rc2/apple/testing/DefaultTestBundle.plist

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/generated.xcfilelist
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/generated.xcfilelist
@@ -1,5 +1,3 @@
-$(BAZEL_OUT)/applebin_macos-darwin_x86_64-dbg-STABLE-3/bin/tools/generators/legacy/test/rules_xcodeproj/tests.__internal__.__test_bundle/Info.plist
-$(BAZEL_OUT)/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/generators/legacy/test/rules_xcodeproj/tests.__internal__.__test_bundle/Info.plist
 $(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-0/bin/external/_main~internal~rules_xcodeproj_generated/generator/test/fixtures/generator/xcodeproj_bwx/xcodeproj_bwx-params/generator.10.link.params
 $(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-0/bin/external/_main~internal~rules_xcodeproj_generated/generator/test/fixtures/generator/xcodeproj_bwx/xcodeproj_bwx-params/generator.25.link.params
 $(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-0/bin/external/_main~internal~rules_xcodeproj_generated/generator/test/fixtures/generator/xcodeproj_bwx/xcodeproj_bwx-params/swiftc.14.link.params
@@ -17,6 +15,7 @@ $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/
 $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/_main~non_module_deps~com_github_michaeleisel_zippyjsoncfamily/ZippyJSONCFamily.rules_xcodeproj.cxx.compile.params
 $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/_main~non_module_deps~com_github_tuist_xcodeproj/XcodeProj.rules_xcodeproj.swift.compile.params
 $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generators/legacy/generator.library.rules_xcodeproj.swift.compile.params
+$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generators/legacy/test/rules_xcodeproj/tests.__internal__.__test_bundle/Info.plist
 $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generators/legacy/test/tests.library.rules_xcodeproj.swift.compile.params
 $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generators/lib/GeneratorCommon/GeneratorCommon.rules_xcodeproj.swift.compile.params
 $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/swiftc_stub/swiftc_stub.library.rules_xcodeproj.swift.compile.params
@@ -29,6 +28,7 @@ $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/
 $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/_main~non_module_deps~com_github_michaeleisel_zippyjsoncfamily/ZippyJSONCFamily.rules_xcodeproj.cxx.compile.params
 $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/_main~non_module_deps~com_github_tuist_xcodeproj/XcodeProj.rules_xcodeproj.swift.compile.params
 $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/legacy/generator.library.rules_xcodeproj.swift.compile.params
+$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/legacy/test/rules_xcodeproj/tests.__internal__.__test_bundle/Info.plist
 $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/legacy/test/tests.library.rules_xcodeproj.swift.compile.params
 $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/lib/GeneratorCommon/GeneratorCommon.rules_xcodeproj.swift.compile.params
 $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/swiftc_stub/swiftc_stub.library.rules_xcodeproj.swift.compile.params

--- a/test/fixtures/generator/bwx_project_spec.json
+++ b/test/fixtures/generator/bwx_project_spec.json
@@ -1,17 +1,17 @@
 {
     "B": "rules_xcodeproj",
     "E": [
-        "@@//tools/generators/legacy/test:tests.__internal__.__test_bundle applebin_macos-darwin_x86_64-dbg-STABLE-3",
+        "@@//tools/generators/legacy/test:tests.__internal__.__test_bundle macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
         {},
-        "@@//tools/generators/legacy/test:tests.__internal__.__test_bundle applebin_macos-darwin_x86_64-opt-STABLE-4",
+        "@@//tools/generators/legacy/test:tests.__internal__.__test_bundle macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2",
         {}
     ],
     "R": "@@//test/fixtures/generator:xcodeproj_bwx",
     "T": "fixture-target-ids-file",
     "e": [
-        "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-3/bin/tools/generators/legacy/test/rules_xcodeproj/tests.__internal__.__test_bundle/Info.plist",
-        "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/generators/legacy/test/rules_xcodeproj/tests.__internal__.__test_bundle/Info.plist",
-        "external/rules_apple~2.5.0/apple/testing/DefaultTestBundle.plist",
+        "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generators/legacy/test/rules_xcodeproj/tests.__internal__.__test_bundle/Info.plist",
+        "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/legacy/test/rules_xcodeproj/tests.__internal__.__test_bundle/Info.plist",
+        "external/rules_apple~3.0.0-rc2/apple/testing/DefaultTestBundle.plist",
         "test/fixtures/generator/BUILD",
         "tools/generators/legacy/BUILD",
         "tools/generators/legacy/test/BUILD",

--- a/test/fixtures/generator/bwx_targets_spec.json
+++ b/test/fixtures/generator/bwx_targets_spec.json
@@ -595,16 +595,16 @@
             "t": "com.apple.product-type.library.static"
         }
     },
-    "@@//tools/generators/legacy:generator applebin_macos-darwin_x86_64-dbg-STABLE-3",
+    "@@//tools/generators/legacy:generator macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
     {
-        "1": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-3/bin/tools/generators/legacy",
+        "1": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generators/legacy",
         "2": {
             "a": "x86_64",
             "m": "12.0",
             "v": "macosx"
         },
         "6": "bazel-out/darwin_x86_64-dbg-STABLE-0/bin/external/_main~internal~rules_xcodeproj_generated/generator/test/fixtures/generator/xcodeproj_bwx/xcodeproj_bwx-params/generator.10.link.params",
-        "c": "applebin_macos-darwin_x86_64-dbg-STABLE-3",
+        "c": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
         "d": [
             "@@//tools/generators/legacy:generator.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1"
         ],
@@ -613,7 +613,7 @@
         "p": {
             "e": "generator",
             "n": "generator",
-            "p": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-3/bin/tools/generators/legacy/generator",
+            "p": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generators/legacy/generator",
             "t": "com.apple.product-type.tool"
         }
     },
@@ -712,10 +712,10 @@
             "t": "com.apple.product-type.library.static"
         }
     },
-    "@@//tools/generators/legacy/test:tests.__internal__.__test_bundle applebin_macos-darwin_x86_64-dbg-STABLE-3",
+    "@@//tools/generators/legacy/test:tests.__internal__.__test_bundle macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
     {
         "0": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generators/legacy/test/tests.library.rules_xcodeproj.swift.compile.params",
-        "1": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-3/bin/tools/generators/legacy/test",
+        "1": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generators/legacy/test",
         "2": {
             "a": "x86_64",
             "m": "12.0",
@@ -730,16 +730,16 @@
         "6": "bazel-out/darwin_x86_64-dbg-STABLE-0/bin/external/_main~internal~rules_xcodeproj_generated/generator/test/fixtures/generator/xcodeproj_bwx/xcodeproj_bwx-params/tests.13.link.params",
         "b": {
             "CODE_SIGN_STYLE": "Manual",
-            "INFOPLIST_FILE": "$(BAZEL_OUT)/applebin_macos-darwin_x86_64-dbg-STABLE-3/bin/tools/generators/legacy/test/rules_xcodeproj/tests.__internal__.__test_bundle/Info.plist",
+            "INFOPLIST_FILE": "$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generators/legacy/test/rules_xcodeproj/tests.__internal__.__test_bundle/Info.plist",
             "OTHER_SWIFT_FLAGS": "-F$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/Library/Frameworks -I$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/usr/lib -Xcc -I -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_michaeleisel_jjliso8601dateformatter/Sources/JJLISO8601DateFormatter/include -Xcc -I -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/_main~non_module_deps~com_github_michaeleisel_jjliso8601dateformatter/Sources/JJLISO8601DateFormatter/include -Xcc -I -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_michaeleisel_zippyjsoncfamily/Sources/ZippyJSONCFamily/include -Xcc -I -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/_main~non_module_deps~com_github_michaeleisel_zippyjsoncfamily/Sources/ZippyJSONCFamily/include -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_michaeleisel_jjliso8601dateformatter -Xcc -iquote -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/_main~non_module_deps~com_github_michaeleisel_jjliso8601dateformatter -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_michaeleisel_zippyjsoncfamily -Xcc -iquote -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/_main~non_module_deps~com_github_michaeleisel_zippyjsoncfamily -Xcc -iquote -Xcc $(PROJECT_DIR) -Xcc -iquote -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin -Xcc -fmodule-map-file=$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/_main~non_module_deps~com_github_michaeleisel_jjliso8601dateformatter/JJLISO8601DateFormatter.swift.modulemap -Xcc -fmodule-map-file=$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/_main~non_module_deps~com_github_michaeleisel_zippyjsoncfamily/ZippyJSONCFamily.swift.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all",
             "PREVIEWS_SWIFT_INCLUDE__": "",
             "PREVIEWS_SWIFT_INCLUDE__NO": "",
-            "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-3/bin/tools/generators/legacy/test",
+            "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generators/legacy/test",
             "PRODUCT_BUNDLE_IDENTIFIER": "com.bazelbuild.rulesapple.Tests",
             "PRODUCT_MODULE_NAME": "tests",
             "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/_main~non_module_deps~com_github_apple_swift_argument_parser $(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generators/lib/GeneratorCommon $(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/_main~non_module_deps~com_github_apple_swift_collections $(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/_main~non_module_deps~com_github_kylef_pathkit $(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/_main~non_module_deps~com_github_michaeleisel_zippyjson bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/_main~non_module_deps~com_github_tadija_aexml $(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/_main~non_module_deps~com_github_tuist_xcodeproj $(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generators/legacy $(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/_main~dev_non_module_deps~com_github_pointfreeco_xctest_dynamic_overlay $(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/_main~dev_non_module_deps~com_github_pointfreeco_swift_custom_dump"
         },
-        "c": "applebin_macos-darwin_x86_64-dbg-STABLE-3",
+        "c": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
         "d": [
             "@@//tools/generators/legacy:generator.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
             "@@//tools/generators/lib/GeneratorCommon:GeneratorCommon macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
@@ -811,14 +811,14 @@
             "e": "tests",
             "m": "tests",
             "n": "tests",
-            "p": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-3/bin/tools/generators/legacy/test/tests.__internal__.__test_bundle_archive-root/tests.xctest",
+            "p": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generators/legacy/test/tests.__internal__.__test_bundle_archive-root/tests.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         }
     },
-    "@@//tools/swiftc_stub:swiftc applebin_macos-darwin_x86_64-dbg-STABLE-3",
+    "@@//tools/swiftc_stub:swiftc macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
     {
         "0": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/swiftc_stub/swiftc_stub.library.rules_xcodeproj.swift.compile.params",
-        "1": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-3/bin/tools/swiftc_stub",
+        "1": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/swiftc_stub",
         "2": {
             "a": "x86_64",
             "m": "12.0",
@@ -835,7 +835,7 @@
             "OTHER_SWIFT_FLAGS": "-Xcc -iquote -Xcc $(PROJECT_DIR) -Xcc -iquote -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all",
             "PRODUCT_MODULE_NAME": "tools_swiftc_stub_swiftc_stub_library"
         },
-        "c": "applebin_macos-darwin_x86_64-dbg-STABLE-3",
+        "c": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
         "i": {
             "s": [
                 "tools/swiftc_stub/main.swift"
@@ -854,7 +854,7 @@
             ],
             "e": "swiftc",
             "n": "swiftc",
-            "p": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-3/bin/tools/swiftc_stub/swiftc",
+            "p": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/swiftc_stub/swiftc",
             "t": "com.apple.product-type.tool"
         }
     },
@@ -1516,9 +1516,9 @@
             "Release"
         ]
     },
-    "@@//tools/generators/legacy:generator applebin_macos-darwin_x86_64-opt-STABLE-4",
+    "@@//tools/generators/legacy:generator macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2",
     {
-        "1": "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/generators/legacy",
+        "1": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/legacy",
         "2": {
             "a": "x86_64",
             "m": "12.0",
@@ -1528,7 +1528,7 @@
         "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym"
         },
-        "c": "applebin_macos-darwin_x86_64-opt-STABLE-4",
+        "c": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2",
         "d": [
             "@@//tools/generators/legacy:generator.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2"
         ],
@@ -1537,7 +1537,7 @@
         "p": {
             "e": "generator",
             "n": "generator",
-            "p": "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/generators/legacy/generator",
+            "p": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/legacy/generator",
             "t": "com.apple.product-type.tool"
         },
         "x": [
@@ -1545,10 +1545,10 @@
             "Release"
         ]
     },
-    "@@//tools/generators/legacy/test:tests.__internal__.__test_bundle applebin_macos-darwin_x86_64-opt-STABLE-4",
+    "@@//tools/generators/legacy/test:tests.__internal__.__test_bundle macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2",
     {
         "0": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/legacy/test/tests.library.rules_xcodeproj.swift.compile.params",
-        "1": "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/generators/legacy/test",
+        "1": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/legacy/test",
         "2": {
             "a": "x86_64",
             "m": "12.0",
@@ -1564,17 +1564,17 @@
         "b": {
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
-            "INFOPLIST_FILE": "$(BAZEL_OUT)/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/generators/legacy/test/rules_xcodeproj/tests.__internal__.__test_bundle/Info.plist",
+            "INFOPLIST_FILE": "$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/legacy/test/rules_xcodeproj/tests.__internal__.__test_bundle/Info.plist",
             "OTHER_SWIFT_FLAGS": "-F$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/Library/Frameworks -I$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/usr/lib -Xcc -I -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_michaeleisel_jjliso8601dateformatter/Sources/JJLISO8601DateFormatter/include -Xcc -I -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/_main~non_module_deps~com_github_michaeleisel_jjliso8601dateformatter/Sources/JJLISO8601DateFormatter/include -Xcc -I -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_michaeleisel_zippyjsoncfamily/Sources/ZippyJSONCFamily/include -Xcc -I -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/_main~non_module_deps~com_github_michaeleisel_zippyjsoncfamily/Sources/ZippyJSONCFamily/include -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_michaeleisel_jjliso8601dateformatter -Xcc -iquote -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/_main~non_module_deps~com_github_michaeleisel_jjliso8601dateformatter -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_michaeleisel_zippyjsoncfamily -Xcc -iquote -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/_main~non_module_deps~com_github_michaeleisel_zippyjsoncfamily -Xcc -iquote -Xcc $(PROJECT_DIR) -Xcc -iquote -Xcc $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin -Xcc -fmodule-map-file=$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/_main~non_module_deps~com_github_michaeleisel_jjliso8601dateformatter/JJLISO8601DateFormatter.swift.modulemap -Xcc -fmodule-map-file=$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/_main~non_module_deps~com_github_michaeleisel_zippyjsoncfamily/ZippyJSONCFamily.swift.modulemap -Xcc -Os -Xcc -DNDEBUG=1 -Xcc -Wno-unused-variable -Xcc -Winit-self -Xcc -Wno-extra",
             "PREVIEWS_SWIFT_INCLUDE__": "",
             "PREVIEWS_SWIFT_INCLUDE__NO": "",
-            "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/generators/legacy/test",
+            "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/legacy/test",
             "PRODUCT_BUNDLE_IDENTIFIER": "com.bazelbuild.rulesapple.Tests",
             "PRODUCT_MODULE_NAME": "tests",
             "SWIFT_COMPILATION_MODE": "wholemodule",
             "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/_main~non_module_deps~com_github_apple_swift_argument_parser $(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/lib/GeneratorCommon $(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/_main~non_module_deps~com_github_apple_swift_collections $(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/_main~non_module_deps~com_github_kylef_pathkit $(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/_main~non_module_deps~com_github_michaeleisel_zippyjson bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/_main~non_module_deps~com_github_tadija_aexml $(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/external/_main~non_module_deps~com_github_tuist_xcodeproj $(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/legacy"
         },
-        "c": "applebin_macos-darwin_x86_64-opt-STABLE-4",
+        "c": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2",
         "d": [
             "@@//tools/generators/legacy:generator.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2",
             "@@//tools/generators/lib/GeneratorCommon:GeneratorCommon macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2"
@@ -1645,7 +1645,7 @@
             "e": "tests",
             "m": "tests",
             "n": "tests",
-            "p": "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/generators/legacy/test/tests.__internal__.__test_bundle_archive-root/tests.xctest",
+            "p": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/generators/legacy/test/tests.__internal__.__test_bundle_archive-root/tests.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         },
         "x": [
@@ -1653,10 +1653,10 @@
             "Release"
         ]
     },
-    "@@//tools/swiftc_stub:swiftc applebin_macos-darwin_x86_64-opt-STABLE-4",
+    "@@//tools/swiftc_stub:swiftc macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2",
     {
         "0": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/swiftc_stub/swiftc_stub.library.rules_xcodeproj.swift.compile.params",
-        "1": "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/swiftc_stub",
+        "1": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/swiftc_stub",
         "2": {
             "a": "x86_64",
             "m": "12.0",
@@ -1675,7 +1675,7 @@
             "PRODUCT_MODULE_NAME": "tools_swiftc_stub_swiftc_stub_library",
             "SWIFT_COMPILATION_MODE": "wholemodule"
         },
-        "c": "applebin_macos-darwin_x86_64-opt-STABLE-4",
+        "c": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2",
         "i": {
             "s": [
                 "tools/swiftc_stub/main.swift"
@@ -1694,7 +1694,7 @@
             ],
             "e": "swiftc",
             "n": "swiftc",
-            "p": "bazel-out/applebin_macos-darwin_x86_64-opt-STABLE-4/bin/tools/swiftc_stub/swiftc",
+            "p": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2/bin/tools/swiftc_stub/swiftc",
             "t": "com.apple.product-type.tool"
         },
         "x": [

--- a/test/internal/info_plists/get_file_tests.bzl
+++ b/test/internal/info_plists/get_file_tests.bzl
@@ -8,6 +8,12 @@ load(
 )
 
 # buildifier: disable=bzl-visibility
+load(
+    "@build_bazel_rules_apple//apple/internal:providers.bzl",
+    "new_applebundleinfo",
+)
+
+# buildifier: disable=bzl-visibility
 load("//xcodeproj/internal:info_plists.bzl", "info_plists")
 
 # NOTE: It is not possible to create a dict with a key of apple_common.Objc.
@@ -25,7 +31,7 @@ def _get_file_from_bundle_info_test(ctx):
     info_plist_file = ctx.actions.declare_file("Info.plist")
     ctx.actions.write(info_plist_file, content = "")
 
-    bundle_info = AppleBundleInfo(infoplist = info_plist_file)
+    bundle_info = new_applebundleinfo(infoplist = info_plist_file)
     target = {AppleBundleInfo: bundle_info}
 
     actual = info_plists.get_file(target)
@@ -39,7 +45,7 @@ def _get_file_from_binary_info_test(ctx):
     info_plist_file = ctx.actions.declare_file("Info.plist")
     ctx.actions.write(info_plist_file, content = "")
 
-    infoplist_info = AppleBinaryInfo(infoplist = info_plist_file)
+    infoplist_info = new_applebundleinfo(infoplist = info_plist_file)
     target = {AppleBinaryInfo: infoplist_info}
 
     actual = info_plists.get_file(target)

--- a/test/internal/targets/is_test_bundle_tests.bzl
+++ b/test/internal/targets/is_test_bundle_tests.bzl
@@ -8,13 +8,20 @@ load(
 )
 
 # buildifier: disable=bzl-visibility
+load(
+    "@build_bazel_rules_apple//apple/internal:providers.bzl",
+    "new_iosxctestbundleinfo",
+    "new_macosxctestbundleinfo",
+)
+
+# buildifier: disable=bzl-visibility
 load("//xcodeproj/internal:targets.bzl", "targets")
 
 def _is_test_bundle_for_ios_test_bundle_test(ctx):
     env = unittest.begin(ctx)
 
-    target = {IosXcTestBundleInfo: IosXcTestBundleInfo()}
-    dep = {IosXcTestBundleInfo: IosXcTestBundleInfo()}
+    target = {IosXcTestBundleInfo: new_iosxctestbundleinfo()}
+    dep = {IosXcTestBundleInfo: new_iosxctestbundleinfo()}
     deps = [dep]
 
     actual = targets.is_test_bundle(target, deps)
@@ -27,8 +34,8 @@ is_test_bundle_for_ios_test_bundle_test = unittest.make(_is_test_bundle_for_ios_
 def _is_test_bundle_for_macos_test_bundel_test(ctx):
     env = unittest.begin(ctx)
 
-    target = {MacosXcTestBundleInfo: MacosXcTestBundleInfo()}
-    dep = {MacosXcTestBundleInfo: MacosXcTestBundleInfo()}
+    target = {MacosXcTestBundleInfo: new_macosxctestbundleinfo()}
+    dep = {MacosXcTestBundleInfo: new_macosxctestbundleinfo()}
     deps = [dep]
 
     actual = targets.is_test_bundle(target, deps)
@@ -41,7 +48,7 @@ is_test_bundle_for_macos_test_bundel_test = unittest.make(_is_test_bundle_for_ma
 def _is_test_bundle_has_provider_but_not_dep_test(ctx):
     env = unittest.begin(ctx)
 
-    target = {MacosXcTestBundleInfo: MacosXcTestBundleInfo()}
+    target = {MacosXcTestBundleInfo: new_macosxctestbundleinfo()}
     dep = {}
     deps = [dep]
 
@@ -56,7 +63,7 @@ def _is_test_bundle_does_not_have_provider_test(ctx):
     env = unittest.begin(ctx)
 
     target = {}
-    dep = {MacosXcTestBundleInfo: MacosXcTestBundleInfo()}
+    dep = {MacosXcTestBundleInfo: new_macosxctestbundleinfo()}
     deps = [dep]
 
     actual = targets.is_test_bundle(target, deps)
@@ -69,8 +76,8 @@ is_test_bundle_does_not_have_provider_test = unittest.make(_is_test_bundle_does_
 def _is_test_bundle_more_than_one_dep_test(ctx):
     env = unittest.begin(ctx)
 
-    target = {MacosXcTestBundleInfo: MacosXcTestBundleInfo()}
-    dep = {MacosXcTestBundleInfo: MacosXcTestBundleInfo()}
+    target = {MacosXcTestBundleInfo: new_macosxctestbundleinfo()}
+    dep = {MacosXcTestBundleInfo: new_macosxctestbundleinfo()}
     deps = [dep, dep]
 
     actual = targets.is_test_bundle(target, deps)


### PR DESCRIPTION
This will allow us to use newer versions of Bazel 7.