### PR TITLE
Add `.bazelversion` to release code ownership

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,6 +2,7 @@
 
 # Release
 
+/.bazelversion @MobileNativeFoundation/rules_xcodeproj-maintainers-release
 /.bcr/ @MobileNativeFoundation/rules_xcodeproj-maintainers-release
 /distribution/ @MobileNativeFoundation/rules_xcodeproj-maintainers-release
 /MODULE.bazel @MobileNativeFoundation/rules_xcodeproj-maintainers-release


### PR DESCRIPTION
Bazel version (or a fork) can impact how a release could be made.