### PR TITLE
Split `compilation_providers` return in two

### DIFF
--- a/xcodeproj/internal/compilation_providers.bzl
+++ b/xcodeproj/internal/compilation_providers.bzl
@@ -150,9 +150,9 @@ def _collect_compilation_providers(
             cc_info.compilation_context if cc_info else None
         ),
         compilation_contexts = [
-            providers.cc_info.compilation_context
+            providers._cc_info.compilation_context
             for providers in transitive_implementation_providers
-            if providers.cc_info
+            if providers._cc_info
         ],
     )
 
@@ -161,13 +161,16 @@ def _collect_compilation_providers(
 
     return (
         struct(
-            _propagated_framework_files = EMPTY_DEPSET,
-            _propagated_objc = objc,
             cc_info = cc_info,
             framework_files = EMPTY_DEPSET,
             is_top_level = False,
             is_xcode_library_target = is_xcode_library_target,
             objc = objc,
+        ),
+        struct(
+            _cc_info = cc_info,
+            _propagated_framework_files = EMPTY_DEPSET,
+            _propagated_objc = objc,
         ),
         implementation_compilation_context,
     )
@@ -214,9 +217,9 @@ def _merge_compilation_providers(
         propagated_framework_files = framework_files
 
     transitive_cc_infos = [
-        providers.cc_info
+        providers._cc_info
         for _, providers in transitive_compilation_providers
-        if providers.cc_info
+        if providers._cc_info
     ]
 
     if len(transitive_cc_infos) > 1 or (cc_info and transitive_cc_infos):
@@ -238,7 +241,7 @@ def _merge_compilation_providers(
     objc = None
     if _objc_has_linking_info:
         maybe_objc_providers = [
-            _to_objc(providers._propagated_objc, providers.cc_info)
+            _to_objc(providers._propagated_objc, providers._cc_info)
             for _, providers in transitive_compilation_providers
         ]
         objc_providers = [objc for objc in maybe_objc_providers if objc]
@@ -253,13 +256,16 @@ def _merge_compilation_providers(
 
     return (
         struct(
-            _propagated_framework_files = propagated_framework_files,
-            _propagated_objc = propagated_objc,
             cc_info = merged_cc_info,
             framework_files = framework_files,
             is_top_level = True,
             is_xcode_library_target = False,
             objc = objc,
+        ),
+        struct(
+            _cc_info = merged_cc_info,
+            _propagated_framework_files = propagated_framework_files,
+            _propagated_objc = propagated_objc,
         ),
         implementation_compilation_context,
     )

--- a/xcodeproj/internal/input_files.bzl
+++ b/xcodeproj/internal/input_files.bzl
@@ -6,7 +6,7 @@ load(
     "AppleResourceInfo",
 )
 load("@build_bazel_rules_swift//swift:swift.bzl", "SwiftInfo", "SwiftProtoInfo")
-load(":compilation_providers.bzl", comp_providers = "compilation_providers")
+load(":compilation_providers.bzl", "compilation_providers")
 load(
     ":files.bzl",
     "FRAMEWORK_EXTENSIONS",
@@ -506,7 +506,7 @@ def _collect_input_files(
     bwx_unfocused_libraries = None
     if should_include_non_xcode_outputs(ctx = ctx):
         if unfocused == None:
-            (dep_compilation_providers, _) = comp_providers.merge(
+            (dep_compilation_providers, _, _) = compilation_providers.merge(
                 transitive_compilation_providers = [
                     (info.xcode_target, info.compilation_providers)
                     for info in transitive_infos

--- a/xcodeproj/internal/legacy_xcodeprojinfos.bzl
+++ b/xcodeproj/internal/legacy_xcodeprojinfos.bzl
@@ -9,7 +9,7 @@ load(
 )
 load(":automatic_target_info.bzl", "calculate_automatic_target_info")
 load(":bazel_labels.bzl", "bazel_labels")
-load(":compilation_providers.bzl", comp_providers = "compilation_providers")
+load(":compilation_providers.bzl", "compilation_providers")
 load(":input_files.bzl", "input_files")
 load(":library_targets.bzl", "process_library_target")
 load(":lldb_contexts.bzl", "lldb_contexts")
@@ -253,9 +253,10 @@ def _make_skipped_target_xcodeprojinfo(
         `transitive_infos`.
     """
     (
-        compilation_providers,
         _,
-    ) = comp_providers.merge(
+        provider_compilation_providers,
+        _,
+    ) = compilation_providers.merge(
         transitive_compilation_providers = [
             (
                 dep[XcodeProjInfo].xcode_target,
@@ -349,7 +350,7 @@ def _make_skipped_target_xcodeprojinfo(
                 for info in valid_transitive_infos
             ],
         ),
-        compilation_providers = compilation_providers,
+        compilation_providers = provider_compilation_providers,
         dependencies = dependencies,
         envs = memory_efficient_depset(
             [

--- a/xcodeproj/internal/library_targets.bzl
+++ b/xcodeproj/internal/library_targets.bzl
@@ -80,7 +80,8 @@ def process_library_target(
     swift_info = target[SwiftInfo] if SwiftInfo in target else None
 
     (
-        compilation_providers,
+        target_compilation_providers,
+        provider_compilation_providers,
         implementation_compilation_context,
     ) = comp_providers.collect(
         cc_info = target[CcInfo],
@@ -94,7 +95,7 @@ def process_library_target(
     linker_inputs = linker_input_files.collect(
         target = target,
         automatic_target_info = automatic_target_info,
-        compilation_providers = compilation_providers,
+        compilation_providers = target_compilation_providers,
     )
 
     cpp = ctx.fragments.cpp
@@ -180,7 +181,7 @@ def process_library_target(
     )
 
     return processed_target(
-        compilation_providers = compilation_providers,
+        compilation_providers = provider_compilation_providers,
         dependencies = dependencies,
         inputs = provider_inputs,
         library = product.file,

--- a/xcodeproj/internal/top_level_targets.bzl
+++ b/xcodeproj/internal/top_level_targets.bzl
@@ -9,7 +9,7 @@ load(
     "get_targeted_device_family",
 )
 load(":collections.bzl", "set_if_true")
-load(":compilation_providers.bzl", comp_providers = "compilation_providers")
+load(":compilation_providers.bzl", "compilation_providers")
 load(":configuration.bzl", "calculate_configuration")
 load(":files.bzl", "build_setting_path", "join_paths_ignoring_empty")
 load(":info_plists.bzl", "info_plists")
@@ -340,7 +340,7 @@ def process_top_level_target(
         )
 
     if avoid_compilation_providers_list:
-        (avoid_compilation_providers, _) = comp_providers.merge(
+        (avoid_compilation_providers, _, _) = compilation_providers.merge(
             transitive_compilation_providers = avoid_compilation_providers_list,
         )
     else:
@@ -361,9 +361,10 @@ def process_top_level_target(
     ]
 
     (
-        compilation_providers,
+        target_compilation_providers,
+        provider_compilation_providers,
         implementation_compilation_context,
-    ) = comp_providers.merge(
+    ) = compilation_providers.merge(
         apple_dynamic_framework_info = apple_dynamic_framework_info,
         cc_info = target[CcInfo] if CcInfo in target else None,
         transitive_compilation_providers = [
@@ -374,7 +375,7 @@ def process_top_level_target(
     linker_inputs = linker_input_files.collect(
         target = target,
         automatic_target_info = automatic_target_info,
-        compilation_providers = compilation_providers,
+        compilation_providers = target_compilation_providers,
         avoid_compilation_providers = avoid_compilation_providers,
     )
 
@@ -534,7 +535,7 @@ def process_top_level_target(
     )
 
     return processed_target(
-        compilation_providers = compilation_providers,
+        compilation_providers = provider_compilation_providers,
         dependencies = dependencies,
         extension_infoplists = extension_infoplists,
         hosted_targets = hosted_targets,

--- a/xcodeproj/internal/unsupported_targets.bzl
+++ b/xcodeproj/internal/unsupported_targets.bzl
@@ -5,7 +5,7 @@ load(
     "AppleResourceBundleInfo",
 )
 load("@build_bazel_rules_swift//swift:swift.bzl", "SwiftInfo")
-load(":compilation_providers.bzl", comp_providers = "compilation_providers")
+load(":compilation_providers.bzl", "compilation_providers")
 load(":configuration.bzl", "calculate_configuration")
 load(":input_files.bzl", "input_files")
 load(":linker_input_files.bzl", "linker_input_files")
@@ -66,9 +66,10 @@ def process_unsupported_target(
         resource_bundle_ids = None
 
     (
-        compilation_providers,
+        target_compilation_providers,
+        provider_compilation_providers,
         _,
-    ) = comp_providers.collect(
+    ) = compilation_providers.collect(
         cc_info = cc_info,
         objc = objc,
         is_xcode_target = False,
@@ -79,7 +80,7 @@ def process_unsupported_target(
     linker_inputs = linker_input_files.collect(
         target = target,
         automatic_target_info = automatic_target_info,
-        compilation_providers = compilation_providers,
+        compilation_providers = target_compilation_providers,
     )
     swiftmodules = process_swiftmodules(swift_info = swift_info)
 
@@ -106,7 +107,7 @@ def process_unsupported_target(
     )
 
     return processed_target(
-        compilation_providers = compilation_providers,
+        compilation_providers = provider_compilation_providers,
         dependencies = dependencies,
         inputs = provider_inputs,
         lldb_context = lldb_contexts.collect(


### PR DESCRIPTION
Reduces retained memory.