### PR TITLE
Set `ASSETCATALOG_COMPILER_GENERATE_ASSET_SYMBOLS = NO` in BwB mode

### DIFF
--- a/examples/integration/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -22651,6 +22651,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_ASSET_SYMBOLS = NO;
 				BAZEL_CONFIG = rules_xcodeproj_integration;
 				BAZEL_EXTERNAL = "$(BAZEL_OUTPUT_BASE)/external";
 				BAZEL_INTEGRATION_DIR = "$(INTERNAL_DIR)/bazel";
@@ -25964,6 +25965,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_ASSET_SYMBOLS = NO;
 				BAZEL_CONFIG = rules_xcodeproj_integration;
 				BAZEL_EXTERNAL = "$(BAZEL_OUTPUT_BASE)/external";
 				BAZEL_INTEGRATION_DIR = "$(INTERNAL_DIR)/bazel";

--- a/examples/rules_ios/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/rules_ios/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -4679,6 +4679,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_ASSET_SYMBOLS = NO;
 				BAZEL_CONFIG = rules_xcodeproj;
 				BAZEL_EXTERNAL = "$(BAZEL_OUTPUT_BASE)/external";
 				BAZEL_INTEGRATION_DIR = "$(INTERNAL_DIR)/bazel";

--- a/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
@@ -4013,6 +4013,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_ASSET_SYMBOLS = NO;
 				BAZEL_CONFIG = rules_xcodeproj;
 				BAZEL_EXTERNAL = "$(BAZEL_OUTPUT_BASE)/external";
 				BAZEL_INTEGRATION_DIR = "$(INTERNAL_DIR)/bazel";
@@ -4609,6 +4610,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_ASSET_SYMBOLS = NO;
 				BAZEL_CONFIG = rules_xcodeproj;
 				BAZEL_EXTERNAL = "$(BAZEL_OUTPUT_BASE)/external";
 				BAZEL_INTEGRATION_DIR = "$(INTERNAL_DIR)/bazel";
@@ -5059,6 +5061,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_ASSET_SYMBOLS = NO;
 				BAZEL_CONFIG = rules_xcodeproj;
 				BAZEL_EXTERNAL = "$(BAZEL_OUTPUT_BASE)/external";
 				BAZEL_INTEGRATION_DIR = "$(INTERNAL_DIR)/bazel";

--- a/tools/generators/legacy/src/Generator/CreateProject.swift
+++ b/tools/generators/legacy/src/Generator/CreateProject.swift
@@ -159,6 +159,7 @@ $(PROJECT_TEMP_DIR)/$(BAZEL_PACKAGE_BIN_DIR)/$(COMPILE_TARGET_NAME)
 
         if buildMode.usesBazelModeBuildScripts {
             buildSettings.merge([
+                "ASSETCATALOG_COMPILER_GENERATE_ASSET_SYMBOLS": false,
                 "CC": "$(BAZEL_INTEGRATION_DIR)/clang.sh",
                 "CXX": "$(BAZEL_INTEGRATION_DIR)/clang.sh",
                 "CODE_SIGNING_ALLOWED": false,

--- a/tools/generators/legacy/test/CreateProjectTests.swift
+++ b/tools/generators/legacy/test/CreateProjectTests.swift
@@ -187,6 +187,7 @@ $(PROJECT_TEMP_DIR)/$(BAZEL_PACKAGE_BIN_DIR)/$(COMPILE_TARGET_NAME)
 
         let buildSettings: [String: Any] = [
             "ALWAYS_SEARCH_USER_PATHS": false,
+            "ASSETCATALOG_COMPILER_GENERATE_ASSET_SYMBOLS": false,
             "BAZEL_CONFIG": "rules_xcodeproj_fixtures",
             "BAZEL_EXTERNAL": "$(BAZEL_OUTPUT_BASE)/external",
             "BAZEL_LLDB_INIT": "$(HOME)/.lldbinit-rules_xcodeproj",

--- a/tools/generators/pbxproj_prefix/README.md
+++ b/tools/generators/pbxproj_prefix/README.md
@@ -185,6 +185,7 @@ Here is an example output:
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_ASSET_SYMBOLS = NO;
 				BAZEL_CONFIG = rules_xcodeproj;
 				BAZEL_EXTERNAL = "$(BAZEL_OUTPUT_BASE)/external";
 				BAZEL_INTEGRATION_DIR = "$(INTERNAL_DIR)/bazel";
@@ -252,6 +253,7 @@ Here is an example output:
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_ASSET_SYMBOLS = NO;
 				BAZEL_CONFIG = rules_xcodeproj;
 				BAZEL_EXTERNAL = "$(BAZEL_OUTPUT_BASE)/external";
 				BAZEL_INTEGRATION_DIR = "$(INTERNAL_DIR)/bazel";

--- a/tools/generators/pbxproj_prefix/src/Generator/PBXProjectBuildSettings.swift
+++ b/tools/generators/pbxproj_prefix/src/Generator/PBXProjectBuildSettings.swift
@@ -24,6 +24,10 @@ extension Generator {
     ) -> String {
         return createBuildSettingsAttribute(buildSettings: [
             .init(key: "ALWAYS_SEARCH_USER_PATHS", value: "NO"),
+            .init(
+                key: "ASSETCATALOG_COMPILER_GENERATE_ASSET_SYMBOLS",
+                value: "NO"
+            ),
             .init(key: "BAZEL_CONFIG", value: "rules_xcodeproj"),
             .init(
                 key: "BAZEL_EXTERNAL",

--- a/tools/generators/pbxproj_prefix/test/PBXProjectBuildSettingsTests.swift
+++ b/tools/generators/pbxproj_prefix/test/PBXProjectBuildSettingsTests.swift
@@ -19,6 +19,7 @@ class PBXProjectBuildSettingsTests: XCTestCase {
         let expectedBuildSettings = #"""
 {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_ASSET_SYMBOLS = NO;
 				BAZEL_CONFIG = rules_xcodeproj;
 				BAZEL_EXTERNAL = "$(BAZEL_OUTPUT_BASE)/external";
 				BAZEL_INTEGRATION_DIR = "$(INTERNAL_DIR)/bazel";


### PR DESCRIPTION
We can’t use the artifacts it in BwB mode.