### PR TITLE
Favor shorthand form when using labels for Xcode target names

### DIFF
--- a/examples/integration/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -21696,7 +21696,7 @@
 			buildSettings = {
 				ARCHS = x86_64;
 				"ARCHS[sdk=iphoneos*]" = arm64;
-				BAZEL_LABEL = "@@//iOSApp/Test/TestingUtils:TestingUtils";
+				BAZEL_LABEL = "@@//iOSApp/Test/TestingUtils";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-19/bin/iOSApp/Test/TestingUtils";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-6/bin/iOSApp/Test/TestingUtils";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphonesimulator*]" = "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/TestingUtils";
@@ -22098,7 +22098,7 @@
 				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
 				BAZEL_COMPILE_TARGET_IDS = "@@//CommandLine/CommandLineTool:tool.library CONFIGURATION-STABLE-23";
 				"BAZEL_COMPILE_TARGET_IDS[sdk=macosx*]" = "$(BAZEL_COMPILE_TARGET_IDS)";
-				BAZEL_LABEL = "@@//CommandLine/CommandLineTool:CommandLineTool";
+				BAZEL_LABEL = "@@//CommandLine/CommandLineTool";
 				BAZEL_OUTPUTS_DSYM = "\"bazel-out/CONFIGURATION-STABLE-23/bin/CommandLine/CommandLineTool/CommandLineTool.dSYM\"";
 				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-23/bin/CommandLine/CommandLineTool/CommandLineTool_codesigned";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = CommandLineTool_codesigned;
@@ -22201,7 +22201,7 @@
 			buildSettings = {
 				ARCHS = x86_64;
 				"ARCHS[sdk=iphoneos*]" = arm64;
-				BAZEL_LABEL = "@@//iOSApp/Test/TestingUtils:TestingUtils";
+				BAZEL_LABEL = "@@//iOSApp/Test/TestingUtils";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-20/bin/iOSApp/Test/TestingUtils";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-12/bin/iOSApp/Test/TestingUtils";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphonesimulator*]" = "bazel-out/CONFIGURATION-STABLE-9/bin/iOSApp/Test/TestingUtils";
@@ -22588,7 +22588,7 @@
 				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
 				BAZEL_COMPILE_TARGET_IDS = "@@//CommandLine/CommandLineTool:tool.library CONFIGURATION-STABLE-26";
 				"BAZEL_COMPILE_TARGET_IDS[sdk=macosx*]" = "$(BAZEL_COMPILE_TARGET_IDS)";
-				BAZEL_LABEL = "@@//CommandLine/CommandLineTool:CommandLineTool";
+				BAZEL_LABEL = "@@//CommandLine/CommandLineTool";
 				BAZEL_OUTPUTS_DSYM = "\"bazel-out/CONFIGURATION-STABLE-26/bin/CommandLine/CommandLineTool/CommandLineTool.dSYM\"";
 				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-26/bin/CommandLine/CommandLineTool/CommandLineTool_codesigned";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = CommandLineTool_codesigned;
@@ -24187,7 +24187,7 @@
 				ASAN_OTHER_CFLAGS__ = "$(ASAN_OTHER_CFLAGS__NO)";
 				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) -ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/c.compile.params";
 				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
-				BAZEL_LABEL = "@@//cc/tool:tool";
+				BAZEL_LABEL = "@@//cc/tool";
 				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-1/bin/cc/tool/tool_codesigned";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = tool_codesigned;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-1/bin/cc/tool";
@@ -24702,7 +24702,7 @@
 				ASAN_OTHER_CFLAGS__ = "$(ASAN_OTHER_CFLAGS__NO)";
 				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) -ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/c.compile.params";
 				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
-				BAZEL_LABEL = "@@//iOSApp/Source/Utils:Utils";
+				BAZEL_LABEL = "@@//iOSApp/Source/Utils";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-9/bin/iOSApp/Source/Utils";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-12/bin/iOSApp/Source/Utils";
 				BAZEL_TARGET_ID = "@@//iOSApp/Source/Utils:Utils CONFIGURATION-STABLE-9";
@@ -25486,7 +25486,7 @@
 				ASAN_OTHER_CFLAGS__ = "$(ASAN_OTHER_CFLAGS__NO)";
 				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) -ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/c.compile.params";
 				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
-				BAZEL_LABEL = "@@//iOSApp/Source/Utils:Utils";
+				BAZEL_LABEL = "@@//iOSApp/Source/Utils";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Source/Utils";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-6/bin/iOSApp/Source/Utils";
 				BAZEL_TARGET_ID = "@@//iOSApp/Source/Utils:Utils CONFIGURATION-STABLE-3";
