### PR TITLE
Only use special `platform_mappings` when using Bzlmod with Bazel 6

### DIFF
--- a/examples/integration/.bazelrc
+++ b/examples/integration/.bazelrc
@@ -3,8 +3,6 @@ import %workspace%/../../shared.bazelrc
 
 build --experimental_cc_implementation_deps
 
-common:nobzlmod --platform_mappings=platform_mappings-nobzlmod
-
 # Exercise the extra flags feature
 
 build:rules_xcodeproj --@rules_xcodeproj//xcodeproj:extra_common_flags='--verbose_failures'

--- a/examples/integration/bazel_6.bazelrc
+++ b/examples/integration/bazel_6.bazelrc
@@ -1,0 +1,2 @@
+common --platform_mappings=platform_mappings-bzlmod_no_repo_map
+common:nobzlmod --platform_mappings=platform_mappings

--- a/examples/integration/platform_mappings
+++ b/examples/integration/platform_mappings
@@ -1,129 +1,129 @@
 platforms:
-  @@apple_support~1.9.0//platforms:macos_x86_64
+  @build_bazel_apple_support//platforms:macos_x86_64
     --apple_platform_type=macos
     --cpu=darwin_x86_64
 
-  @@apple_support~1.9.0//platforms:macos_arm64
+  @build_bazel_apple_support//platforms:macos_arm64
     --apple_platform_type=macos
     --cpu=darwin_arm64
 
-  @@apple_support~1.9.0//platforms:macos_arm64e
+  @build_bazel_apple_support//platforms:macos_arm64e
     --apple_platform_type=macos
     --cpu=darwin_arm64e
 
-  @@apple_support~1.9.0//platforms:ios_i386
+  @build_bazel_apple_support//platforms:ios_i386
     --apple_platform_type=ios
     --cpu=ios_i386
 
-  @@apple_support~1.9.0//platforms:ios_x86_64
+  @build_bazel_apple_support//platforms:ios_x86_64
     --apple_platform_type=ios
     --cpu=ios_x86_64
 
-  @@apple_support~1.9.0//platforms:ios_sim_arm64
+  @build_bazel_apple_support//platforms:ios_sim_arm64
     --apple_platform_type=ios
     --cpu=ios_sim_arm64
 
-  @@apple_support~1.9.0//platforms:ios_armv7
+  @build_bazel_apple_support//platforms:ios_armv7
     --apple_platform_type=ios
     --cpu=ios_armv7
 
-  @@apple_support~1.9.0//platforms:ios_arm64
+  @build_bazel_apple_support//platforms:ios_arm64
     --apple_platform_type=ios
     --cpu=ios_arm64
 
-  @@apple_support~1.9.0//platforms:ios_arm64e
+  @build_bazel_apple_support//platforms:ios_arm64e
     --apple_platform_type=ios
     --cpu=ios_arm64e
 
-  @@apple_support~1.9.0//platforms:tvos_x86_64
+  @build_bazel_apple_support//platforms:tvos_x86_64
     --apple_platform_type=tvos
     --cpu=tvos_x86_64
 
-  @@apple_support~1.9.0//platforms:tvos_sim_arm64
+  @build_bazel_apple_support//platforms:tvos_sim_arm64
     --apple_platform_type=tvos
     --cpu=tvos_sim_arm64
 
-  @@apple_support~1.9.0//platforms:tvos_arm64
+  @build_bazel_apple_support//platforms:tvos_arm64
     --apple_platform_type=tvos
     --cpu=tvos_arm64
 
-  @@apple_support~1.9.0//platforms:watchos_x86_64
+  @build_bazel_apple_support//platforms:watchos_x86_64
     --apple_platform_type=watchos
     --cpu=watchos_x86_64
 
-  @@apple_support~1.9.0//platforms:watchos_arm64
+  @build_bazel_apple_support//platforms:watchos_arm64
     --apple_platform_type=watchos
     --cpu=watchos_arm64
 
-  @@apple_support~1.9.0//platforms:watchos_armv7k
+  @build_bazel_apple_support//platforms:watchos_armv7k
     --apple_platform_type=watchos
     --cpu=watchos_armv7k
 
-  @@apple_support~1.9.0//platforms:watchos_arm64_32
+  @build_bazel_apple_support//platforms:watchos_arm64_32
     --apple_platform_type=watchos
     --cpu=watchos_arm64_32
 
 flags:
   --cpu=darwin_x86_64
   --apple_platform_type=macos
-    @@apple_support~1.9.0//platforms:macos_x86_64
+    @build_bazel_apple_support//platforms:macos_x86_64
 
   --cpu=darwin_arm64
   --apple_platform_type=macos
-    @@apple_support~1.9.0//platforms:macos_arm64
+    @build_bazel_apple_support//platforms:macos_arm64
 
   --cpu=darwin_arm64e
   --apple_platform_type=macos
