### PR TITLE
Add support for `actions.declare_directory` to `mock_actions`

### DIFF
--- a/test/internal/pbxproj_partials/write_files_and_groups_tests.bzl
+++ b/test/internal/pbxproj_partials/write_files_and_groups_tests.bzl
@@ -6,11 +6,21 @@ load("//test:mock_actions.bzl", "mock_actions")
 # buildifier: disable=bzl-visibility
 load("//xcodeproj/internal:pbxproj_partials.bzl", "pbxproj_partials")
 
-_KNOWN_REGIONS_DECLARED_FILE = "a_generator_name_pbxproj_partials/pbxproject_known_regions"
-_FILES_AND_GROUPS_DECLARED_FILE = "a_generator_name_pbxproj_partials/files_and_groups"
-_RESOLVED_REPOSITORIES_FILE_DECLARED_FILE = "a_generator_name_pbxproj_partials/resolved_repositories_file"
-_FILE_PATHS_FILE = "a_generator_name_pbxproj_partials/file_paths_file"
-_FOLDER_PATHS_FILE = "a_generator_name_pbxproj_partials/folder_paths_file"
+_KNOWN_REGIONS_DECLARED_FILE = mock_actions.mock_file(
+    "a_generator_name_pbxproj_partials/pbxproject_known_regions",
+)
+_FILES_AND_GROUPS_DECLARED_FILE = mock_actions.mock_file(
+    "a_generator_name_pbxproj_partials/files_and_groups",
+)
+_RESOLVED_REPOSITORIES_FILE_DECLARED_FILE = mock_actions.mock_file(
+    "a_generator_name_pbxproj_partials/resolved_repositories_file",
+)
+_FILE_PATHS_FILE = mock_actions.mock_file(
+    "a_generator_name_pbxproj_partials/file_paths_file",
+)
+_FOLDER_PATHS_FILE = mock_actions.mock_file(
+    "a_generator_name_pbxproj_partials/folder_paths_file",
+)
 
 def _write_files_and_groups_test_impl(ctx):
     env = unittest.begin(ctx)
@@ -213,7 +223,10 @@ def write_files_and_groups_test_suite(name):
 
             # Expected
             expected_args = expected_args,
-            expected_writes = expected_writes,
+            expected_writes = {
+                file.path: content
+                for file, content in expected_writes.items()
+            },
         )
 
     # Basic
