### PR TITLE
Rename `xcodeprojinfos` to `legacy_xcodeprojinfos`

### DIFF
--- a/xcodeproj/internal/legacy_xcodeprojinfos.bzl
+++ b/xcodeproj/internal/legacy_xcodeprojinfos.bzl
@@ -663,6 +663,6 @@ def _make_xcodeprojinfo(*, ctx, attrs, build_mode, target, transitive_infos):
         **info_fields
     )
 
-xcodeprojinfos = struct(
+legacy_xcodeprojinfos = struct(
     make = _make_xcodeprojinfo,
 )

--- a/xcodeproj/internal/xcodeproj_legacy_aspect.bzl
+++ b/xcodeproj/internal/xcodeproj_legacy_aspect.bzl
@@ -1,13 +1,13 @@
 """Module containing implementation functions for the legacy \
 `xcodeproj_aspect` aspect."""
 
+load(":legacy_xcodeprojinfos.bzl", "legacy_xcodeprojinfos")
 load(
     ":provisioning_profiles.bzl",
     "XcodeProjProvisioningProfileInfo",
     "provisioning_profiles",
 )
 load(":xcodeprojinfo.bzl", "XcodeProjInfo")
-load(":xcodeprojinfos.bzl", "xcodeprojinfos")
 
 # Utility
 
@@ -99,7 +99,7 @@ def _xcodeproj_legacy_aspect_impl(target, ctx):
         # Only create an `XcodeProjInfo` if the target hasn't already created
         # one
         attrs = dir(ctx.rule.attr)
-        info = xcodeprojinfos.make(
+        info = legacy_xcodeprojinfos.make(
             ctx = ctx,
             build_mode = ctx.attr._build_mode,
             target = target,


### PR DESCRIPTION
In preparation of incremental generation mode.