### PR TITLE
Remove unneeded `extra_indexbuild_flags` setting

### DIFF
--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj_extra_flags.bazelrc
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj_extra_flags.bazelrc
@@ -1,2 +1,1 @@
 build:rules_xcodeproj_integration --config=cache
-build:rules_xcodeproj_integration_indexbuild --bes_backend= --bes_results_url=

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj_extra_flags.bazelrc
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj_extra_flags.bazelrc
@@ -1,2 +1,1 @@
 build:rules_xcodeproj_integration --config=cache
-build:rules_xcodeproj_integration_indexbuild --bes_backend= --bes_results_url=

--- a/examples/rules_ios/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj_extra_flags.bazelrc
+++ b/examples/rules_ios/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj_extra_flags.bazelrc
@@ -1,2 +1,1 @@
 build:rules_xcodeproj --config=cache
-build:rules_xcodeproj_indexbuild --bes_backend= --bes_results_url=

--- a/shared.bazelrc
+++ b/shared.bazelrc
@@ -54,7 +54,6 @@ build:cache --jobs=100
 build:cache --modify_execution_info=^(BitcodeSymbolsCopy|BundleApp|BundleTreeApp|DsymDwarf|DsymLipo|GenerateAppleSymbolsFile|ObjcBinarySymbolStrip|CppLink|ObjcLink|ProcessAndSign|SignBinary|SwiftArchive|SwiftStdlibCopy)$=+no-remote,^(BundleResources|ImportedDynamicFrameworkProcessor)$=+no-remote-exec
 build:cache --remote_cache=grpcs://remote.buildbuddy.io
 build:cache --@rules_xcodeproj//xcodeproj:extra_common_flags='--config=cache'
-build:cache --@rules_xcodeproj//xcodeproj:extra_indexbuild_flags='--bes_backend= --bes_results_url='
 build:cache --@rules_xcodeproj//xcodeproj:extra_generator_flags='--bes_backend= --bes_results_url='
 
 # Build with --config=remote to use BuildBuddy RBE


### PR DESCRIPTION
We already unset `--bes_backend= --bes_results_url=` for `indexbuild_rules_xcodeproj` in `xcodeproj.bazelrc`.