### PR TITLE
Fix process build log paths

### DIFF
--- a/xcodeproj/internal/bazel_integration_files/process_bazel_build_log.py
+++ b/xcodeproj/internal/bazel_integration_files/process_bazel_build_log.py
@@ -19,14 +19,14 @@ def _main(command: List[str]) -> None:
     bazel_out_directory = os.getenv("BAZEL_OUT")
     if not bazel_out_directory:
         sys.exit("BAZEL_OUT environment variable must be set")
-    bazel_out_prefix = bazel_out_directory[:-(len("/bazel-out")+1)]
+    bazel_out_prefix = bazel_out_directory[:-len("/bazel-out")]
     if not bazel_out_prefix.startswith("/"):
         bazel_out_prefix = f"{srcroot}/{bazel_out_prefix}"
 
     external_directory = os.getenv("BAZEL_EXTERNAL")
     if not external_directory:
         sys.exit("BAZEL_EXTERNAL environment variable must be set")
-    external_prefix = bazel_out_directory[:-(len("/external")+1)]
+    external_prefix = bazel_out_directory[:-len("/external")]
     if not external_prefix.startswith("/"):
         external_prefix = f"{srcroot}/{external_prefix}"
 


### PR DESCRIPTION
Looks like there's an off by 1 error in the log processing. The `BAZEL_OUT` environment variable sets up paths that end with `execroot/repo-name/bazel-out`, and this is causing an extra character to get cut off, which means error log paths produce `execroot/repo-nam/bazel-out` instead of `execroot/repo-name/bazel-out`.