-    @@apple_support~1.9.0//platforms:macos_arm64e
+    @build_bazel_apple_support//platforms:macos_arm64e
 
   --cpu=ios_i386
   --apple_platform_type=ios
-    @@apple_support~1.9.0//platforms:ios_i386
+    @build_bazel_apple_support//platforms:ios_i386
 
   --cpu=ios_x86_64
   --apple_platform_type=ios
-    @@apple_support~1.9.0//platforms:ios_x86_64
+    @build_bazel_apple_support//platforms:ios_x86_64
 
   --cpu=ios_sim_arm64
   --apple_platform_type=ios
-    @@apple_support~1.9.0//platforms:ios_sim_arm64
+    @build_bazel_apple_support//platforms:ios_sim_arm64
 
   --cpu=ios_armv7
   --apple_platform_type=ios
-    @@apple_support~1.9.0//platforms:ios_armv7
+    @build_bazel_apple_support//platforms:ios_armv7
 
   --cpu=ios_arm64
   --apple_platform_type=ios
-    @@apple_support~1.9.0//platforms:ios_arm64
+    @build_bazel_apple_support//platforms:ios_arm64
 
   --cpu=ios_arm64e
   --apple_platform_type=ios
-    @@apple_support~1.9.0//platforms:ios_arm64e
+    @build_bazel_apple_support//platforms:ios_arm64e
 
   --cpu=tvos_x86_64
   --apple_platform_type=tvos
-    @@apple_support~1.9.0//platforms:tvos_x86_64
+    @build_bazel_apple_support//platforms:tvos_x86_64
 
   --cpu=tvos_sim_arm64
   --apple_platform_type=tvos
-    @@apple_support~1.9.0//platforms:tvos_sim_arm64
+    @build_bazel_apple_support//platforms:tvos_sim_arm64
 
   --cpu=tvos_arm64
   --apple_platform_type=tvos
-    @@apple_support~1.9.0//platforms:tvos_arm64
+    @build_bazel_apple_support//platforms:tvos_arm64
 
   --cpu=watchos_x86_64
   --apple_platform_type=watchos
-    @@apple_support~1.9.0//platforms:watchos_x86_64
+    @build_bazel_apple_support//platforms:watchos_x86_64
 
   --cpu=watchos_arm64
   --apple_platform_type=watchos
-    @@apple_support~1.9.0//platforms:watchos_arm64
+    @build_bazel_apple_support//platforms:watchos_arm64
 
   --cpu=watchos_armv7k
   --apple_platform_type=watchos
-    @@apple_support~1.9.0//platforms:watchos_armv7k
+    @build_bazel_apple_support//platforms:watchos_armv7k
 
   --cpu=watchos_arm64_32
   --apple_platform_type=watchos
-    @@apple_support~1.9.0//platforms:watchos_arm64_32
+    @build_bazel_apple_support//platforms:watchos_arm64_32

--- a/examples/integration/platform_mappings-bzlmod_no_repo_map
+++ b/examples/integration/platform_mappings-bzlmod_no_repo_map
@@ -1,129 +1,129 @@
 platforms:
-  @build_bazel_apple_support//platforms:macos_x86_64
+  @@apple_support~1.9.0//platforms:macos_x86_64
     --apple_platform_type=macos
     --cpu=darwin_x86_64
 
-  @build_bazel_apple_support//platforms:macos_arm64
+  @@apple_support~1.9.0//platforms:macos_arm64
     --apple_platform_type=macos
     --cpu=darwin_arm64
 
-  @build_bazel_apple_support//platforms:macos_arm64e
+  @@apple_support~1.9.0//platforms:macos_arm64e
     --apple_platform_type=macos
     --cpu=darwin_arm64e
 
-  @build_bazel_apple_support//platforms:ios_i386
+  @@apple_support~1.9.0//platforms:ios_i386
     --apple_platform_type=ios
     --cpu=ios_i386
 
-  @build_bazel_apple_support//platforms:ios_x86_64
+  @@apple_support~1.9.0//platforms:ios_x86_64
     --apple_platform_type=ios
     --cpu=ios_x86_64
 
-  @build_bazel_apple_support//platforms:ios_sim_arm64
+  @@apple_support~1.9.0//platforms:ios_sim_arm64
     --apple_platform_type=ios
     --cpu=ios_sim_arm64
 
-  @build_bazel_apple_support//platforms:ios_armv7
+  @@apple_support~1.9.0//platforms:ios_armv7
     --apple_platform_type=ios
     --cpu=ios_armv7
 
-  @build_bazel_apple_support//platforms:ios_arm64
+  @@apple_support~1.9.0//platforms:ios_arm64
     --apple_platform_type=ios
     --cpu=ios_arm64
 
-  @build_bazel_apple_support//platforms:ios_arm64e
+  @@apple_support~1.9.0//platforms:ios_arm64e
     --apple_platform_type=ios
     --cpu=ios_arm64e
 
