### PR TITLE
Add `.value(for:context:)` to `OrderedDictionary` as well

### DIFF
--- a/tools/generators/lib/PBXProj/BUILD
+++ b/tools/generators/lib/PBXProj/BUILD
@@ -11,6 +11,7 @@ swift_library(
     deps = [
         "//tools/generators/lib/GeneratorCommon",
         "@com_github_apple_swift_argument_parser//:ArgumentParser",
+        "@com_github_apple_swift_collections//:OrderedCollections",
     ],
 )
 

--- a/tools/generators/lib/PBXProj/src/Dictionary+Extensions.swift
+++ b/tools/generators/lib/PBXProj/src/Dictionary+Extensions.swift
@@ -1,4 +1,5 @@
 import GeneratorCommon
+import OrderedCollections
 
 extension Dictionary {
     public mutating func update(_ values: [Key: Value]) {
@@ -11,6 +12,27 @@ extension Dictionary {
 }
 
 extension Dictionary where Key: Comparable {
+    public func value(
+        for key: Key,
+        context: @autoclosure () -> String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws -> Value {
+        guard let value = self[key] else {
+            throw PreconditionError(
+                message: """
+\(context()) "\(key)" not found in:
+\(keys.sorted())
+""",
+                file: file,
+                line: line
+            )
+        }
+        return value
+    }
+}
+
+extension OrderedDictionary where Key: Comparable {
     public func value(
         for key: Key,
         context: @autoclosure () -> String,


### PR DESCRIPTION
Will be used in a future change.