### PR TITLE
Pass `rule_attr` and `rule_kind` instead of accessing `ctx`

### DIFF
--- a/xcodeproj/internal/app_icons.bzl
+++ b/xcodeproj/internal/app_icons.bzl
@@ -49,13 +49,14 @@ def _find_default_icon_path(set_path, app_icon_files):
 
     return None
 
-def _get_app_icon_info(ctx, automatic_target_info):
+def _get_app_icon_info(ctx, automatic_target_info, rule_attr):
     """Attempts to find the application icon name.
 
     Args:
         ctx: The aspect context.
         automatic_target_info: The `XcodeProjAutomaticTargetProcessingInfo` for
             `target`.
+        rule_attr: `ctx.rule.attr`.
 
     Returns:
         The application icon name, if found. Otherwise, `None`.
@@ -63,7 +64,7 @@ def _get_app_icon_info(ctx, automatic_target_info):
     if not automatic_target_info.app_icons:
         return None
 
-    app_icons = getattr(ctx.rule.attr, automatic_target_info.app_icons, None)
+    app_icons = getattr(rule_attr, automatic_target_info.app_icons, None)
     if not app_icons:
         return None
 

--- a/xcodeproj/internal/build_settings.bzl
+++ b/xcodeproj/internal/build_settings.bzl
@@ -21,11 +21,11 @@ _DEVICE_FAMILY_VALUES = {
     "mac": None,
 }
 
-def get_product_module_name(*, ctx, target):
+def get_product_module_name(*, rule_attr, target):
     """Generates a module name for the given target.
 
     Args:
-        ctx: The aspect context.
+        rule_attr: `ctx.rule.attr`.
         target: The `Target` to generate a module name for.
 
     Returns:
@@ -35,7 +35,7 @@ def get_product_module_name(*, ctx, target):
             the target's `Label` into a valid module name (e.g. "//some/pkg:target"
             becomes "some_pkg_target").
     """
-    module_name = getattr(ctx.rule.attr, "module_name", None)
+    module_name = getattr(rule_attr, "module_name", None)
     if module_name:
         return (module_name, module_name)
 
@@ -43,7 +43,7 @@ def get_product_module_name(*, ctx, target):
         # A `swift_proto_library` target must only have exactly one target in
         # the deps attribute. This is already validated in
         # `swift_proto_library`'s implementation.
-        target_to_derive_module_name = ctx.rule.attr.deps[0]
+        target_to_derive_module_name = rule_attr.deps[0]
 
         # The module name of the Swift library produced by a
         # `swift_proto_library` is based on the name of the `proto_library`

--- a/xcodeproj/internal/info_plists.bzl
+++ b/xcodeproj/internal/info_plists.bzl
@@ -13,12 +13,12 @@ def _get_file(target):
         return getattr(target[AppleBinaryInfo], "infoplist", None)
     return None
 
-def _adjust_for_xcode(file, default_app_icon_path, *, ctx):
+def _adjust_for_xcode(file, default_app_icon_path, *, ctx, rule_attr):
     if file == None:
         return None
 
     output = ctx.actions.declare_file(
-        "rules_xcodeproj/{}/Info.plist".format(ctx.rule.attr.name),
+        "rules_xcodeproj/{}/Info.plist".format(rule_attr.name),
     )
     command = """\
 cp "{input}" "{output}"

