### PR TITLE
Test 6.4.0 RCs in CI

### DIFF
--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -17,7 +17,7 @@ x_templates:
       env: {}
     - &bazel_lts
       env:
-        USE_BAZEL_VERSION: latest
+        USE_BAZEL_VERSION: last_rc
     - &bazel_head
       env:
         USE_BAZEL_VERSION: last_green


### PR DESCRIPTION
We would have had this more recently, but it was incorrectly returning an RC build instead of the latest release.