### PR TITLE
Encode watchKit extension information into `ConsolidationMapEntry`

### DIFF
--- a/test/internal/pbxproj_partials/write_pbxtargetdependencies_tests.bzl
+++ b/test/internal/pbxproj_partials/write_pbxtargetdependencies_tests.bzl
@@ -42,6 +42,7 @@ def _dict_to_xcode_target(d):
             type = d["product_type"],
         ),
         test_host = d["test_host"],
+        watchkit_extension = d["watchkit_extension"],
     )
 
 # FIXME: Extract
@@ -56,7 +57,8 @@ def mock_xcode_target(
         product_basename,
         product_file_path,
         product_type,
-        test_host = None):
+        test_host = None,
+        watchkit_extension = None):
     return struct(
         id = id,
         arch = arch,
@@ -68,6 +70,7 @@ def mock_xcode_target(
         product_file_path = product_file_path,
         product_type = product_type,
         test_host = test_host,
+        watchkit_extension = watchkit_extension,
     )
 
 def _write_pbxtargetdependencies_test_impl(ctx):
@@ -293,6 +296,8 @@ def write_pbxtargetdependencies_test_suite(name):
                     product_file_path = "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-3/bin/tools/generators/legacy/libgenerator.a",
                     product_basename = "libgenerator.a",
                     module_name_attribute = "generator",
+                    # This doesn't make sense, it's just to test it
+                    watchkit_extension = "//some/extension some-config",
                 ),
             },
         },
@@ -311,6 +316,10 @@ def write_pbxtargetdependencies_test_suite(name):
             "--target-and-test-hosts",
             "'//tools/generators/legacy/test:tests.__internal__.__test_bundle applebin_macos-darwin_x86_64-dbg-STABLE-3'",
             "'//tools/generators/legacy:generator applebin_macos-darwin_x86_64-dbg-STABLE-3'",
+            # targetAndWatchKitExtensions
+            "--target-and-watch-kit-extensions",
+            "'//tools/generators/legacy:generator.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1'",
+            "'//some/extension some-config'",
             # consolidationMapOutputPaths
             "--consolidation-map-output-paths",
             _consolidation_map_declared_file(0),

