### PR TITLE
Remove lld linker override

### DIFF
--- a/examples/integration/MODULE.bazel
+++ b/examples/integration/MODULE.bazel
@@ -18,10 +18,6 @@ bazel_dep(
     version = "1.11.0",
     repo_name = "build_bazel_rules_swift",
 )
-bazel_dep(
-    name = "rules_apple_linker",
-    version = "0.4.0",
-)
 bazel_dep(name = "bazel_skylib", version = "1.4.2")
 bazel_dep(
     name = "examples_cc_external",

--- a/examples/integration/WORKSPACE
+++ b/examples/integration/WORKSPACE
@@ -51,19 +51,6 @@ load(
 
 apple_support_dependencies()
 
-# rules_apple_linker used for testing using a different linker
-
-http_archive(
-    name = "rules_apple_linker",
-    sha256 = "70b664b3ddc335178d163f487d0bda5e895f3dc00d311c17c3b4050e780056b8",
-    strip_prefix = "rules_apple_linker-0.4.0",
-    url = "https://github.com/keith/rules_apple_linker/archive/refs/tags/0.4.0.tar.gz",
-)
-
-load("@rules_apple_linker//:deps.bzl", "rules_apple_linker_deps")
-
-rules_apple_linker_deps()
-
 # Used for testing shared cache between Intel and Apple silicon
 
 register_execution_platforms("@build_bazel_apple_support//platforms:macos_x86_64")

--- a/examples/integration/iOSApp/Source/BUILD
+++ b/examples/integration/iOSApp/Source/BUILD
@@ -91,7 +91,6 @@ ios_application(
     watch_application = "//watchOSApp",
     deps = [
         ":iOSApp.library",
-        "@rules_apple_linker//:lld",
     ],
 )
 


### PR DESCRIPTION
The most recent linker version doesn’t support rules_apple 3.0.0 with Xcode 15+. We aren’t losing out on much coverage anymore by doing this, since everything is handled in the `link.params` file with minimal filtering.