### PR TITLE
Rename some `compilation_providers` attributes

### DIFF
--- a/xcodeproj/internal/compilation_providers.bzl
+++ b/xcodeproj/internal/compilation_providers.bzl
@@ -116,12 +116,12 @@ def _collect_compilation_providers(
 
     return (
         struct(
-            _framework_files = EMPTY_DEPSET,
-            _is_top_level = False,
-            _is_xcode_library_target = is_xcode_library_target,
             _propagated_framework_files = EMPTY_DEPSET,
             _propagated_objc = objc,
             cc_info = cc_info,
+            framework_files = EMPTY_DEPSET,
+            is_top_level = False,
+            is_xcode_library_target = is_xcode_library_target,
             objc = objc,
         ),
         implementation_compilation_context,
@@ -208,12 +208,12 @@ def _merge_compilation_providers(
 
     return (
         struct(
-            _framework_files = framework_files,
-            _is_top_level = True,
-            _is_xcode_library_target = False,
             _propagated_framework_files = propagated_framework_files,
             _propagated_objc = propagated_objc,
             cc_info = merged_cc_info,
+            framework_files = framework_files,
+            is_top_level = True,
+            is_xcode_library_target = False,
             objc = objc,
         ),
         implementation_compilation_context,

--- a/xcodeproj/internal/linker_input_files.bzl
+++ b/xcodeproj/internal/linker_input_files.bzl
@@ -42,7 +42,7 @@ def _collect_linker_inputs(
         compilation_providers = compilation_providers,
     )
 
-    if compilation_providers._is_top_level:
+    if compilation_providers.is_top_level:
         primary_static_library = None
         top_level_values = _extract_top_level_values(
             target = target,
@@ -52,7 +52,7 @@ def _collect_linker_inputs(
             objc_libraries = objc_libraries,
             cc_linker_inputs = cc_linker_inputs,
         )
-    elif compilation_providers._is_xcode_library_target:
+    elif compilation_providers.is_xcode_library_target:
         primary_static_library = _compute_primary_static_library(
             objc_libraries = objc_libraries,
             cc_linker_inputs = cc_linker_inputs,
@@ -229,7 +229,7 @@ def _extract_top_level_values(
 
         # Dynamic frameworks from `AppleDynamicFrameworkInfo`
         dynamic_frameworks.extend(
-            compilation_providers._framework_files.to_list(),
+            compilation_providers.framework_files.to_list(),
         )
 
         # Dedup libraries


### PR DESCRIPTION
This attributes are used outside of the `compilation_providers` module.