-  @build_bazel_apple_support//platforms:tvos_x86_64
+  @@apple_support~1.9.0//platforms:tvos_x86_64
     --apple_platform_type=tvos
     --cpu=tvos_x86_64
 
-  @build_bazel_apple_support//platforms:tvos_sim_arm64
+  @@apple_support~1.9.0//platforms:tvos_sim_arm64
     --apple_platform_type=tvos
     --cpu=tvos_sim_arm64
 
-  @build_bazel_apple_support//platforms:tvos_arm64
+  @@apple_support~1.9.0//platforms:tvos_arm64
     --apple_platform_type=tvos
     --cpu=tvos_arm64
 
-  @build_bazel_apple_support//platforms:watchos_x86_64
+  @@apple_support~1.9.0//platforms:watchos_x86_64
     --apple_platform_type=watchos
     --cpu=watchos_x86_64
 
-  @build_bazel_apple_support//platforms:watchos_arm64
+  @@apple_support~1.9.0//platforms:watchos_arm64
     --apple_platform_type=watchos
     --cpu=watchos_arm64
 
-  @build_bazel_apple_support//platforms:watchos_armv7k
+  @@apple_support~1.9.0//platforms:watchos_armv7k
     --apple_platform_type=watchos
     --cpu=watchos_armv7k
 
-  @build_bazel_apple_support//platforms:watchos_arm64_32
+  @@apple_support~1.9.0//platforms:watchos_arm64_32
     --apple_platform_type=watchos
     --cpu=watchos_arm64_32
 
 flags:
   --cpu=darwin_x86_64
   --apple_platform_type=macos
-    @build_bazel_apple_support//platforms:macos_x86_64
+    @@apple_support~1.9.0//platforms:macos_x86_64
 
   --cpu=darwin_arm64
   --apple_platform_type=macos
-    @build_bazel_apple_support//platforms:macos_arm64
+    @@apple_support~1.9.0//platforms:macos_arm64
 
   --cpu=darwin_arm64e
   --apple_platform_type=macos
-    @build_bazel_apple_support//platforms:macos_arm64e
+    @@apple_support~1.9.0//platforms:macos_arm64e
 
   --cpu=ios_i386
   --apple_platform_type=ios
-    @build_bazel_apple_support//platforms:ios_i386
+    @@apple_support~1.9.0//platforms:ios_i386
 
   --cpu=ios_x86_64
   --apple_platform_type=ios
-    @build_bazel_apple_support//platforms:ios_x86_64
+    @@apple_support~1.9.0//platforms:ios_x86_64
 
   --cpu=ios_sim_arm64
   --apple_platform_type=ios
-    @build_bazel_apple_support//platforms:ios_sim_arm64
+    @@apple_support~1.9.0//platforms:ios_sim_arm64
 
   --cpu=ios_armv7
   --apple_platform_type=ios
-    @build_bazel_apple_support//platforms:ios_armv7
+    @@apple_support~1.9.0//platforms:ios_armv7
 
   --cpu=ios_arm64
   --apple_platform_type=ios
-    @build_bazel_apple_support//platforms:ios_arm64
+    @@apple_support~1.9.0//platforms:ios_arm64
 
   --cpu=ios_arm64e
   --apple_platform_type=ios
-    @build_bazel_apple_support//platforms:ios_arm64e
+    @@apple_support~1.9.0//platforms:ios_arm64e
 
   --cpu=tvos_x86_64
   --apple_platform_type=tvos
-    @build_bazel_apple_support//platforms:tvos_x86_64
+    @@apple_support~1.9.0//platforms:tvos_x86_64
 
   --cpu=tvos_sim_arm64
   --apple_platform_type=tvos
-    @build_bazel_apple_support//platforms:tvos_sim_arm64
+    @@apple_support~1.9.0//platforms:tvos_sim_arm64
 
   --cpu=tvos_arm64
   --apple_platform_type=tvos
-    @build_bazel_apple_support//platforms:tvos_arm64
+    @@apple_support~1.9.0//platforms:tvos_arm64
 
   --cpu=watchos_x86_64
   --apple_platform_type=watchos
-    @build_bazel_apple_support//platforms:watchos_x86_64
+    @@apple_support~1.9.0//platforms:watchos_x86_64
 
   --cpu=watchos_arm64
   --apple_platform_type=watchos
-    @build_bazel_apple_support//platforms:watchos_arm64
+    @@apple_support~1.9.0//platforms:watchos_arm64
 
   --cpu=watchos_armv7k
   --apple_platform_type=watchos
-    @build_bazel_apple_support//platforms:watchos_armv7k
+    @@apple_support~1.9.0//platforms:watchos_armv7k
 
   --cpu=watchos_arm64_32
   --apple_platform_type=watchos
-    @build_bazel_apple_support//platforms:watchos_arm64_32
+    @@apple_support~1.9.0//platforms:watchos_arm64_32


### PR DESCRIPTION
Bazel 7 now properly supports repository maps in the `platform_mappings` file.