### PR TITLE
Set “Bazel LTS” CI to use 6.4.0rc4

### DIFF
--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -17,7 +17,7 @@ x_templates:
       env: {}
     - &bazel_lts
       env:
-        USE_BAZEL_VERSION: last_rc
+        USE_BAZEL_VERSION: 6.4.0rc4
     - &bazel_head
       env:
         USE_BAZEL_VERSION: last_green


### PR DESCRIPTION
This is because Bazel 7 rc1 is now out, so we need to be specific here. Once 6.4.0 is out we can change it to `latest`. And once Bazel 7 is out we can add an LTS-1 CI.