### PR TITLE
Make mutable copy of extensions when processing top-level target

### DIFF
--- a/xcodeproj/internal/top_level_targets.bzl
+++ b/xcodeproj/internal/top_level_targets.bzl
@@ -238,7 +238,7 @@ def process_top_level_target(
         watch_app_target_info.xcode_target.id if watch_app_target_info else None
     )
 
-    extension_targets = getattr(ctx.rule.attr, "extensions", [])
+    extension_targets = list(getattr(ctx.rule.attr, "extensions", []))
     extension_target = getattr(ctx.rule.attr, "extension", None)
     if extension_target:
         extension_targets.append(extension_target)


### PR DESCRIPTION
### What has changed
- Wraps `getattr` result with `list()` for when getting `extensions`.

### Why it was changed
- Logic below assumes `extension_targets` is mutable.
- When both `extensions` and `extension` are present, it fails with `attempting to change a frozen list`.