### PR TITLE
Upgrade `xcodeproj_rules_dependencies` rules_swift and rules_apple

### DIFF
--- a/xcodeproj/repositories.bzl
+++ b/xcodeproj/repositories.bzl
@@ -129,15 +129,15 @@ def xcodeproj_rules_dependencies(
         _maybe(
             http_archive,
             name = "build_bazel_rules_swift",
-            sha256 = "f7ab777e1b246cebed185417bffd93135be806e45248c57fd34e0f676bfb1c65",
-            url = "https://github.com/bazelbuild/rules_swift/releases/download/1.11.0/rules_swift.1.11.0.tar.gz",
+            sha256 = "abbc41234c37031bc2c561a80fe8a2f8d95efcbbf2a2cb61be0b7201b5dd01a9",
+            url = "https://github.com/bazelbuild/rules_swift/releases/download/1.12.0/rules_swift.1.12.0.tar.gz",
             ignore_version_differences = ignore_version_differences,
         )
 
         is_bazel_6 = hasattr(apple_common, "link_multi_arch_static_library")
         if is_bazel_6:
-            rules_apple_sha256 = "8ac4c7997d863f3c4347ba996e831b5ec8f7af885ee8d4fe36f1c3c8f0092b2c"
-            rules_apple_version = "2.5.0"
+            rules_apple_sha256 = "20da675977cb8249919df14d0ce6165d7b00325fb067f0b06696b893b90a55e8"
+            rules_apple_version = "3.0.0"
         else:
             rules_apple_sha256 = "f94e6dddf74739ef5cb30f000e13a2a613f6ebfa5e63588305a71fce8a8a9911"
             rules_apple_version = "1.1.3"
@@ -148,8 +148,8 @@ def xcodeproj_rules_dependencies(
             _maybe(
                 http_archive,
                 name = "build_bazel_apple_support",
-                sha256 = "45d6bbad5316c9c300878bf7fffc4ffde13d620484c9184708c917e20b8b63ff",
-                url = "https://github.com/bazelbuild/apple_support/releases/download/1.8.1/apple_support.1.8.1.tar.gz",
+                sha256 = "62cb8c6658739d22986bbe4b025fe9f0f42cce91394096dc85d64b120ccde229",
+                url = "https://github.com/bazelbuild/apple_support/releases/download/1.10.1/apple_support.1.10.1.tar.gz",
                 ignore_version_differences = ignore_version_differences,
             )
 


### PR DESCRIPTION
This upgrades `WORKSPACE` users to rules_swift 1.12.0 and rules_apple 3.0.0.

Users not on Bazel 7.0.0-pre.20230823.4 or newer will most likely need a platform_mappings file. In the `examples/integration` directory are some examples of that file.