### PR TITLE
Include all transitive swiftmodules in `bc` output group when needed

### DIFF
--- a/xcodeproj/internal/input_files.bzl
+++ b/xcodeproj/internal/input_files.bzl
@@ -553,10 +553,10 @@ def _collect_input_files(
                 ],
             )
         for module in non_target_swift_info_modules.to_list():
-            compiled, indexstore = swift_to_outputs(
+            swiftmodules, indexstore = swift_to_outputs(
                 parse_swift_info_module(module),
             )
-            generated.extend(compiled)
+            generated.extend(swiftmodules)
             if should_produce_output_groups and indexstore:
                 indexstores.append(indexstore)
 
@@ -568,16 +568,11 @@ def _collect_input_files(
         unfocused_generated_compiling = []
         unfocused_generated_indexstores = []
         for module in unfocused_swift_info_modules.to_list():
-            compiled, indexstore = swift_to_outputs(
+            swiftmodules, indexstore = swift_to_outputs(
                 parse_swift_info_module(module),
             )
 
-            if compiled:
-                # We only need the single swiftmodule in order to download
-                # everything from the remote cache (because of
-                # `--experimental_remote_download_regex`). Reducing the number
-                # of items in an output group keeps the BEP small.
-                unfocused_generated_compiling.append(compiled[0])
+            unfocused_generated_compiling.extend(swiftmodules)
             if indexstore:
                 unfocused_generated_indexstores.append(indexstore)
 
@@ -642,6 +637,10 @@ def _collect_input_files(
     # would get a `depset` for the modulemaps, so they would be properly
     # represented in the BEP.
     modulemaps = modulemaps_depset.to_list()
+
+    a = [e for e in extra_files if "archive.objlist" in e]
+    if a:
+        print("WWWWWWWWTFFFFFFFFFFFF 1?", id, a)
 
     if id:
         compiling_files = memory_efficient_depset(

--- a/xcodeproj/internal/input_files.bzl
+++ b/xcodeproj/internal/input_files.bzl
@@ -638,10 +638,6 @@ def _collect_input_files(
     # represented in the BEP.
     modulemaps = modulemaps_depset.to_list()
 
-    a = [e for e in extra_files if "archive.objlist" in e]
-    if a:
-        print("WWWWWWWWTFFFFFFFFFFFF 1?", id, a)
-
     if id:
         compiling_files = memory_efficient_depset(
             modulemaps,

--- a/xcodeproj/internal/target_properties.bzl
+++ b/xcodeproj/internal/target_properties.bzl
@@ -1,6 +1,6 @@
 """Functions for processing target properties"""
 
-load(":collections.bzl", "set_if_true", "uniq")
+load(":collections.bzl", "uniq")
 load(":memory_efficiency.bzl", "memory_efficient_depset")
 
 _WATCHKIT2 = "com.apple.product-type.application.watchapp2"

--- a/xcodeproj/internal/xcode_targets.bzl
+++ b/xcodeproj/internal/xcode_targets.bzl
@@ -241,7 +241,7 @@ def _to_xcode_target_outputs(outputs):
     swift_generated_header = None
     if direct_outputs:
         swift = direct_outputs.swift
-        if swift:
+        if swift and swift.module:
             swiftmodule = swift.module.swiftmodule
             if swift.generated_header:
                 swift_generated_header = swift.generated_header


### PR DESCRIPTION
Fixes #2563.

Top-level swift targets, such as `swift_test` don’t set a value for `SwiftInfo.direct_modules[0].swift`. This makes sense, as downstream targets shouldn’t get any transitive swiftmodules from it. We previously worked around this by manually including transitive direct swiftmodules. This worked fine until compiler plugins, which introduced a new way that transitive swiftmodules could be collected. Thankfully the information we need is in the `compilation_context`.

As part of this change, we now only add the `.swiftmodule` files to `generated`. Previously we would add `.swiftdoc` and the generated header as well. We can’t do that with the information in `compilation_context`. If the swift generated header is used as an input for another target, it will get picked up that way.