### PR TITLE
Add `ExpressibleByArgument` conformance to `Optional`

### DIFF
--- a/tools/generators/lib/PBXProj/src/Optional+Extensions.swift
+++ b/tools/generators/lib/PBXProj/src/Optional+Extensions.swift
@@ -1,0 +1,12 @@
+import ArgumentParser
+
+// MARK: - ExpressibleByArgument
+
+extension Optional: ExpressibleByArgument where Wrapped: ExpressibleByArgument {
+    public init?(argument: String) {
+        guard !argument.isEmpty else {
+            return nil
+        }
+        self = Wrapped(argument: argument)
+    }
+}


### PR DESCRIPTION
This will allow using things like `String?` directly in `ParsableArguments`.