### PR TITLE
Prevent `.objlist` files from appearing in `extra_files`

### DIFF
--- a/xcodeproj/internal/linker_input_files.bzl
+++ b/xcodeproj/internal/linker_input_files.bzl
@@ -10,6 +10,7 @@ _SKIP_INPUT_EXTENSIONS = {
     "dylib": None,
     "framework": None,
     "lo": None,
+    "objlist": None,
     "swiftmodule": None,
     "xctest": None,
 }


### PR DESCRIPTION
A linking change in Bazel is causing these files to come through via the additional inputs. We can revert if people have an actual use case for these files to be there.