@@ -25731,7 +25731,7 @@
 				ASAN_OTHER_CFLAGS__ = "$(ASAN_OTHER_CFLAGS__NO)";
 				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) -ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/c.compile.params";
 				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
-				BAZEL_LABEL = "@@//iOSApp/Source/CoreUtilsMixed/MixedAnswer:MixedAnswer";
+				BAZEL_LABEL = "@@//iOSApp/Source/CoreUtilsMixed/MixedAnswer";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-9/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-12/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer";
 				BAZEL_TARGET_ID = "@@//iOSApp/Source/CoreUtilsMixed/MixedAnswer:MixedAnswer CONFIGURATION-STABLE-9";
@@ -26570,7 +26570,7 @@
 				ASAN_OTHER_CFLAGS__ = "$(ASAN_OTHER_CFLAGS__NO)";
 				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) -ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/c.compile.params";
 				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
-				BAZEL_LABEL = "@@//iOSApp/Source/CoreUtilsMixed/MixedAnswer:MixedAnswer";
+				BAZEL_LABEL = "@@//iOSApp/Source/CoreUtilsMixed/MixedAnswer";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-6/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer";
 				BAZEL_TARGET_ID = "@@//iOSApp/Source/CoreUtilsMixed/MixedAnswer:MixedAnswer CONFIGURATION-STABLE-3";
@@ -26802,7 +26802,7 @@
 				ASAN_OTHER_CFLAGS__ = "$(ASAN_OTHER_CFLAGS__NO)";
 				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) -ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/c.compile.params";
 				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
-				BAZEL_LABEL = "@@//cc/tool:tool";
+				BAZEL_LABEL = "@@//cc/tool";
 				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-2/bin/cc/tool/tool_codesigned";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = tool_codesigned;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-2/bin/cc/tool";

--- a/examples/integration/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -22320,7 +22320,7 @@
 			buildSettings = {
 				ARCHS = x86_64;
 				"ARCHS[sdk=iphoneos*]" = arm64;
-				BAZEL_LABEL = "@@//iOSApp/Test/TestingUtils:TestingUtils";
+				BAZEL_LABEL = "@@//iOSApp/Test/TestingUtils";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-19/bin/iOSApp/Test/TestingUtils";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-6/bin/iOSApp/Test/TestingUtils";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphonesimulator*]" = "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/TestingUtils";
@@ -22688,7 +22688,7 @@
 				ASAN_OTHER_CFLAGS__ = "$(ASAN_OTHER_CFLAGS__NO)";
 				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) -ivfsoverlay $(DERIVED_FILE_DIR)/xcode-overlay.yaml -ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/c.compile.params";
 				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
-				BAZEL_LABEL = "@@//iOSApp/Source/CoreUtilsMixed/MixedAnswer:MixedAnswer";
+				BAZEL_LABEL = "@@//iOSApp/Source/CoreUtilsMixed/MixedAnswer";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-6/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer";
 				BAZEL_TARGET_ID = "@@//iOSApp/Source/CoreUtilsMixed/MixedAnswer:MixedAnswer CONFIGURATION-STABLE-3";
@@ -25097,7 +25097,7 @@
 				ASAN_OTHER_CFLAGS__ = "$(ASAN_OTHER_CFLAGS__NO)";
 				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) -ivfsoverlay $(DERIVED_FILE_DIR)/xcode-overlay.yaml -ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/c.compile.params";
 				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
-				BAZEL_LABEL = "@@//iOSApp/Source/CoreUtilsMixed/MixedAnswer:MixedAnswer";
+				BAZEL_LABEL = "@@//iOSApp/Source/CoreUtilsMixed/MixedAnswer";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-9/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-12/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer";
 				BAZEL_TARGET_ID = "@@//iOSApp/Source/CoreUtilsMixed/MixedAnswer:MixedAnswer CONFIGURATION-STABLE-9";
@@ -25957,7 +25957,7 @@
 				ASAN_OTHER_CFLAGS__ = "$(ASAN_OTHER_CFLAGS__NO)";
 				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) -ivfsoverlay $(DERIVED_FILE_DIR)/xcode-overlay.yaml -ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/c.compile.params";
 				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
-				BAZEL_LABEL = "@@//cc/tool:tool";
+				BAZEL_LABEL = "@@//cc/tool";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-2/bin/cc/tool";
 				BAZEL_TARGET_ID = "@@//cc/tool:tool CONFIGURATION-STABLE-2";
 				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
