### PR TITLE
Add `Decodable` conformance to `TargetID`

### DIFF
--- a/tools/generators/lib/PBXProj/src/TargetID.swift
+++ b/tools/generators/lib/PBXProj/src/TargetID.swift
@@ -1,4 +1,5 @@
 import ArgumentParser
+import Foundation
 
 /// A type-safe identifier for a target.
 public struct TargetID: Equatable, Hashable, ExpressibleByArgument {
@@ -23,6 +24,14 @@ extension TargetID: Comparable {
 extension TargetID: CustomStringConvertible {
     public var description: String {
         return rawValue
+    }
+}
+
+// MARK: - Decodable
+
+extension TargetID: Decodable {
+    public init(from decoder: Decoder) throws {
+        self.init(try decoder.singleValueContainer().decode(String.self))
     }
 }
 


### PR DESCRIPTION
Will be used in decoding `extension_point_identifiers_file`.