### PR TITLE
Use a label for `new_local_repository.build_file`

### DIFF
--- a/examples/integration/WORKSPACE
+++ b/examples/integration/WORKSPACE
@@ -61,7 +61,7 @@ local_repository(
 
 new_local_repository(
     name = "examples_command_line_external",
-    build_file = "CommandLine/external/BUILD.tpl",
+    build_file = "//CommandLine/external:BUILD.tpl",
     path = "CommandLine/external",
 )
 

--- a/examples/integration/WORKSPACE.bzlmod
+++ b/examples/integration/WORKSPACE.bzlmod
@@ -1,5 +1,5 @@
 new_local_repository(
     name = "examples_command_line_external",
-    build_file = "CommandLine/external/BUILD.tpl",
+    build_file = "//CommandLine/external:BUILD.tpl",
     path = "CommandLine/external",
 )


### PR DESCRIPTION
Fixes a new Bazel HEAD requirement.