@@ -26037,7 +26037,7 @@
 				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
 				BAZEL_COMPILE_TARGET_IDS = "@@//CommandLine/CommandLineTool:tool.library CONFIGURATION-STABLE-26";
 				"BAZEL_COMPILE_TARGET_IDS[sdk=macosx*]" = "$(BAZEL_COMPILE_TARGET_IDS)";
-				BAZEL_LABEL = "@@//CommandLine/CommandLineTool:CommandLineTool";
+				BAZEL_LABEL = "@@//CommandLine/CommandLineTool";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-26/bin/CommandLine/CommandLineTool";
 				BAZEL_TARGET_ID = "@@//CommandLine/CommandLineTool:CommandLineTool CONFIGURATION-STABLE-26";
 				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
@@ -26422,7 +26422,7 @@
 				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
 				BAZEL_COMPILE_TARGET_IDS = "@@//CommandLine/CommandLineTool:tool.library CONFIGURATION-STABLE-23";
 				"BAZEL_COMPILE_TARGET_IDS[sdk=macosx*]" = "$(BAZEL_COMPILE_TARGET_IDS)";
-				BAZEL_LABEL = "@@//CommandLine/CommandLineTool:CommandLineTool";
+				BAZEL_LABEL = "@@//CommandLine/CommandLineTool";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-23/bin/CommandLine/CommandLineTool";
 				BAZEL_TARGET_ID = "@@//CommandLine/CommandLineTool:CommandLineTool CONFIGURATION-STABLE-23";
 				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
@@ -27589,7 +27589,7 @@
 				ASAN_OTHER_CFLAGS__ = "$(ASAN_OTHER_CFLAGS__NO)";
 				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) -ivfsoverlay $(DERIVED_FILE_DIR)/xcode-overlay.yaml -ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/c.compile.params";
 				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
-				BAZEL_LABEL = "@@//cc/tool:tool";
+				BAZEL_LABEL = "@@//cc/tool";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-1/bin/cc/tool";
 				BAZEL_TARGET_ID = "@@//cc/tool:tool CONFIGURATION-STABLE-1";
 				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
@@ -27842,7 +27842,7 @@
 				ASAN_OTHER_CFLAGS__ = "$(ASAN_OTHER_CFLAGS__NO)";
 				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) -ivfsoverlay $(DERIVED_FILE_DIR)/xcode-overlay.yaml -ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/c.compile.params";
 				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
-				BAZEL_LABEL = "@@//iOSApp/Source/Utils:Utils";
+				BAZEL_LABEL = "@@//iOSApp/Source/Utils";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-9/bin/iOSApp/Source/Utils";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-12/bin/iOSApp/Source/Utils";
 				BAZEL_TARGET_ID = "@@//iOSApp/Source/Utils:Utils CONFIGURATION-STABLE-9";
@@ -28016,7 +28016,7 @@
 				ASAN_OTHER_CFLAGS__ = "$(ASAN_OTHER_CFLAGS__NO)";
 				ASAN_OTHER_CFLAGS__NO = "-working-directory $(PROJECT_DIR) -ivfsoverlay $(DERIVED_FILE_DIR)/xcode-overlay.yaml -ivfsoverlay $(OBJROOT)/bazel-out-overlay.yaml @$(DERIVED_FILE_DIR)/c.compile.params";
 				ASAN_OTHER_CFLAGS__YES = "$(ASAN_OTHER_CFLAGS__NO) -Wno-macro-redefined -D_FORTIFY_SOURCE=0";
-				BAZEL_LABEL = "@@//iOSApp/Source/Utils:Utils";
+				BAZEL_LABEL = "@@//iOSApp/Source/Utils";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Source/Utils";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-6/bin/iOSApp/Source/Utils";
 				BAZEL_TARGET_ID = "@@//iOSApp/Source/Utils:Utils CONFIGURATION-STABLE-3";
@@ -28481,7 +28481,7 @@
 			buildSettings = {
 				ARCHS = x86_64;
 				"ARCHS[sdk=iphoneos*]" = arm64;
-				BAZEL_LABEL = "@@//iOSApp/Test/TestingUtils:TestingUtils";
+				BAZEL_LABEL = "@@//iOSApp/Test/TestingUtils";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-20/bin/iOSApp/Test/TestingUtils";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-12/bin/iOSApp/Test/TestingUtils";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphonesimulator*]" = "bazel-out/CONFIGURATION-STABLE-9/bin/iOSApp/Test/TestingUtils";

