### PR TITLE
Add `Hashable` conformance to `BuildableReference`

### DIFF
--- a/tools/generators/lib/XCScheme/src/BuildableReference.swift
+++ b/tools/generators/lib/XCScheme/src/BuildableReference.swift
@@ -1,4 +1,4 @@
-public struct BuildableReference: Equatable {
+public struct BuildableReference: Equatable, Hashable {
     public let blueprintIdentifier: String
     let buildableName: String
     public let blueprintName: String


### PR DESCRIPTION
Needed in order to use `Set` to deduplicate them.