### PR TITLE
Add `tools/bazel` to release code ownership

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,6 +5,7 @@
 /.bcr/ @MobileNativeFoundation/rules_xcodeproj-maintainers-release
 /distribution/ @MobileNativeFoundation/rules_xcodeproj-maintainers-release
 /MODULE.bazel @MobileNativeFoundation/rules_xcodeproj-maintainers-release
+/tools/bazel @MobileNativeFoundation/rules_xcodeproj-maintainers-release
 /xcodeproj/repositories.bzl @MobileNativeFoundation/rules_xcodeproj-maintainers-release
 
 # Admin


### PR DESCRIPTION
This script can impact how a release could be made.