--- a/examples/rules_ios/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/rules_ios/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -4193,7 +4193,7 @@
 			buildSettings = {
 				ARCHS = x86_64;
 				"ARCHS[sdk=iphoneos*]" = arm64;
-				BAZEL_LABEL = "@//iOSApp/Source/CoreUtilsMixed/MixedAnswer:MixedAnswer";
+				BAZEL_LABEL = "@//iOSApp/Source/CoreUtilsMixed/MixedAnswer";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-1/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-2/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer";
 				BAZEL_TARGET_ID = "@//iOSApp/Source/CoreUtilsMixed/MixedAnswer:MixedAnswer CONFIGURATION-STABLE-1";
@@ -4303,7 +4303,7 @@
 			buildSettings = {
 				ARCHS = x86_64;
 				"ARCHS[sdk=iphoneos*]" = arm64;
-				BAZEL_LABEL = "@//iOSApp/Source/CoreUtilsObjC:CoreUtilsObjC";
+				BAZEL_LABEL = "@//iOSApp/Source/CoreUtilsObjC";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-1/bin/iOSApp/Source/CoreUtilsObjC";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-2/bin/iOSApp/Source/CoreUtilsObjC";
 				BAZEL_TARGET_ID = "@//iOSApp/Source/CoreUtilsObjC:CoreUtilsObjC CONFIGURATION-STABLE-1";
@@ -4609,7 +4609,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
-				BAZEL_LABEL = "@//iOSApp/Source/Utils:Utils";
+				BAZEL_LABEL = "@//iOSApp/Source/Utils";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-1/bin/iOSApp/Source/Utils";
 				BAZEL_TARGET_ID = "@//iOSApp/Source/Utils:Utils CONFIGURATION-STABLE-1";
 				"BAZEL_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_TARGET_ID)";

--- a/tools/generators/legacy/test/BazelLabelTests.swift
+++ b/tools/generators/legacy/test/BazelLabelTests.swift
@@ -24,6 +24,13 @@ class BazelLabelTests: XCTestCase {
         XCTAssertEqual(label.name, "bar")
     }
 
+    func test_init_withStringLiteral_nameWithSlash() throws {
+        let label: BazelLabel = "@//foo/bar/wiz:bar/wiz"
+        XCTAssertEqual(label.repository, "@")
+        XCTAssertEqual(label.package, "foo/bar/wiz")
+        XCTAssertEqual(label.name, "bar/wiz")
+    }
+
     func test_customString_withRepository() throws {
         let label: BazelLabel = "@awesome_repo//foo/bar:hello"
         let actual = "\(label)"
@@ -39,7 +46,19 @@ class BazelLabelTests: XCTestCase {
     func test_customString_noName() throws {
         let label: BazelLabel = "@//foo/bar"
         let actual = "\(label)"
-        XCTAssertEqual("@//foo/bar:bar", actual)
+        XCTAssertEqual("@//foo/bar", actual)
+    }
+
+    func test_customString_shorthandForm() throws {
+        let label: BazelLabel = "@//foo/bar:bar"
+        let actual = "\(label)"
+        XCTAssertEqual("@//foo/bar", actual)
+    }
+
+    func test_customString_nameWithSlash() throws {
+        let label: BazelLabel = "@//foo/bar/wiz:bar/wiz"
+        let actual = "\(label)"
+        XCTAssertEqual("@//foo/bar/wiz:bar/wiz", actual)
     }
 
     func test_encodingAndDecoding() throws {


### PR DESCRIPTION
### What has changed
Here's a proposal to favor the shorthand form of labels when they are used for Xcode target names,
i.e. `//foo/bar/lib` instead of `//foo/bar/lib:lib`.

That'll in particular make a positive difference when `target_name_mode = "label"` is used, and remove redundancies from names.

Before | After
--- | ---
<img width="600" alt="label_before" src="https://user-images.githubusercontent.com/1083513/271799729-ae574543-2c85-4e63-bdd3-870ffd2ddb99.png"> | <img width="600" alt="label_after" src="https://user-images.githubusercontent.com/1083513/271799728-0fd62a2b-3765-4b83-8e56-e98cde158ef2.png">

### Why this was changed

For context, our project has targets that have long labels.
To give a pseudo-example, it would be more convenient to display in Xcode:
`//apple/Extraterrestrial/RegistrationSummaryTransition`
instead of 
`//apple/Extraterrestrial/RegistrationSummaryTransition:RegistrationSummaryTransition`

### How can a reviewer test this change

Since the shorthand form is synonymous with the full form, I don't expect this to break anything,
and haven't witnessed any issues during testing,
but please correct me if I'm shortsighted or if this change should be done elsewhere.

This has also been applied to the label fallback logic in `target_name_mode = "auto"`, and if the fallback label happens to have a shorthand form, it will be favored.