### PR TITLE
Make the launchable target error more detailed

### DIFF
--- a/tools/generators/legacy/src/Generator/XCSchemeInfo+LaunchActionInfo.swift
+++ b/tools/generators/legacy/src/Generator/XCSchemeInfo+LaunchActionInfo.swift
@@ -22,7 +22,7 @@ extension XCSchemeInfo {
             guard targetInfo.productType.isLaunchable else {
                 throw PreconditionError(message: """
 An `XCSchemeInfo.LaunchActionInfo` should have a launchable \
-`XCSchemeInfo.TargetInfo` value.
+`XCSchemeInfo.TargetInfo` value: "\(targetInfo.label)".
 """)
             }
             self.buildConfigurationName = buildConfigurationName

--- a/tools/generators/legacy/test/XCSchemeInfo+LaunchActionInfoTests.swift
+++ b/tools/generators/legacy/test/XCSchemeInfo+LaunchActionInfoTests.swift
@@ -38,7 +38,7 @@ extension XCSchemeInfoLaunchActionInfoTests {
             return
         }
         XCTAssertEqual(preconditionError.message, """
-An `XCSchemeInfo.LaunchActionInfo` should have a launchable `XCSchemeInfo.TargetInfo` value.
+An `XCSchemeInfo.LaunchActionInfo` should have a launchable `XCSchemeInfo.TargetInfo` value: "\(libraryTargetInfo.label)".
 """)
     }
 }

--- a/tools/generators/legacy/test/XCSchemeInfo+LaunchActionInfoTests.swift
+++ b/tools/generators/legacy/test/XCSchemeInfo+LaunchActionInfoTests.swift
@@ -38,7 +38,8 @@ extension XCSchemeInfoLaunchActionInfoTests {
             return
         }
         XCTAssertEqual(preconditionError.message, """
-An `XCSchemeInfo.LaunchActionInfo` should have a launchable `XCSchemeInfo.TargetInfo` value: "\(libraryTargetInfo.label)".
+An `XCSchemeInfo.LaunchActionInfo` should have a launchable \
+`XCSchemeInfo.TargetInfo` value: "\(libraryTargetInfo.label)".
 """)
     }
 }


### PR DESCRIPTION
If you have a non-launchable target as a launch target in the scheme, you will get this error:
```
ERROR: Internal precondition failure:
tools/generators/legacy/src/Generator/XCSchemeInfo+LaunchActionInfo.swift:23: An XCSchemeInfo.LaunchActionInfo should have a launchable XCSchemeInfo.TargetInfo value.
```
If you have many schemes, it is difficult to find the root cause of the problem based on the error.
These changes should simplify it.
```
ERROR: Internal precondition failure:
tools/generators/legacy/src/Generator/XCSchemeInfo+LaunchActionInfo.swift:23: An XCSchemeInfo.LaunchActionInfo should have a launchable XCSchemeInfo.TargetInfo value: <label of the target>.
```

Let me know if you see a better way to formalize the error.