### PR TITLE
Remove temporary_directory

### DIFF
--- a/xcodeproj/internal/xcodeproj_macro.bzl
+++ b/xcodeproj/internal/xcodeproj_macro.bzl
@@ -514,7 +514,6 @@ Please refer to https://bazel.build/extending/config#defining) on how to them.
         project_options = project_options,
         scheme_autogeneration_mode = scheme_autogeneration_mode,
         schemes_json = schemes_json,
-        temporary_directory = temporary_directory,
         testonly = testonly,
         top_level_device_targets = top_level_device_targets,
         top_level_simulator_targets = top_level_simulator_targets,


### PR DESCRIPTION
This was setting `temporary_directory = None` on xcodeproj_runner, although it doesn't define it.

Example failure: https://buildkite.com/bazel/bazelisk-plus-incompatible-flags/builds/1645#018a8918-b94e-4920-97c1-46fee1f6c2e7
Addresses: https://github.com/bazelbuild/bazel/issues/19403