### PR TITLE
Use `@autoclosure` with `Dictionary.value()`

### DIFF
--- a/tools/generators/lib/PBXProj/src/Dictionary+Extensions.swift
+++ b/tools/generators/lib/PBXProj/src/Dictionary+Extensions.swift
@@ -13,14 +13,14 @@ extension Dictionary {
 extension Dictionary where Key: Comparable {
     public func value(
         for key: Key,
-        context: String,
+        context: @autoclosure () -> String,
         file: StaticString = #filePath,
         line: UInt = #line
     ) throws -> Value {
         guard let value = self[key] else {
             throw PreconditionError(
                 message: """
-\(context) "\(key)" not found in:
+\(context()) "\(key)" not found in:
 \(keys.sorted())
 """,
                 file: file,


### PR DESCRIPTION
Will prevent string creation if there isn’t an error.