### PR TITLE
Set buildableName to productName first if present

### DIFF
--- a/examples/rules_ios/iOSApp/Source/CoreUtilsMixed/MixedAnswer/BUILD
+++ b/examples/rules_ios/iOSApp/Source/CoreUtilsMixed/MixedAnswer/BUILD
@@ -10,7 +10,7 @@ rules_ios_apple_framework(
         "MixedAnswer.swift",
     ],
     bundle_id = "rules-xcodeproj.MixedAnswer",
-    module_name = "MixedAnswer",
+    module_name = "MixedAnswer_iOS",
     platforms = {
         "ios": "15.0",
     },

--- a/tools/generators/legacy/src/Extensions/PBXTarget+Extensions.swift
+++ b/tools/generators/legacy/src/Extensions/PBXTarget+Extensions.swift
@@ -7,7 +7,7 @@ extension PBXTarget {
     }
 
     var buildableName: String {
-        return product?.path ?? name
+        return (productName ?? product?.path ?? name) + "."
     }
 
     var schemeName: String {


### PR DESCRIPTION
Draft to discuss the behavior I'm seeing. Repro steps:

* In `main`, `cd examples/rules_ios` change `MixedAnswer` as in this PR and `bazel run //:xcodeproj` (don't open Xcode)
* Make a copy of `examples/rules_ios/rules_ios.xcodeproj/xcshareddata/xcschemes/MixedAnswer_iOS (Static Framework).xcscheme` and launch Xcode
* Note how launching Xcode changes the file above, the before vs after diff is:
```sh
18c18
<                      BuildableName = "MixedAnswer"
---
>                      BuildableName = "MixedAnswer_iOS."
36c36
<                BuildableName = "MixedAnswer"
---
>                BuildableName = "MixedAnswer_iOS."
```

Not sure why Xcode needs that `.` at the end and apparently it changes it to the value in `module_name`. 

The change I made in this PR to `tools/generators/legacy/src/Extensions/PBXTarget+Extensions.swift` matches what I see but looking for some help to understand if setting `buildableName` that way is desired or not. If not, how can we make the generated project match what Xcode expects?

Motivation is Xcode launch times in a big codebase, Xcode launches faster for me if the generated project matches the expected format which I assume prevents Xcode from trying to "fix it" and update these files at launch time.