### PR TITLE
Disable Bazel sandboxing by default

### DIFF
--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -63,6 +63,10 @@ build:rules_xcodeproj --nolegacy_important_outputs
 # in the logs when generating, and all of the many outputs when building
 build:rules_xcodeproj --show_result=0
 
+# Disable sandboxing. Sandboxing on macOS is still very slow.
+build:rules_xcodeproj --noworker_sandboxing
+build:rules_xcodeproj --spawn_strategy=remote,worker,local
+
 ### `--config=rules_xcodeproj_generator`
 #
 # Used when generating a project.

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -63,6 +63,10 @@ build:rules_xcodeproj --nolegacy_important_outputs
 # in the logs when generating, and all of the many outputs when building
 build:rules_xcodeproj --show_result=0
 
+# Disable sandboxing. Sandboxing on macOS is still very slow.
+build:rules_xcodeproj --noworker_sandboxing
+build:rules_xcodeproj --spawn_strategy=remote,worker,local
+
 ### `--config=rules_xcodeproj_generator`
 #
 # Used when generating a project.

--- a/examples/rules_ios/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/rules_ios/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -63,6 +63,10 @@ build:rules_xcodeproj --nolegacy_important_outputs
 # in the logs when generating, and all of the many outputs when building
 build:rules_xcodeproj --show_result=0
 
+# Disable sandboxing. Sandboxing on macOS is still very slow.
+build:rules_xcodeproj --noworker_sandboxing
+build:rules_xcodeproj --spawn_strategy=remote,worker,local
+
 ### `--config=rules_xcodeproj_generator`
 #
 # Used when generating a project.

--- a/xcodeproj/internal/templates/xcodeproj.bazelrc
+++ b/xcodeproj/internal/templates/xcodeproj.bazelrc
@@ -63,6 +63,10 @@ build:rules_xcodeproj --nolegacy_important_outputs
 # in the logs when generating, and all of the many outputs when building
 build:rules_xcodeproj --show_result=0
 
+# Disable sandboxing. Sandboxing on macOS is still very slow.
+build:rules_xcodeproj --noworker_sandboxing
+build:rules_xcodeproj --spawn_strategy=remote,worker,local
+
 ### `--config=rules_xcodeproj_generator`
 #
 # Used when generating a project.


### PR DESCRIPTION
For non-Swift targets, this is a huge speedup.