### PR TITLE
Fix legacy tests

### DIFF
--- a/tools/generators/legacy/src/Generator/CreateProducts.swift
+++ b/tools/generators/legacy/src/Generator/CreateProducts.swift
@@ -91,7 +91,7 @@ struct Products: Equatable {
 }
 
 extension Products {
-    init(_ products: [ProductKeys: PBXFileReference]) {
+    init(_ products: OrderedDictionary<ProductKeys, PBXFileReference>) {
         for (keys, product) in products {
             byTarget[keys.targetKey] = product
             for filePath in keys.filePaths {

--- a/tools/generators/legacy/test/Fixtures.swift
+++ b/tools/generators/legacy/test/Fixtures.swift
@@ -1313,7 +1313,7 @@ $(BAZEL_OUT)/z/A.link.params
 
         if let group = group {
             // The order products are added to a group matters for uuid fixing
-            products.byTarget.sortedLocalizedStandard().forEach { product in
+            products.byTarget.values.forEach { product in
                 group.addChild(product)
             }
         }


### PR DESCRIPTION
Regressed with c744087bfae1271149ec8034e163f2b756252b02, because CI was no longer testing it (which will be enabled in a future change).