### PR TITLE
Build static library for library targets in Xcode

### DIFF
--- a/xcodeproj/internal/library_targets.bzl
+++ b/xcodeproj/internal/library_targets.bzl
@@ -136,6 +136,7 @@ def process_library_target(
         id = id,
         inputs = target_inputs,
         output_group_info = output_group_info,
+        product = product,
         swift_info = swift_info,
         transitive_infos = transitive_infos,
     )

--- a/xcodeproj/internal/output_files.bzl
+++ b/xcodeproj/internal/output_files.bzl
@@ -133,11 +133,11 @@ def _collect_output_files(
 
     Args:
         ctx: The aspect context.
-        debug_outputs: The `AppleDebugOutputs` provider for the target, or
-            `None`.
         copy_product_transitively: Whether or not to copy the product
             transitively. Currently this should only be true for top-level
             targets.
+        debug_outputs: The `AppleDebugOutputs` provider for the target, or
+            `None`.
         id: A unique identifier for the target.
         output_group_info: The `OutputGroupInfo` provider for the target, or
             `None`.

--- a/xcodeproj/internal/top_level_targets.bzl
+++ b/xcodeproj/internal/top_level_targets.bzl
@@ -430,12 +430,13 @@ def process_top_level_target(
     output_group_info = target[OutputGroupInfo] if OutputGroupInfo in target else None
     (target_outputs, provider_outputs) = output_files.collect(
         ctx = ctx,
+        copy_product_transitively = True,
         debug_outputs = debug_outputs,
         id = id,
         inputs = target_inputs,
         output_group_info = output_group_info,
+        product = product,
         swift_info = swift_info,
-        top_level_product = product,
         infoplist = infoplist,
         transitive_infos = transitive_infos,
     )


### PR DESCRIPTION
Fixes #2691.

Though, don’t transitively build them (top-level targets will implicitly do that).

This ensures that non-Swift library targets compile when built directly in Xcode.