### PR TITLE
Remove label from `ConsolidationMapEntry.encode()`

### DIFF
--- a/tools/generators/lib/PBXProj/src/ConsolidationMapEntry.swift
+++ b/tools/generators/lib/PBXProj/src/ConsolidationMapEntry.swift
@@ -35,7 +35,7 @@ extension ConsolidationMapEntry {
     private static let subSeparatorCharacter: Character = "\t"
 
     public static func encode(
-        entires: [ConsolidationMapEntry],
+        _ entires: [ConsolidationMapEntry],
         to url: URL
     ) throws {
         var data = Data()

--- a/tools/generators/lib/PBXProj/test/ConsolidationMapEntryTests.swift
+++ b/tools/generators/lib/PBXProj/test/ConsolidationMapEntryTests.swift
@@ -38,7 +38,7 @@ final class ConsolidationMapEntryTests: XCTestCase {
 
         // Act
 
-        try ConsolidationMapEntry.encode(entires: input, to: file)
+        try ConsolidationMapEntry.encode(input, to: file)
         let output = try await ConsolidationMapEntry.decode(from: file)
 
         // Assert

--- a/tools/generators/pbxtargetdependencies/src/Generator/WriteConsolidationMap.swift
+++ b/tools/generators/pbxtargetdependencies/src/Generator/WriteConsolidationMap.swift
@@ -34,6 +34,6 @@ extension Generator.WriteConsolidationMap {
         _ entries: [ConsolidationMapEntry],
         to url: URL
     ) throws {
-        try ConsolidationMapEntry.encode(entires: entries, to: url)
+        try ConsolidationMapEntry.encode(entries, to: url)
     }
 }

--- a/tools/generators/pbxtargetdependencies/src/Generator/WriteConsolidationMaps.swift
+++ b/tools/generators/pbxtargetdependencies/src/Generator/WriteConsolidationMaps.swift
@@ -19,7 +19,7 @@ extension Generator {
             self.callable = callable
         }
 
-        /// Writes a consolidation map to disk.
+        /// Writes consolidation maps to disk.
         func callAsFunction(
             _ consolidationMaps: [URL : [ConsolidationMapEntry]]
         ) async throws {


### PR DESCRIPTION
Just a little cleanup.