@@ -237,11 +250,11 @@ def write_files_and_groups_test_suite(name):
         # Expected
         expected_args = [
             # knownRegionsOutputPath
-            _KNOWN_REGIONS_DECLARED_FILE,
+            _KNOWN_REGIONS_DECLARED_FILE.path,
             # filesAndGroupsOutputPath
-            _FILES_AND_GROUPS_DECLARED_FILE,
+            _FILES_AND_GROUPS_DECLARED_FILE.path,
             # resolvedRepositoriesOutputPath
-            _RESOLVED_REPOSITORIES_FILE_DECLARED_FILE,
+            _RESOLVED_REPOSITORIES_FILE_DECLARED_FILE.path,
             # workspace
             "/Users/TimApple/StarBoard",
             # installPath
@@ -251,9 +264,9 @@ def write_files_and_groups_test_suite(name):
             # selectedModelVersionsFile
             "some/selected_model_versions_file",
             # filePathsFile
-            _FILE_PATHS_FILE,
+            _FILE_PATHS_FILE.path,
             # folderPathsFile
-            _FOLDER_PATHS_FILE,
+            _FOLDER_PATHS_FILE.path,
             # developmentRegion
             "en",
             # useBaseInternationalization
@@ -304,11 +317,11 @@ def write_files_and_groups_test_suite(name):
         # Expected
         expected_args = [
             # knownRegionsOutputPath
-            _KNOWN_REGIONS_DECLARED_FILE,
+            _KNOWN_REGIONS_DECLARED_FILE.path,
             # filesAndGroupsOutputPath
-            _FILES_AND_GROUPS_DECLARED_FILE,
+            _FILES_AND_GROUPS_DECLARED_FILE.path,
             # resolvedRepositoriesOutputPath
-            _RESOLVED_REPOSITORIES_FILE_DECLARED_FILE,
+            _RESOLVED_REPOSITORIES_FILE_DECLARED_FILE.path,
             # workspace
             "/Users/TimApple/StarBoard",
             # installPath
@@ -318,9 +331,9 @@ def write_files_and_groups_test_suite(name):
             # selectedModelVersionsFile
             "some/selected_model_versions_file",
             # filePathsFile
-            _FILE_PATHS_FILE,
+            _FILE_PATHS_FILE.path,
             # folderPathsFile
-            _FOLDER_PATHS_FILE,
+            _FOLDER_PATHS_FILE.path,
             # developmentRegion
             "enGB",
             # useBaseInternationalization

--- a/test/internal/pbxproj_partials/write_pbxproj_prefix_tests.bzl
+++ b/test/internal/pbxproj_partials/write_pbxproj_prefix_tests.bzl
@@ -7,9 +7,15 @@ load("//test:utils.bzl", "mock_apple_platform_to_platform_name")
 # buildifier: disable=bzl-visibility
 load("//xcodeproj/internal:pbxproj_partials.bzl", "pbxproj_partials")
 
-_OUTPUT_DECLARED_FILE = "a_generator_name_pbxproj_partials/pbxproj_prefix"
-_POST_BUILD_DECLARED_FILE = "a_generator_name_pbxproj_partials/post_build_script"
-_PRE_BUILD_DECLARED_FILE = "a_generator_name_pbxproj_partials/pre_build_script"
+_OUTPUT_DECLARED_FILE = mock_actions.mock_file(
+    "a_generator_name_pbxproj_partials/pbxproj_prefix",
+)
+_POST_BUILD_DECLARED_FILE = mock_actions.mock_file(
+    "a_generator_name_pbxproj_partials/post_build_script",
+)
+_PRE_BUILD_DECLARED_FILE = mock_actions.mock_file(
+    "a_generator_name_pbxproj_partials/pre_build_script",
+)
 
 def _write_pbxproj_prefix_test_impl(ctx):
     env = unittest.begin(ctx)
@@ -201,7 +207,10 @@ def write_pbxproj_prefix_test_suite(name):
 
             # Expected
             expected_args = expected_args,
-            expected_writes = expected_writes,
+            expected_writes = {
+                file.path: content
+                for file, content in expected_writes.items()
+            },
         )
 
     # Basic
@@ -232,7 +241,7 @@ def write_pbxproj_prefix_test_suite(name):
         # Expected
         expected_args = [
             # outputPath
-            _OUTPUT_DECLARED_FILE,
+            _OUTPUT_DECLARED_FILE.path,
             # workspace
             "/Users/TimApple/StarBoard",
             # executionRootFile
@@ -292,7 +301,7 @@ def write_pbxproj_prefix_test_suite(name):
         # Expected
         expected_args = [
             # outputPath
-            _OUTPUT_DECLARED_FILE,
+            _OUTPUT_DECLARED_FILE.path,
             # workspace
             "/Users/TimApple/StarBoard",
             # executionRootFile
@@ -322,10 +331,10 @@ def write_pbxproj_prefix_test_suite(name):
             "Debug",
             # preBuildScript
             "--pre-build-script",
-            _PRE_BUILD_DECLARED_FILE,
+            _PRE_BUILD_DECLARED_FILE.path,
             # postBuildScript
             "--post-build-script",
-            _POST_BUILD_DECLARED_FILE,
+            _POST_BUILD_DECLARED_FILE.path,
             # colorize
             "--colorize",
         ],

--- a/test/internal/pbxproj_partials/write_pbxtargetdependencies_tests.bzl
+++ b/test/internal/pbxproj_partials/write_pbxtargetdependencies_tests.bzl
@@ -7,13 +7,23 @@ load("//test:utils.bzl", "mock_apple_platform_to_platform_name")
 # buildifier: disable=bzl-visibility
 load("//xcodeproj/internal:pbxproj_partials.bzl", "pbxproj_partials")
 
-_TARGET_DEPENDENCIES_DECLARED_FILE = "a_generator_name_pbxproj_partials/pbxtargetdependencies"
-_TARGETS_DECLARED_FILE = "a_generator_name_pbxproj_partials/pbxproject_targets"
-_TARGET_ATTRIBUTES_DECLARED_FILE = "a_generator_name_pbxproj_partials/pbxproject_target_attributes"
-_CONSOLIDATION_MAPS_INPUTS_FILE = "a_generator_name_pbxproj_partials/consolidation_maps_inputs_file"
+_TARGET_DEPENDENCIES_DECLARED_FILE = mock_actions.mock_file(
+    "a_generator_name_pbxproj_partials/pbxtargetdependencies",
+)
+_TARGETS_DECLARED_FILE = mock_actions.mock_file(
+    "a_generator_name_pbxproj_partials/pbxproject_targets",
+)
+_TARGET_ATTRIBUTES_DECLARED_FILE = mock_actions.mock_file(
+    "a_generator_name_pbxproj_partials/pbxproject_target_attributes",
+)
+_CONSOLIDATION_MAPS_INPUTS_FILE = mock_actions.mock_file(
+    "a_generator_name_pbxproj_partials/consolidation_maps_inputs_file",
+)
 
 def _consolidation_map_declared_file(idx):
-    return "a_generator_name_pbxproj_partials/consolidation_maps/{}".format(idx)
+    return mock_actions.mock_file(
+        "a_generator_name_pbxproj_partials/consolidation_maps/{}".format(idx),
+    )
 
 def _json_to_xcode_targets_by_label(json_str):
     return {
@@ -62,11 +72,11 @@ def mock_xcode_target(
         watchkit_extension = None):
     return struct(
         id = id,
+        apple_platform = apple_platform,
         arch = arch,
         dependencies = dependencies,
         module_name_attribute = module_name_attribute,
         os_version = os_version,
-        apple_platform = apple_platform,
         product_basename = product_basename,
         product_file_path = product_file_path,
         product_type = product_type,
@@ -265,7 +275,10 @@ def write_pbxtargetdependencies_test_suite(name):
 
             # Expected
             expected_args = expected_args,
-            expected_writes = expected_writes,
+            expected_writes = {
+                file.path: content
+                for file, content in expected_writes.items()
+            },
         )
 
     # Full
@@ -333,13 +346,13 @@ def write_pbxtargetdependencies_test_suite(name):
         # Expected
         expected_args = [
             # targetDependenciesOutputPath
-            _TARGET_DEPENDENCIES_DECLARED_FILE,
+            _TARGET_DEPENDENCIES_DECLARED_FILE.path,
             # targetsOutputPath
-            _TARGETS_DECLARED_FILE,
+            _TARGETS_DECLARED_FILE.path,
             # targetAttributesOutputPath
-            _TARGET_ATTRIBUTES_DECLARED_FILE,
+            _TARGET_ATTRIBUTES_DECLARED_FILE.path,
             # consolidationMapsInputsFile,
-            _CONSOLIDATION_MAPS_INPUTS_FILE,
+            _CONSOLIDATION_MAPS_INPUTS_FILE.path,
             # minimumXcodeVersion
             "14.3.1",
             # targetAndTestHosts
@@ -355,8 +368,8 @@ def write_pbxtargetdependencies_test_suite(name):
         expected_writes = {
             _CONSOLIDATION_MAPS_INPUTS_FILE: "\n".join([
                 "2",
-                _consolidation_map_declared_file(0),
-                _consolidation_map_declared_file(1),
+                _consolidation_map_declared_file(0).path,
+                _consolidation_map_declared_file(1).path,
                 "2",
                 str(Label("//tools/generators/legacy/test:tests.__internal__.__test_bundle")),
                 "1",


### PR DESCRIPTION
This also changes the format of declared files to a `struct`, to better mimic `File`. This is needed in order to handle actions that use declared directories, like the upcoming `xcschemes` generator.