--- a/xcodeproj/internal/input_files.bzl
+++ b/xcodeproj/internal/input_files.bzl
@@ -105,6 +105,7 @@ def _collect_input_files(
         ctx,
         target,
         attrs,
+        rule_attr,
         unfocused = False,
         id,
         platform,
@@ -122,6 +123,7 @@ def _collect_input_files(
         ctx: The aspect context.
         target: The `Target` to collect inputs from.
         attrs: `dir(ctx.rule.attr)` (as a performance optimization).
+        rule_attr: `ctx.rule.attr`.
         unfocused: Whether the target is unfocused. If `None`, it will be
             determined automatically (this should only be the case for
             `non_xcode_target`s).
@@ -364,7 +366,7 @@ def _collect_input_files(
             # Only attributes in `file_handlers` are categorized
             continue
 
-        dep = getattr(ctx.rule.attr, attr)
+        dep = getattr(rule_attr, attr)
 
         dep_type = type(dep)
         if dep_type == "Target":
@@ -667,7 +669,7 @@ def _collect_input_files(
             indexstore_and_target_overrides = transitive_indexstore_overrides,
             indexstores = transitive_indexstores,
             name = "xi",
-            rule_name = ctx.rule.attr.name,
+            rule_name = rule_attr.name,
         )
 
         # We don't want to declare indexstore files as outputs, because they

--- a/xcodeproj/internal/library_targets.bzl
+++ b/xcodeproj/internal/library_targets.bzl
@@ -31,6 +31,7 @@ def process_library_target(
         target,
         attrs,
         automatic_target_info,
+        rule_attr,
         transitive_infos):
     """Gathers information about a library target.
 
@@ -41,6 +42,7 @@ def process_library_target(
         attrs: `dir(ctx.rule.attr)` (as a performance optimization).
         automatic_target_info: The `XcodeProjAutomaticTargetProcessingInfo` for
             `target`.
+        rule_attr: `ctx.rule.attr`.
         transitive_infos: A `list` of `depset`s of `XcodeProjInfo`s from the
             transitive dependencies of `target`.
 
@@ -53,9 +55,9 @@ def process_library_target(
 
     build_settings = {}
 
-    product_name = ctx.rule.attr.name
+    product_name = rule_attr.name
     module_name_attribute, product_module_name = get_product_module_name(
-        ctx = ctx,
+        rule_attr = rule_attr,
         target = target,
     )
     set_if_true(
@@ -72,7 +74,7 @@ def process_library_target(
     deps_infos = [
         dep[XcodeProjInfo]
         for attr in automatic_target_info.implementation_deps
-        for dep in getattr(ctx.rule.attr, attr, [])
+        for dep in getattr(rule_attr, attr, [])
         if XcodeProjInfo in dep
     ]
 
@@ -119,6 +121,7 @@ def process_library_target(
         ctx = ctx,
         target = target,
         attrs = attrs,
+        rule_attr = rule_attr,
         id = id,
         platform = platform,
         is_bundle = False,
@@ -137,6 +140,7 @@ def process_library_target(
         inputs = target_inputs,
         output_group_info = output_group_info,
         product = product,
+        rule_attr = rule_attr,
         swift_info = swift_info,
         transitive_infos = transitive_infos,
     )

--- a/xcodeproj/internal/output_files.bzl
+++ b/xcodeproj/internal/output_files.bzl
@@ -126,6 +126,7 @@ def _collect_output_files(
         indexstore_overrides = [],
         infoplist = None,
         inputs = None,
+        rule_attr,
         transitive_infos,
         should_produce_dto = True,
         should_produce_output_groups = True):
@@ -148,6 +149,7 @@ def _collect_output_files(
             targets.
         infoplist: A `File` or `None`.
         inputs: A value returned from `input_files.collect`, or `None`.
+        rule_attr: `ctx.rule.attr`.
         transitive_infos: A `list` of `XcodeProjInfo`s for the transitive
             dependencies of the target.
         should_produce_dto: If `True`, `outputs_files.to_dto` will return
@@ -257,7 +259,7 @@ def _collect_output_files(
             indexstore_and_target_overrides = transitive_indexstore_overrides,
             indexstores = transitive_indexstores,
             name = "bi",
-            rule_name = ctx.rule.attr.name,
+            rule_name = rule_attr.name,
         )
 
         # We don't want to declare indexstore files as outputs, because they

--- a/xcodeproj/internal/resource_target.bzl
+++ b/xcodeproj/internal/resource_target.bzl
@@ -53,6 +53,7 @@ def _process_resource_bundle(bundle, *, bundle_id):
         debug_outputs = None,
         id = id,
         output_group_info = None,
+        rule_attr = None,
         swift_info = None,
         transitive_infos = EMPTY_LIST,
         should_produce_dto = False,

--- a/xcodeproj/internal/unsupported_targets.bzl
+++ b/xcodeproj/internal/unsupported_targets.bzl
@@ -25,6 +25,7 @@ def process_unsupported_target(
         target,
         attrs,
         automatic_target_info,
+        rule_attr,
         transitive_infos):
     """Gathers information about a non-Xcode target.
 
@@ -34,6 +35,7 @@ def process_unsupported_target(
         attrs: `dir(ctx.rule.attr)` (as a performance optimization).
         automatic_target_info: The `XcodeProjAutomaticTargetProcessingInfo` for
             `target`.
+        rule_attr: `ctx.rule.attr`.
         transitive_infos: A `list` of `depset`s of `XcodeProjInfo`s from the
             transitive dependencies of `target`.
 
@@ -57,7 +59,7 @@ def process_unsupported_target(
                     ),
                 ),
                 getattr(
-                    ctx.rule.attr,
+                    rule_attr,
                     automatic_target_info.bundle_id,
                 ),
             ),
@@ -92,6 +94,7 @@ def process_unsupported_target(
         ctx = ctx,
         target = target,
         attrs = attrs,
+        rule_attr = rule_attr,
         unfocused = None,
         id = None,
         platform = None,

--- a/xcodeproj/internal/xcodeproj_legacy_aspect.bzl
+++ b/xcodeproj/internal/xcodeproj_legacy_aspect.bzl
@@ -25,7 +25,7 @@ def _should_ignore_attr(attr):
         attr in _IGNORE_ATTR
     )
 
-def _transitive_infos(*, ctx, attrs):
+def _transitive_infos(*, attrs, rule_attr):
     transitive_infos = []
 
     # TODO: Have `XcodeProjAutomaticTargetProcessingInfo` tell us which
@@ -36,7 +36,7 @@ def _transitive_infos(*, ctx, attrs):
         if _should_ignore_attr(attr):
             continue
 
-        dep = getattr(ctx.rule.attr, attr)
+        dep = getattr(rule_attr, attr)
 
         dep_type = type(dep)
         if dep_type == "list":
@@ -98,15 +98,19 @@ def _xcodeproj_legacy_aspect_impl(target, ctx):
     if XcodeProjInfo not in target:
         # Only create an `XcodeProjInfo` if the target hasn't already created
         # one
-        attrs = dir(ctx.rule.attr)
+        rule_attr = ctx.rule.attr
+
+        attrs = dir(rule_attr)
         info = legacy_xcodeprojinfos.make(
             ctx = ctx,
             build_mode = ctx.attr._build_mode,
-            target = target,
             attrs = attrs,
+            rule_attr = rule_attr,
+            rule_kind = ctx.rule.kind,
+            target = target,
             transitive_infos = _transitive_infos(
-                ctx = ctx,
                 attrs = attrs,
+                rule_attr = rule_attr,
             ),
         )
         if info:


### PR DESCRIPTION
End goal is to remove use of `ctx`.