### PR TITLE
Fix parsing of `Optional` arguments

### DIFF
--- a/tools/generators/lib/PBXProj/src/Optional+Extensions.swift
+++ b/tools/generators/lib/PBXProj/src/Optional+Extensions.swift
@@ -4,9 +4,10 @@ import ArgumentParser
 
 extension Optional: ExpressibleByArgument where Wrapped: ExpressibleByArgument {
     public init?(argument: String) {
-        guard !argument.isEmpty else {
-            return nil
+        if argument.isEmpty {
+            self = .none
+        } else {
+            self = Wrapped(argument: argument)
         }
-        self = Wrapped(argument: argument)
     }
 }


### PR DESCRIPTION
Returning `nil` means a parsing failure, we want `.some(.none)` instead.