--- a/tools/generators/lib/PBXProj/test/ConsolidationMapEntryTests.swift
+++ b/tools/generators/lib/PBXProj/test/ConsolidationMapEntryTests.swift
@@ -16,6 +16,7 @@ final class ConsolidationMapEntryTests: XCTestCase {
                 productPath: "some/tool with spaces/c",
                 uiTestHostName: nil,
                 subIdentifier: .init(shard: "42", hash: "18270012"),
+                watchKitExtensionProductIdentifier: nil,
                 dependencySubIdentifiers: [
                     .init(shard: "02", hash: "00234561"),
                     .init(shard: "79", hash: "11111111"),
@@ -29,6 +30,13 @@ final class ConsolidationMapEntryTests: XCTestCase {
                 productPath: "a/test.xctest",
                 uiTestHostName: "Disambiguated 3 (Name)",
                 subIdentifier: .init(shard: "01", hash: "12345678"),
+                // Doesn't make sense, but testing the encoding and decoding
+                watchKitExtensionProductIdentifier: .init(
+                    shard: "42",
+                    type: .product,
+                    path: "extension.appex",
+                    hash: "77777777"
+                ),
                 dependencySubIdentifiers: []
             ),
             .init(
@@ -39,6 +47,7 @@ final class ConsolidationMapEntryTests: XCTestCase {
                 productPath: "a/libtest.a",
                 uiTestHostName: nil,
                 subIdentifier: .init(shard: "00", hash: "00000000"),
+                watchKitExtensionProductIdentifier: nil,
                 dependencySubIdentifiers: [
                     .init(shard: "44", hash: "00000000"),
                 ]

--- a/tools/generators/pbxtargetdependencies/src/Generator/CalculateIdentifiedTargetsMap.swift
+++ b/tools/generators/pbxtargetdependencies/src/Generator/CalculateIdentifiedTargetsMap.swift
@@ -1,7 +1,8 @@
+import OrderedCollections
 import PBXProj
 
 extension Generator {
-    struct CalculateTargetIdentifierMap {
+    struct CalculateIdentifiedTargetsMap {
         private let callable: Callable
 
         /// - Parameters:
@@ -14,7 +15,7 @@ extension Generator {
         /// Calculates a map from target id to identifier.
         func callAsFunction(
             identifiedTargets: [IdentifiedTarget]
-        ) -> [TargetID: Identifiers.Targets.Identifier] {
+        ) -> OrderedDictionary<TargetID, IdentifiedTarget> {
             return callable(
                 /*identifiedTargets:*/ identifiedTargets
             )
@@ -22,19 +23,19 @@ extension Generator {
     }
 }
 
-// MARK: - CalculateTargetIdentifierMap.Callable
+// MARK: - CalculateIdentifiedTargetsMap.Callable
 
-extension Generator.CalculateTargetIdentifierMap {
+extension Generator.CalculateIdentifiedTargetsMap {
     typealias Callable = (
         _ identifiedTargets: [IdentifiedTarget]
-    ) -> [TargetID: Identifiers.Targets.Identifier]
+    ) -> OrderedDictionary<TargetID, IdentifiedTarget>
 
     static func defaultCallable(
         identifiedTargets: [IdentifiedTarget]
-    ) -> [TargetID: Identifiers.Targets.Identifier] {
-        return Dictionary(
+    ) -> OrderedDictionary<TargetID, IdentifiedTarget> {
+        return OrderedDictionary(
             uniqueKeysWithValues: identifiedTargets.flatMap { target in
-                target.key.sortedIds.map { ($0, target.identifier) }
+                target.key.sortedIds.map { ($0, target) }
             }
         )
     }

--- a/tools/generators/pbxtargetdependencies/src/Generator/ConsolidationMapsArguments.swift
+++ b/tools/generators/pbxtargetdependencies/src/Generator/ConsolidationMapsArguments.swift
@@ -296,7 +296,8 @@ struct ConsolidationMapArguments: Equatable {
 
 extension ConsolidationMapsArguments {
     func toConsolidationMapArguments(
-        testHosts: [TargetID: TargetID]
+        testHosts: [TargetID: TargetID],
+        watchKitExtensions: [TargetID: TargetID]
     ) throws -> [ConsolidationMapArguments] {
         var dependenciesStartIndex = dependencies.startIndex
         var labelsStartIndex = labels.startIndex
@@ -346,6 +347,14 @@ extension ConsolidationMapsArguments {
                         uiTestHost = nil
                     }
 
+                    let watchKitExtension: TargetID?
+                    if productType == .watch2App {
+                        watchKitExtension = try watchKitExtensions
+                            .value(for: id, context: "WatchKit extension")
+                    } else {
+                        watchKitExtension = nil
+                    }
+
                     targetArguments.append(
                         .init(
                             id: id,
@@ -359,6 +368,7 @@ extension ConsolidationMapsArguments {
                             productBasename: productBasenames[targetIndex],
                             moduleName: moduleNames[targetIndex],
                             uiTestHost: uiTestHost,
+                            watchKitExtension: watchKitExtension,
                             dependencies: dependencies
                         )
                     )

--- a/tools/generators/pbxtargetdependencies/src/Generator/CreateDependencyObjects.swift
+++ b/tools/generators/pbxtargetdependencies/src/Generator/CreateDependencyObjects.swift
@@ -1,3 +1,4 @@
+import OrderedCollections
 import PBXProj
 
 extension Generator {
@@ -26,11 +27,11 @@ extension Generator {
         /// objects.
         func callAsFunction(
             identifiedTargets: [IdentifiedTarget],
-            identifiers: [TargetID: Identifiers.Targets.Identifier]
+            identifiedTargetsMap: OrderedDictionary<TargetID, IdentifiedTarget>
         ) throws -> [Object] {
             return try callable(
                 /*identifiedTargets:*/ identifiedTargets,
-                /*identifiers:*/ identifiers,
+                /*identifiedTargetsMap:*/ identifiedTargetsMap,
                 /*createContainerItemProxyObject:*/
                     createContainerItemProxyObject,
                 /*createTargetDependencyObject:*/ createTargetDependencyObject
@@ -44,7 +45,7 @@ extension Generator {
 extension Generator.CreateDependencyObjects {
     typealias Callable = (
         _ identifiedTargets: [IdentifiedTarget],
-        _ identifiers: [TargetID: Identifiers.Targets.Identifier],
+        _ identifiedTargetsMap: OrderedDictionary<TargetID, IdentifiedTarget>,
         _ createContainerItemProxyObject:
             Generator.CreateContainerItemProxyObject,
         _ createTargetDependencyObject: Generator.CreateTargetDependencyObject
@@ -52,7 +53,7 @@ extension Generator.CreateDependencyObjects {
 
     static func defaultCallable(
         identifiedTargets: [IdentifiedTarget],
-        identifiers: [TargetID: Identifiers.Targets.Identifier],
+        identifiedTargetsMap: OrderedDictionary<TargetID, IdentifiedTarget>,
         createContainerItemProxyObject:
             Generator.CreateContainerItemProxyObject,
         createTargetDependencyObject: Generator.CreateTargetDependencyObject
@@ -84,10 +85,10 @@ extension Generator.CreateDependencyObjects {
             addElements(from: identifier, to: .bazelDependencies)
 
             for dependency in target.dependencies {
-                let dependencyIdentifier = try identifiers.value(
+                let dependencyIdentifier = try identifiedTargetsMap.value(
                     for: dependency,
                     context: "Dependency"
-                )
+                ).identifier
 
                 addElements(from: identifier, to: dependencyIdentifier)
             }

--- a/tools/generators/pbxtargetdependencies/src/Generator/CreateTargetAttributesObjects.swift
+++ b/tools/generators/pbxtargetdependencies/src/Generator/CreateTargetAttributesObjects.swift
@@ -1,3 +1,4 @@
+import OrderedCollections
 import PBXProj
 
 extension Generator {
@@ -21,14 +22,14 @@ extension Generator {
         /// Calculates all the `PBXProject.targets` objects.
         func callAsFunction(
             identifiedTargets: [IdentifiedTarget],
+            identifiedTargetsMap: OrderedDictionary<TargetID, IdentifiedTarget>,
             testHosts: [TargetID: TargetID],
-            identifiers: [TargetID: Identifiers.Targets.Identifier],
             createdOnToolsVersion: String
         ) throws -> [Object] {
             return try callable(
                 /*identifiedTargets:*/ identifiedTargets,
+                /*identifiedTargetsMap:*/ identifiedTargetsMap,
                 /*testHosts:*/ testHosts,
-                /*identifiers:*/ identifiers,
                 /*createdOnToolsVersion:*/ createdOnToolsVersion,
                 /*createTargetAttributesContent:*/ createTargetAttributesContent
             )
@@ -41,16 +42,16 @@ extension Generator {
 extension Generator.CreateTargetAttributesObjects {
     typealias Callable = (
         _ identifiedTargets: [IdentifiedTarget],
+        _ identifiedTargetsMap: OrderedDictionary<TargetID, IdentifiedTarget>,
         _ testHosts: [TargetID: TargetID],
-        _ identifiers: [TargetID: Identifiers.Targets.Identifier],
         _ createdOnToolsVersion: String,
         _ createTargetAttributesContent: Generator.CreateTargetAttributesContent
     ) throws -> [Object]
 
     static func defaultCallable(
         identifiedTargets: [IdentifiedTarget],
+        identifiedTargetsMap: OrderedDictionary<TargetID, IdentifiedTarget>,
         testHosts: [TargetID: TargetID],
-        identifiers: [TargetID: Identifiers.Targets.Identifier],
         createdOnToolsVersion: String,
         createTargetAttributesContent: Generator.CreateTargetAttributesContent
     ) throws -> [Object] {
@@ -73,8 +74,9 @@ extension Generator.CreateTargetAttributesObjects {
                     content: createTargetAttributesContent(
                         createdOnToolsVersion: createdOnToolsVersion,
                         testHostIdentifier: try testHosts[anId].flatMap { id in
-                            return try identifiers
+                            return try identifiedTargetsMap
                                 .value(for: id, context: "Test host")
+                                .identifier
                                 .full
                         }
                     )

--- a/tools/generators/pbxtargetdependencies/src/Generator/Environment.swift
+++ b/tools/generators/pbxtargetdependencies/src/Generator/Environment.swift
@@ -10,12 +10,12 @@ extension Generator {
 
         let calculateCreatedOnToolsVersion: CalculateCreatedOnToolsVersion
 
+        let calculateIdentifiedTargetsMap: CalculateIdentifiedTargetsMap
+
         let calculateTargetAttributesPartial: CalculateTargetAttributesPartial
 
         let calculateTargetDependenciesPartial:
             CalculateTargetDependenciesPartial
-
-        let calculateTargetIdentifierMap: CalculateTargetIdentifierMap
 
         let calculateTargetsPartial: CalculateTargetsPartial
 
@@ -36,11 +36,12 @@ extension Generator.Environment {
         calculateConsolidationMaps: Generator.CalculateConsolidationMaps(),
         calculateCreatedOnToolsVersion:
             Generator.CalculateCreatedOnToolsVersion(),
+        calculateIdentifiedTargetsMap:
+            Generator.CalculateIdentifiedTargetsMap(),
         calculateTargetAttributesPartial:
             Generator.CalculateTargetAttributesPartial(),
         calculateTargetDependenciesPartial:
             Generator.CalculateTargetDependenciesPartial(),
-        calculateTargetIdentifierMap: Generator.CalculateTargetIdentifierMap(),
         calculateTargetsPartial: Generator.CalculateTargetsPartial(),
         createDependencyObjects: Generator.CreateDependencyObjects(
             createContainerItemProxyObject:

--- a/tools/generators/pbxtargetdependencies/src/Generator/GeneratorArguments.swift
+++ b/tools/generators/pbxtargetdependencies/src/Generator/GeneratorArguments.swift
@@ -41,6 +41,12 @@ Minimum Xcode version that the generated project supports.
         )
         private var targetAndTestHosts: [TargetID] = []
 
+        @Option(
+            parsing: .upToNextOption,
+            help: "Pairs of <target> <watchkit-extension> target IDs."
+        )
+        private var targetAndWatchKitExtensions: [TargetID] = []
+
         @OptionGroup var consolidationMapsArguments: ConsolidationMapsArguments
 
         mutating func validate() throws {
@@ -64,6 +70,24 @@ extension Generator.Arguments {
                     return (
                         targetAndTestHosts[index],
                         targetAndTestHosts[index+1]
+                    )
+                }
+        )
+    }
+
+    var watchKitExtensions: [TargetID: TargetID] {
+        return Dictionary(
+            uniqueKeysWithValues:
+                stride(
+                    from: 0,
+                    to: targetAndWatchKitExtensions.count - 1,
+                    by: 2
+                )
+                .lazy
+                .map { index in
+                    return (
+                        targetAndWatchKitExtensions[index],
+                        targetAndWatchKitExtensions[index+1]
                     )
                 }
         )

--- a/tools/generators/pbxtargetdependencies/src/Generator/IdentifyTargets.swift
+++ b/tools/generators/pbxtargetdependencies/src/Generator/IdentifyTargets.swift
@@ -12,6 +12,7 @@ struct IdentifiedTarget: Equatable {
     let productBasename: String
     let uiTestHostName: String?
     let identifier: Identifiers.Targets.Identifier
+    let watchKitExtension: TargetID?
     let dependencies: [TargetID]
 }
 

--- a/tools/generators/pbxtargetdependencies/src/Generator/InnerIdentifyTargets.swift
+++ b/tools/generators/pbxtargetdependencies/src/Generator/InnerIdentifyTargets.swift
@@ -18,7 +18,7 @@ extension Generator {
 
             self.callable = callable
         }
-        
+
         /// Identifies a set of disambiguated targets.
         func callAsFunction(
             _ disambiguatedTargets: [DisambiguatedTarget],
@@ -82,6 +82,7 @@ extension Generator.InnerIdentifyTargets {
                     uiTestHostName: disambiguatedTarget
                         .target.uiTestHost.flatMap { idsToNames[$0] },
                     identifier: identifier,
+                    watchKitExtension: aTarget.watchKitExtension,
                     dependencies: aTarget.dependencies
                 )
             )

--- a/tools/generators/pbxtargetdependencies/src/Generator/Target.swift
+++ b/tools/generators/pbxtargetdependencies/src/Generator/Target.swift
@@ -18,5 +18,6 @@ struct Target: Equatable {
 
     let moduleName: String
     let uiTestHost: TargetID?
+    let watchKitExtension: TargetID?
     let dependencies: [TargetID]
 }

--- a/tools/generators/pbxtargetdependencies/test/Generator/CalculateIdentifiedTargetsMapTests.swift
+++ b/tools/generators/pbxtargetdependencies/test/Generator/CalculateIdentifiedTargetsMapTests.swift
@@ -1,23 +1,15 @@
 import CustomDump
+import OrderedCollections
 import XCTest
 
 @testable import pbxtargetdependencies
 @testable import PBXProj
 
-final class CalculateTargetIdentifierMapTests: XCTestCase {
+final class CalculateIdentifiedTargetsMapTests: XCTestCase {
     func test() throws {
         // Arrange
 
         let identifiedTargets: [IdentifiedTarget] = [
-            .mock(
-                key: ["A", "B"],
-                identifier: .init(
-                    pbxProjEscapedName: "AB",
-                    subIdentifier: .init(shard: "01", hash: "00000000"),
-                    full: "AB_ID /* AB */",
-                    withoutComment: "AB_ID"
-                )
-            ),
             .mock(
                 key: ["C"],
                 identifier: .init(
@@ -27,17 +19,26 @@ final class CalculateTargetIdentifierMapTests: XCTestCase {
                     withoutComment: "C_ID"
                 )
             ),
+            .mock(
+                key: ["A", "B"],
+                identifier: .init(
+                    pbxProjEscapedName: "AB",
+                    subIdentifier: .init(shard: "01", hash: "00000000"),
+                    full: "AB_ID /* AB */",
+                    withoutComment: "AB_ID"
+                )
+            ),
         ]
 
-        let expectedMap: [TargetID: Identifiers.Targets.Identifier] = [
-            "A": identifiedTargets[0].identifier,
-            "B": identifiedTargets[0].identifier,
-            "C": identifiedTargets[1].identifier,
+        let expectedMap: OrderedDictionary<TargetID, IdentifiedTarget> = [
+            "C": identifiedTargets[0],
+            "A": identifiedTargets[1],
+            "B": identifiedTargets[1],
         ]
 
         // Act
 
-        let map = Generator.CalculateTargetIdentifierMap
+        let map = Generator.CalculateIdentifiedTargetsMap
             .defaultCallable(identifiedTargets: identifiedTargets)
 
         // Assert

--- a/tools/generators/pbxtargetdependencies/test/Generator/ConsolidateTargetsTests.swift
+++ b/tools/generators/pbxtargetdependencies/test/Generator/ConsolidateTargetsTests.swift
@@ -716,6 +716,7 @@ extension Target {
         productBasename: String = "libtarget.a",
         moduleName: String = "",
         uiTestHost: TargetID? = nil,
+        watchKitExtension: TargetID? = nil,
         dependencies: [TargetID] = []
     ) -> Self {
         return Self(
@@ -730,6 +731,7 @@ extension Target {
             productBasename: productBasename,
             moduleName: moduleName,
             uiTestHost: uiTestHost,
+            watchKitExtension: watchKitExtension,
             dependencies: dependencies
         )
     }

--- a/tools/generators/pbxtargetdependencies/test/Generator/ConsolidationMapsArgumentsTests.swift
+++ b/tools/generators/pbxtargetdependencies/test/Generator/ConsolidationMapsArgumentsTests.swift
@@ -113,6 +113,11 @@ final class ConsolidationMapsArgumentsTests: XCTestCase {
             "//tools/generators/legacy/test:tests.__internal__.__test_bundle applebin_macos-darwin_x86_64-dbg-STABLE-4": 
                 "//tools/generators/legacy:generator applebin_macos-darwin_x86_64-dbg-STABLE-4",
         ]
+        // Doesn't make sense, just for testing
+        let watchKitExtensions: [TargetID: TargetID] = [
+            "//tools/generators/legacy/test:tests.__internal__.__test_bundle applebin_macos-darwin_x86_64-dbg-STABLE-4":
+                "//tools/generators/legacy:generator applebin_macos-darwin_x86_64-dbg-STABLE-4",
+        ]
 
         let expectedConsolidationMapArguments: [ConsolidationMapArguments] = [
             .init(
@@ -133,6 +138,7 @@ final class ConsolidationMapsArgumentsTests: XCTestCase {
                         productBasename: "generator_codesigned",
                         moduleName: "",
                         uiTestHost: nil,
+                        watchKitExtension: nil,
                         dependencies: [
                             "//tools/generators/legacy:generator.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
                         ]
@@ -149,6 +155,7 @@ final class ConsolidationMapsArgumentsTests: XCTestCase {
                         productBasename: "tests.xctest",
                         moduleName: "tests",
                         uiTestHost: "//tools/generators/legacy:generator applebin_macos-darwin_x86_64-dbg-STABLE-3",
+                        watchKitExtension: nil,
                         dependencies: [
                             "//tools/generators/legacy:generator.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
                             "//tools/generators/lib/GeneratorCommon:GeneratorCommon macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
@@ -167,6 +174,8 @@ final class ConsolidationMapsArgumentsTests: XCTestCase {
                         productBasename: "tests.xctest",
                         moduleName: "tests",
                         uiTestHost: nil,
+                        // FIXME: FIXME
+                        watchKitExtension: nil,
                         dependencies: [
                             "//tools/generators/legacy:generator.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-2",
                             "//tools/generators/lib/GeneratorCommon:GeneratorCommon macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-2",
@@ -193,6 +202,7 @@ final class ConsolidationMapsArgumentsTests: XCTestCase {
                         productBasename: "libgenerator.a",
                         moduleName: "generator",
                         uiTestHost: nil,
+                        watchKitExtension: nil,
                         dependencies: [
                             "//tools/generators/lib/GeneratorCommon:GeneratorCommon macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
                             "@com_github_apple_swift_collections//:OrderedCollections macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
@@ -208,7 +218,10 @@ final class ConsolidationMapsArgumentsTests: XCTestCase {
         // Act
 
         let consolidationMapArguments = try arguments
-            .toConsolidationMapArguments(testHosts: testHosts)
+            .toConsolidationMapArguments(
+                testHosts: testHosts,
+                watchKitExtensions: watchKitExtensions
+            )
 
         // Assert
 

--- a/tools/generators/pbxtargetdependencies/test/Generator/CreateDependencyObjectsTests.swift
+++ b/tools/generators/pbxtargetdependencies/test/Generator/CreateDependencyObjectsTests.swift
@@ -1,4 +1,5 @@
 import CustomDump
+import OrderedCollections
 import XCTest
 
 @testable import pbxtargetdependencies
@@ -32,10 +33,13 @@ final class CreateDependencyObjectsTests: XCTestCase {
                 dependencies: []
             ),
         ]
-        let identifiers: [TargetID : Identifiers.Targets.Identifier] = [
-            "A": identifiedTargets[0].identifier,
-            "B": identifiedTargets[0].identifier,
-            "C": identifiedTargets[1].identifier,
+        let identifiedTargetsMap: OrderedDictionary<
+            TargetID,
+            IdentifiedTarget
+        > = [
+            "A": identifiedTargets[0],
+            "B": identifiedTargets[0],
+            "C": identifiedTargets[1],
         ]
 
         let createContainerItemProxyObject =
@@ -59,15 +63,18 @@ final class CreateDependencyObjectsTests: XCTestCase {
             Generator.CreateContainerItemProxyObject.MockTracker.Called
         ] = [
             .init(
-                subIdentifier: identifiers["A"]!.subIdentifier,
+                subIdentifier:
+                    identifiedTargetsMap["A"]!.identifier.subIdentifier,
                 dependencyIdentifier: .bazelDependencies
             ),
             .init(
-                subIdentifier: identifiers["A"]!.subIdentifier,
-                dependencyIdentifier: identifiers["C"]!
+                subIdentifier:
+                    identifiedTargetsMap["A"]!.identifier.subIdentifier,
+                dependencyIdentifier: identifiedTargetsMap["C"]!.identifier
             ),
             .init(
-                subIdentifier: identifiers["C"]!.subIdentifier,
+                subIdentifier:
+                    identifiedTargetsMap["C"]!.identifier.subIdentifier,
                 dependencyIdentifier: .bazelDependencies
             ),
         ]
@@ -75,17 +82,20 @@ final class CreateDependencyObjectsTests: XCTestCase {
             Generator.CreateTargetDependencyObject.MockTracker.Called
         ] = [
             .init(
-                subIdentifier: identifiers["A"]!.subIdentifier,
+                subIdentifier:
+                    identifiedTargetsMap["A"]!.identifier.subIdentifier,
                 dependencyIdentifier: .bazelDependencies,
                 containerItemProxyIdentifier: "CIP_AB1_ID"
             ),
             .init(
-                subIdentifier: identifiers["A"]!.subIdentifier,
+                subIdentifier:
+                    identifiedTargetsMap["A"]!.identifier.subIdentifier,
                 dependencyIdentifier: identifiedTargets[1].identifier,
                 containerItemProxyIdentifier: "CIP_AB2_ID"
             ),
             .init(
-                subIdentifier: identifiers["C"]!.subIdentifier,
+                subIdentifier:
+                    identifiedTargetsMap["C"]!.identifier.subIdentifier,
                 dependencyIdentifier: .bazelDependencies,
                 containerItemProxyIdentifier: "CIP_C_ID"
             ),
@@ -105,7 +115,7 @@ final class CreateDependencyObjectsTests: XCTestCase {
         let objects = try Generator.CreateDependencyObjects
             .defaultCallable(
                 identifiedTargets: identifiedTargets,
-                identifiers: identifiers,
+                identifiedTargetsMap: identifiedTargetsMap,
                 createContainerItemProxyObject:
                     createContainerItemProxyObject.mock,
                 createTargetDependencyObject:
@@ -130,16 +140,6 @@ final class CreateDependencyObjectsTests: XCTestCase {
 
         let identifiedTargets: [IdentifiedTarget] = [
             .mock(
-                key: ["A", "B"],
-                identifier: .init(
-                    pbxProjEscapedName: "AB",
-                    subIdentifier: .init(shard: "01", hash: "00000000"),
-                    full: "AB_ID /* AB */",
-                    withoutComment: "AB_ID"
-                ),
-                dependencies: []
-            ),
-            .mock(
                 key: ["C"],
                 identifier: .init(
                     pbxProjEscapedName: "C",
@@ -149,11 +149,24 @@ final class CreateDependencyObjectsTests: XCTestCase {
                 ),
                 dependencies: []
             ),
+            .mock(
+                key: ["A", "B"],
+                identifier: .init(
+                    pbxProjEscapedName: "AB",
+                    subIdentifier: .init(shard: "01", hash: "00000000"),
+                    full: "AB_ID /* AB */",
+                    withoutComment: "AB_ID"
+                ),
+                dependencies: []
+            ),
         ]
-        let identifiers: [TargetID : Identifiers.Targets.Identifier] = [
-            "A": identifiedTargets[0].identifier,
-            "B": identifiedTargets[0].identifier,
-            "C": identifiedTargets[1].identifier,
+        let identifiedTargetsMap: OrderedDictionary<
+            TargetID,
+            IdentifiedTarget
+        > = [
+            "C": identifiedTargets[1],
+            "A": identifiedTargets[0],
+            "B": identifiedTargets[0],
         ]
 
         let createContainerItemProxyObject =
@@ -175,11 +188,13 @@ final class CreateDependencyObjectsTests: XCTestCase {
             Generator.CreateContainerItemProxyObject.MockTracker.Called
         ] = [
             .init(
-                subIdentifier: identifiers["A"]!.subIdentifier,
+                subIdentifier:
+                    identifiedTargetsMap["A"]!.identifier.subIdentifier,
                 dependencyIdentifier: .bazelDependencies
             ),
             .init(
-                subIdentifier: identifiers["C"]!.subIdentifier,
+                subIdentifier:
+                    identifiedTargetsMap["C"]!.identifier.subIdentifier,
                 dependencyIdentifier: .bazelDependencies
             ),
         ]
@@ -187,12 +202,14 @@ final class CreateDependencyObjectsTests: XCTestCase {
             Generator.CreateTargetDependencyObject.MockTracker.Called
         ] = [
             .init(
-                subIdentifier: identifiers["A"]!.subIdentifier,
+                subIdentifier:
+                    identifiedTargetsMap["A"]!.identifier.subIdentifier,
                 dependencyIdentifier: .bazelDependencies,
                 containerItemProxyIdentifier: "CIP_AB_ID"
             ),
             .init(
-                subIdentifier: identifiers["C"]!.subIdentifier,
+                subIdentifier:
+                    identifiedTargetsMap["C"]!.identifier.subIdentifier,
                 dependencyIdentifier: .bazelDependencies,
                 containerItemProxyIdentifier: "CIP_C_ID"
             ),
@@ -210,7 +227,7 @@ final class CreateDependencyObjectsTests: XCTestCase {
         let objects = try Generator.CreateDependencyObjects
             .defaultCallable(
                 identifiedTargets: identifiedTargets,
-                identifiers: identifiers,
+                identifiedTargetsMap: identifiedTargetsMap,
                 createContainerItemProxyObject:
                     createContainerItemProxyObject.mock,
                 createTargetDependencyObject:

--- a/tools/generators/pbxtargetdependencies/test/Generator/CreateTargetAttributesObjectsTests.swift
+++ b/tools/generators/pbxtargetdependencies/test/Generator/CreateTargetAttributesObjectsTests.swift
@@ -1,4 +1,5 @@
 import CustomDump
+import OrderedCollections
 import XCTest
 
 @testable import pbxtargetdependencies
@@ -36,10 +37,13 @@ final class CreateTargetAttributesObjectsTests: XCTestCase {
             "A": "C",
             "B": "C",
         ]
-        let identifiers: [TargetID : Identifiers.Targets.Identifier] = [
-            "A": identifiedTargets[0].identifier,
-            "B": identifiedTargets[0].identifier,
-            "C": identifiedTargets[1].identifier,
+        let identifiedTargetsMap: OrderedDictionary<
+            TargetID,
+            IdentifiedTarget
+        > = [
+            "A": identifiedTargets[0],
+            "B": identifiedTargets[0],
+            "C": identifiedTargets[1],
         ]
         let createdOnToolsVersion = "14.2.1"
 
@@ -61,7 +65,7 @@ final class CreateTargetAttributesObjectsTests: XCTestCase {
             ),
             .init(
                 createdOnToolsVersion: createdOnToolsVersion,
-                testHostIdentifier: identifiers["C"]!.full
+                testHostIdentifier: identifiedTargetsMap["C"]!.identifier.full
             ),
             .init(
                 createdOnToolsVersion: createdOnToolsVersion,
@@ -75,11 +79,11 @@ final class CreateTargetAttributesObjectsTests: XCTestCase {
                 content: "{TA_BazelDependnencies}"
             ),
             .init(
-                identifier: identifiers["A"]!.full,
+                identifier: identifiedTargetsMap["A"]!.identifier.full,
                 content: "{TA_AB}"
             ),
             .init(
-                identifier: identifiers["C"]!.full,
+                identifier: identifiedTargetsMap["C"]!.identifier.full,
                 content: "{TA_C}"
             ),
         ]
@@ -89,8 +93,8 @@ final class CreateTargetAttributesObjectsTests: XCTestCase {
         let objects = try Generator.CreateTargetAttributesObjects
             .defaultCallable(
                 identifiedTargets: identifiedTargets,
+                identifiedTargetsMap: identifiedTargetsMap,
                 testHosts: testHosts,
-                identifiers: identifiers,
                 createdOnToolsVersion: createdOnToolsVersion,
                 createTargetAttributesContent:
                     createTargetAttributesContent.mock
@@ -126,9 +130,12 @@ final class CreateTargetAttributesObjectsTests: XCTestCase {
             "A": "C",
             "B": "C",
         ]
-        let identifiers: [TargetID : Identifiers.Targets.Identifier] = [
-            "A": identifiedTargets[0].identifier,
-            "B": identifiedTargets[0].identifier,
+        let identifiedTargetsMap: OrderedDictionary<
+            TargetID,
+            IdentifiedTarget
+        > = [
+            "A": identifiedTargets[0],
+            "B": identifiedTargets[0],
         ]
         let createdOnToolsVersion = "14.2.1"
 
@@ -145,8 +152,8 @@ final class CreateTargetAttributesObjectsTests: XCTestCase {
         XCTAssertThrowsError(
             try Generator.CreateTargetAttributesObjects.defaultCallable(
                 identifiedTargets: identifiedTargets,
+                identifiedTargetsMap: identifiedTargetsMap,
                 testHosts: testHosts,
-                identifiers: identifiers,
                 createdOnToolsVersion: createdOnToolsVersion,
                 createTargetAttributesContent:
                     createTargetAttributesContent.mock

--- a/tools/generators/pbxtargetdependencies/test/Generator/IdentifiedTarget+Testing.swift
+++ b/tools/generators/pbxtargetdependencies/test/Generator/IdentifiedTarget+Testing.swift
@@ -19,6 +19,7 @@ extension IdentifiedTarget {
             full: "T_ID /* T */",
             withoutComment: "T_ID"
         ),
+        watchKitExtension: TargetID? = nil,
         dependencies: [TargetID] = []
     ) -> Self {
         return Self(
@@ -31,6 +32,7 @@ extension IdentifiedTarget {
             productBasename: productBasename,
             uiTestHostName: uiTestHostName,
             identifier: identifier,
+            watchKitExtension: watchKitExtension,
             dependencies: dependencies
         )
     }

--- a/tools/generators/pbxtargetdependencies/test/Generator/InnerIdentifyTargetsTests.swift
+++ b/tools/generators/pbxtargetdependencies/test/Generator/InnerIdentifyTargetsTests.swift
@@ -44,7 +44,9 @@ final class InnerIdentifyTargetsTests: XCTestCase {
                             productType: .uiTestBundle,
                             productPath: "C.xctest",
                             productBasename: "C.xctest",
-                            uiTestHost: "B"
+                            uiTestHost: "B",
+                            // Doesn't make sense, just for testing
+                            watchKitExtension: "W"
                         ),
                     ]
                 )
@@ -87,6 +89,7 @@ final class InnerIdentifyTargetsTests: XCTestCase {
                     full: "AB_SHARD00AB_HASH000000000001 /* AB (macOS) */",
                     withoutComment: "AB_SHARD00AB_HASH000000000001"
                 ),
+                watchKitExtension: nil,
                 dependencies: [
                     "C",
                 ]
@@ -106,6 +109,7 @@ final class InnerIdentifyTargetsTests: XCTestCase {
                     full: "C_SHARD00C_HASH000000000001 /* c (iOS) */",
                     withoutComment: "C_SHARD00C_HASH000000000001"
                 ),
+                watchKitExtension: "W",
                 dependencies: []
             ),
         ]

--- a/xcodeproj/internal/pbxproj_partials.bzl
+++ b/xcodeproj/internal/pbxproj_partials.bzl
@@ -42,6 +42,7 @@ _flags = struct(
     product_paths = "--product-paths",
     product_types = "--product-types",
     target_and_test_hosts = "--target-and-test-hosts",
+    target_and_watch_kit_extensions = "--target-and-watch-kit-extensions",
     target_counts = "--target-counts",
     targets = "--targets",
     use_base_internationalization = "--use-base-internationalization",
@@ -439,6 +440,7 @@ def _write_pbxtargetdependencies(
     product_paths = []
     product_types = []
     target_and_test_hosts = []
+    target_and_watch_kit_extensions = []
     target_counts = []
     target_ids = []
     xcode_configuration_counts = []
@@ -480,8 +482,20 @@ def _write_pbxtargetdependencies(
                     target_and_test_hosts.append(xcode_target.id)
                     target_and_test_hosts.append(xcode_target.test_host)
 
+                if xcode_target.watchkit_extension:
+                    target_and_watch_kit_extensions.append(xcode_target.id)
+                    target_and_watch_kit_extensions.append(
+                        xcode_target.watchkit_extension,
+                    )
+
     # targetAndTestHosts
     args.add_all(_flags.target_and_test_hosts, target_and_test_hosts)
+
+    # targetAndWatchKitExtensions
+    args.add_all(
+        _flags.target_and_watch_kit_extensions,
+        target_and_watch_kit_extensions,
+    )
 
     # consolidationMapOutputPaths
     args.add_all(


### PR DESCRIPTION
This will be used by `pbxnativetargets` to generate the needed `Embed App Extensions` build phase for watchOS apps with watchKit extensions.