### PR TITLE
Include fixture generation in the release archive

### DIFF
--- a/xcodeproj/BUILD
+++ b/xcodeproj/BUILD
@@ -65,7 +65,6 @@ filegroup(
             "**/.*",
             "dev_extensions.bzl",
             "repositories.bzl",
-            "testing.bzl",
         ],
     ) + [
         ":release_repositories.bzl",

--- a/xcodeproj/internal/BUILD
+++ b/xcodeproj/internal/BUILD
@@ -33,7 +33,6 @@ filegroup(
         ["**"],
         exclude = [
             "**/.*",
-            "fixtures.bzl",
             "xcodeproj_tests.bzl",
         ],
     ) + [

--- a/xcodeproj/internal/templates/BUILD
+++ b/xcodeproj/internal/templates/BUILD
@@ -13,8 +13,6 @@ filegroup(
         ["**"],
         exclude = [
             "**/.*",
-            "updater.sh",
-            "validator.sh",
         ],
     ),
     tags = ["manual"],


### PR DESCRIPTION
This will be used by the integration tests, once they switch to using the release archive instead of a local override.