### PR TITLE
Add `.bazelignore` to `CODEOWNERS`

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,6 +2,7 @@
 
 # Release
 
+/.bazelignore @MobileNativeFoundation/rules_xcodeproj-maintainers-release
 /.bazelversion @MobileNativeFoundation/rules_xcodeproj-maintainers-release
 /.bcr/ @MobileNativeFoundation/rules_xcodeproj-maintainers-release
 /distribution/ @MobileNativeFoundation/rules_xcodeproj-maintainers-release


### PR DESCRIPTION
This can impact the release archive in subtle ways.