### PR TITLE
Rename `dependencies` to `direct_dependencies`

### DIFF
--- a/docs/bazel.md
+++ b/docs/bazel.md
@@ -578,8 +578,8 @@ return an `XcodeProjInfo` provider instance instead.
 ## XcodeProjInfo
 
 <pre>
-XcodeProjInfo(<a href="#XcodeProjInfo-args">args</a>, <a href="#XcodeProjInfo-compilation_providers">compilation_providers</a>, <a href="#XcodeProjInfo-dependencies">dependencies</a>, <a href="#XcodeProjInfo-envs">envs</a>, <a href="#XcodeProjInfo-extension_infoplists">extension_infoplists</a>, <a href="#XcodeProjInfo-hosted_targets">hosted_targets</a>,
-              <a href="#XcodeProjInfo-inputs">inputs</a>, <a href="#XcodeProjInfo-label">label</a>, <a href="#XcodeProjInfo-labels">labels</a>, <a href="#XcodeProjInfo-lldb_context">lldb_context</a>, <a href="#XcodeProjInfo-mergable_xcode_library_targets">mergable_xcode_library_targets</a>,
+XcodeProjInfo(<a href="#XcodeProjInfo-args">args</a>, <a href="#XcodeProjInfo-compilation_providers">compilation_providers</a>, <a href="#XcodeProjInfo-direct_dependencies">direct_dependencies</a>, <a href="#XcodeProjInfo-envs">envs</a>, <a href="#XcodeProjInfo-extension_infoplists">extension_infoplists</a>,
+              <a href="#XcodeProjInfo-hosted_targets">hosted_targets</a>, <a href="#XcodeProjInfo-inputs">inputs</a>, <a href="#XcodeProjInfo-label">label</a>, <a href="#XcodeProjInfo-labels">labels</a>, <a href="#XcodeProjInfo-lldb_context">lldb_context</a>, <a href="#XcodeProjInfo-mergable_xcode_library_targets">mergable_xcode_library_targets</a>,
               <a href="#XcodeProjInfo-non_top_level_rule_kind">non_top_level_rule_kind</a>, <a href="#XcodeProjInfo-outputs">outputs</a>, <a href="#XcodeProjInfo-potential_target_merges">potential_target_merges</a>, <a href="#XcodeProjInfo-replacement_labels">replacement_labels</a>,
               <a href="#XcodeProjInfo-resource_bundle_ids">resource_bundle_ids</a>, <a href="#XcodeProjInfo-target_type">target_type</a>, <a href="#XcodeProjInfo-transitive_dependencies">transitive_dependencies</a>, <a href="#XcodeProjInfo-xcode_required_targets">xcode_required_targets</a>,
               <a href="#XcodeProjInfo-xcode_target">xcode_target</a>, <a href="#XcodeProjInfo-xcode_targets">xcode_targets</a>)
@@ -600,7 +600,7 @@ Provides information needed to generate an Xcode project.
 | :------------- | :------------- |
 | <a id="XcodeProjInfo-args"></a>args |  A `depset` of `struct`s with `id` and `arg` fields. The `id` field is the target ID (see `xcode_target.id`) of the target and `arg` values for the target (if applicable).    |
 | <a id="XcodeProjInfo-compilation_providers"></a>compilation_providers |  A value returned from `compilation_providers.{collect,merge}`.    |
-| <a id="XcodeProjInfo-dependencies"></a>dependencies |  A `depset` of target IDs (see `xcode_target.id`) that this target directly depends on.    |
+| <a id="XcodeProjInfo-direct_dependencies"></a>direct_dependencies |  A `depset` of target IDs (see `xcode_target.id`) that this target directly depends on.    |
 | <a id="XcodeProjInfo-envs"></a>envs |  A `depset` of `struct`s with `id` and `env` fields. The `id` field is the target ID (see `xcode_target.id`) of the target and `env` values for the target (if applicable).    |
 | <a id="XcodeProjInfo-extension_infoplists"></a>extension_infoplists |  A `depset` of `struct`s with `id` and `infoplist` fields. The `id` field is the target ID (see `xcode_target.id`) of the application extension target. The `infoplist` field is a `File` for the Info.plist for the target.    |
 | <a id="XcodeProjInfo-hosted_targets"></a>hosted_targets |  A `depset` of `struct`s with `host` and `hosted` fields. The `host` field is the target ID (see `xcode_target.id`) of the hosting target. The `hosted` field is the target ID of the hosted target.    |

--- a/test/internal/pbxproj_partials/write_pbxtargetdependencies_tests.bzl
+++ b/test/internal/pbxproj_partials/write_pbxtargetdependencies_tests.bzl
@@ -40,7 +40,7 @@ def _dict_to_xcode_targets_by_id(d):
 def _dict_to_xcode_target(d):
     return struct(
         id = d["id"],
-        dependencies = depset(d["dependencies"]),
+        direct_dependencies = depset(d["direct_dependencies"]),
         platform = struct(
             apple_platform = d["apple_platform"],
             arch = d["arch"],
@@ -62,7 +62,7 @@ def mock_xcode_target(
         id,
         apple_platform,
         arch,
-        dependencies,
+        direct_dependencies,
         module_name_attribute,
         os_version,
         product_basename,
@@ -74,7 +74,7 @@ def mock_xcode_target(
         id = id,
         apple_platform = apple_platform,
         arch = arch,
-        dependencies = dependencies,
+        direct_dependencies = direct_dependencies,
         module_name_attribute = module_name_attribute,
         os_version = os_version,
         product_basename = product_basename,
@@ -303,7 +303,7 @@ def write_pbxtargetdependencies_test_suite(name):
             "//tools/generators/legacy/test:tests.__internal__.__test_bundle": {
                 "//tools/generators/legacy/test:tests.__internal__.__test_bundle applebin_macos-darwin_x86_64-dbg-STABLE-3": mock_xcode_target(
                     id = "//tools/generators/legacy/test:tests.__internal__.__test_bundle applebin_macos-darwin_x86_64-dbg-STABLE-3",
-                    dependencies = [
+                    direct_dependencies = [
                         "//tools/generators/legacy:generator.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-2",
                     ],
                     apple_platform = "MACOS",
@@ -321,7 +321,7 @@ def write_pbxtargetdependencies_test_suite(name):
                     id = "//tools/generators/legacy:generator applebin_macos-darwin_x86_64-dbg-STABLE-3",
                     apple_platform = "IOS_DEVICE",
                     arch = "x86_64",
-                    dependencies = [
+                    direct_dependencies = [
                         "//tools/generators/legacy:generator.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
                     ],
                     os_version = "12.0",
@@ -336,7 +336,7 @@ def write_pbxtargetdependencies_test_suite(name):
                     id = "//tools/generators/legacy:generator.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
                     apple_platform = "WATCHOS_SIMULATOR",
                     arch = "i386",
-                    dependencies = [],
+                    direct_dependencies = [],
                     os_version = "9.1",
                     product_type = "L",
                     product_file_path = "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-3/bin/tools/generators/legacy/libgenerator.a",

--- a/xcodeproj/internal/input_files.bzl
+++ b/xcodeproj/internal/input_files.bzl
@@ -14,6 +14,7 @@ load(
     "normalized_file_path",
 )
 load(":indexstore_filelists.bzl", "indexstore_filelists")
+load(":legacy_target_properties.bzl", "should_include_non_xcode_outputs")
 load(":linker_input_files.bzl", "linker_input_files")
 load(
     ":memory_efficiency.bzl",
@@ -25,7 +26,6 @@ load(
 )
 load(":output_files.bzl", "parse_swift_info_module", "swift_to_outputs")
 load(":resources.bzl", "collect_resources")
-load(":target_properties.bzl", "should_include_non_xcode_outputs")
 load(":xcodeprojinfo.bzl", "XcodeProjInfo")
 
 # Utility

--- a/xcodeproj/internal/legacy_target_properties.bzl
+++ b/xcodeproj/internal/legacy_target_properties.bzl
@@ -1,4 +1,5 @@
-"""Functions for processing target properties"""
+"""Functions for processing target properties. Only to be used when \
+`xcodeproj.generation_mode = "legacy"` is set."""
 
 load(":collections.bzl", "uniq")
 load(":memory_efficiency.bzl", "memory_efficient_depset")
@@ -65,7 +66,7 @@ def process_dependencies(
         else:
             # We pass on the next level of dependencies if the previous target
             # didn't create an Xcode target.
-            direct_transitive_dependencies.append(info.dependencies)
+            direct_transitive_dependencies.append(info.direct_dependencies)
 
     direct = memory_efficient_depset(
         direct_dependencies,

--- a/xcodeproj/internal/legacy_xcodeprojinfos.bzl
+++ b/xcodeproj/internal/legacy_xcodeprojinfos.bzl
@@ -11,6 +11,7 @@ load(":automatic_target_info.bzl", "calculate_automatic_target_info")
 load(":bazel_labels.bzl", "bazel_labels")
 load(":compilation_providers.bzl", "compilation_providers")
 load(":input_files.bzl", "input_files")
+load(":legacy_target_properties.bzl", "process_dependencies")
 load(":library_targets.bzl", "process_library_target")
 load(":lldb_contexts.bzl", "lldb_contexts")
 load(
@@ -21,7 +22,6 @@ load(
 )
 load(":output_files.bzl", "output_files")
 load(":processed_target.bzl", "processed_target")
-load(":target_properties.bzl", "process_dependencies")
 load(":targets.bzl", "targets")
 load(":top_level_targets.bzl", "process_top_level_target")
 load(":unsupported_targets.bzl", "process_unsupported_target")
@@ -124,7 +124,7 @@ def _target_info_fields(
         *,
         args,
         compilation_providers,
-        dependencies,
+        direct_dependencies,
         envs,
         extension_infoplists,
         hosted_targets,
@@ -149,7 +149,8 @@ def _target_info_fields(
         args: Maps to the `XcodeProjInfo.args` field.
         compilation_providers: Maps to the `XcodeProjInfo.compilation_providers`
             field.
-        dependencies: Maps to the `XcodeProjInfo.dependencies` field.
+        direct_dependencies: Maps to the `XcodeProjInfo.direct_dependencies`
+            field.
         envs: Maps to the `XcodeProjInfo.envs` field.
         extension_infoplists: Maps to the `XcodeProjInfo.extension_infoplists`
             field.
@@ -180,7 +181,7 @@ def _target_info_fields(
 
         *   `args`
         *   `compilation_providers`
-        *   `dependencies`
+        *   `direct_dependencies`
         *   `extension_infoplists`
         *   `envs`
         *   `generated_inputs`
@@ -201,7 +202,7 @@ def _target_info_fields(
     return {
         "args": args,
         "compilation_providers": compilation_providers,
-        "dependencies": dependencies,
+        "direct_dependencies": direct_dependencies,
         "envs": envs,
         "extension_infoplists": extension_infoplists,
         "hosted_targets": hosted_targets,
@@ -274,7 +275,7 @@ def _make_skipped_target_xcodeprojinfo(
         for _, info in transitive_infos
     ]
 
-    dependencies, transitive_dependencies = process_dependencies(
+    direct_dependencies, transitive_dependencies = process_dependencies(
         build_mode = build_mode,
         transitive_infos = valid_transitive_infos,
     )
@@ -353,7 +354,7 @@ def _make_skipped_target_xcodeprojinfo(
             ],
         ),
         compilation_providers = provider_compilation_providers,
-        dependencies = dependencies,
+        direct_dependencies = direct_dependencies,
         envs = memory_efficient_depset(
             [
                 struct(
@@ -542,7 +543,7 @@ def _make_non_skipped_target_xcodeprojinfo(
             ],
         ),
         compilation_providers = processed_target.compilation_providers,
-        dependencies = processed_target.dependencies,
+        direct_dependencies = processed_target.direct_dependencies,
         envs = memory_efficient_depset(
             transitive = [
                 info.envs

--- a/xcodeproj/internal/library_targets.bzl
+++ b/xcodeproj/internal/library_targets.bzl
@@ -7,6 +7,12 @@ load(":compilation_providers.bzl", comp_providers = "compilation_providers")
 load(":configuration.bzl", "calculate_configuration")
 load(":files.bzl", "build_setting_path", "join_paths_ignoring_empty")
 load(":input_files.bzl", "input_files")
+load(
+    ":legacy_target_properties.bzl",
+    "process_dependencies",
+    "process_modulemaps",
+    "process_swiftmodules",
+)
 load(":linker_input_files.bzl", "linker_input_files")
 load(":lldb_contexts.bzl", "lldb_contexts")
 load(":opts.bzl", "process_opts")
@@ -15,12 +21,6 @@ load(":platforms.bzl", "platforms")
 load(":processed_target.bzl", "processed_target")
 load(":product.bzl", "process_product")
 load(":target_id.bzl", "get_id")
-load(
-    ":target_properties.bzl",
-    "process_dependencies",
-    "process_modulemaps",
-    "process_swiftmodules",
-)
 load(":xcode_targets.bzl", "xcode_targets")
 load(":xcodeprojinfo.bzl", "XcodeProjInfo")
 
@@ -66,7 +66,7 @@ def process_library_target(
         product_module_name,
     )
 
-    dependencies, transitive_dependencies = process_dependencies(
+    direct_dependencies, transitive_dependencies = process_dependencies(
         build_mode = build_mode,
         transitive_infos = transitive_infos,
     )
@@ -187,7 +187,7 @@ def process_library_target(
 
     return processed_target(
         compilation_providers = provider_compilation_providers,
-        dependencies = dependencies,
+        direct_dependencies = direct_dependencies,
         inputs = provider_inputs,
         library = product.file,
         lldb_context = lldb_context,
@@ -210,7 +210,7 @@ def process_library_target(
             swiftmodules = swiftmodules,
             inputs = target_inputs,
             linker_inputs = linker_inputs,
-            dependencies = dependencies,
+            direct_dependencies = direct_dependencies,
             transitive_dependencies = transitive_dependencies,
             outputs = target_outputs,
         ),

--- a/xcodeproj/internal/pbxproj_partials.bzl
+++ b/xcodeproj/internal/pbxproj_partials.bzl
@@ -551,10 +551,10 @@ def _write_pbxtargetdependencies(
                 consolidation_map_args.add(xcode_target.product.file_path)
                 consolidation_map_args.add(xcode_target.product.basename)
                 consolidation_map_args.add_all(
-                    [xcode_target.dependencies],
+                    [xcode_target.direct_dependencies],
                     map_each = _depset_len,
                 )
-                consolidation_map_args.add_all(xcode_target.dependencies)
+                consolidation_map_args.add_all(xcode_target.direct_dependencies)
 
                 target_xcode_configurations = (
                     xcode_target_configurations[xcode_target.id]

--- a/xcodeproj/internal/processed_target.bzl
+++ b/xcodeproj/internal/processed_target.bzl
@@ -3,7 +3,7 @@
 def processed_target(
         *,
         compilation_providers,
-        dependencies,
+        direct_dependencies,
         extension_infoplists = None,
         hosted_targets = None,
         inputs,
@@ -21,8 +21,8 @@ def processed_target(
     Args:
         compilation_providers: A value returned from
             `compilation_providers.collect`.
-        dependencies: A `depset` of target ids of direct dependencies of this
-            target.
+        direct_dependencies: A `depset` of `id`s of targets that this target
+            directly depends on.
         extension_infoplists: A `list` of `File` for the Info.plist's of an
             application extension target, or `None`.
         hosted_targets: An optional `list` of `struct`s as used in
@@ -54,7 +54,7 @@ def processed_target(
     return struct(
         compilation_providers = compilation_providers,
         extension_infoplists = extension_infoplists,
-        dependencies = dependencies,
+        direct_dependencies = direct_dependencies,
         hosted_targets = hosted_targets,
         inputs = inputs,
         is_top_level = is_top_level,

--- a/xcodeproj/internal/resource_target.bzl
+++ b/xcodeproj/internal/resource_target.bzl
@@ -4,13 +4,13 @@ load("@bazel_skylib//lib:paths.bzl", "paths")
 load(":collections.bzl", "set_if_true")
 load(":files.bzl", "build_setting_path")
 load(":input_files.bzl", "input_files")
+load(
+    ":legacy_target_properties.bzl",
+    "process_modulemaps",
+)
 load(":memory_efficiency.bzl", "EMPTY_LIST")
 load(":output_files.bzl", "output_files")
 load(":product.bzl", "process_product")
-load(
-    ":target_properties.bzl",
-    "process_modulemaps",
-)
 load(":xcode_targets.bzl", "xcode_targets")
 
 def _process_resource_bundle(bundle, *, bundle_id):
@@ -71,7 +71,7 @@ def _process_resource_bundle(bundle, *, bundle_id):
         modulemaps = process_modulemaps(swift_info = None),
         swiftmodules = EMPTY_LIST,
         inputs = input_files.from_resource_bundle(bundle),
-        dependencies = bundle.dependencies,
+        direct_dependencies = bundle.dependencies,
         transitive_dependencies = bundle.dependencies,
         outputs = target_outputs,
     )

--- a/xcodeproj/internal/top_level_targets.bzl
+++ b/xcodeproj/internal/top_level_targets.bzl
@@ -14,6 +14,12 @@ load(":configuration.bzl", "calculate_configuration")
 load(":files.bzl", "build_setting_path", "join_paths_ignoring_empty")
 load(":info_plists.bzl", "info_plists")
 load(":input_files.bzl", "input_files")
+load(
+    ":legacy_target_properties.bzl",
+    "process_dependencies",
+    "process_modulemaps",
+    "process_swiftmodules",
+)
 load(":linker_input_files.bzl", "linker_input_files")
 load(":lldb_contexts.bzl", "lldb_contexts")
 load(
@@ -28,12 +34,6 @@ load(":processed_target.bzl", "processed_target")
 load(":product.bzl", "process_product")
 load(":provisioning_profiles.bzl", "provisioning_profiles")
 load(":target_id.bzl", "get_id")
-load(
-    ":target_properties.bzl",
-    "process_dependencies",
-    "process_modulemaps",
-    "process_swiftmodules",
-)
 load(":xcode_targets.bzl", "xcode_targets")
 load(":xcodeprojinfo.bzl", "XcodeProjInfo")
 
@@ -323,7 +323,7 @@ def process_top_level_target(
     )
     platform = platforms.collect(ctx = ctx)
 
-    dependencies, transitive_dependencies = process_dependencies(
+    direct_dependencies, transitive_dependencies = process_dependencies(
         build_mode = build_mode,
         test_host = test_host,
         top_level_product_type = props.product_type,
@@ -545,7 +545,7 @@ def process_top_level_target(
 
     return processed_target(
         compilation_providers = provider_compilation_providers,
-        dependencies = dependencies,
+        direct_dependencies = direct_dependencies,
         extension_infoplists = extension_infoplists,
         hosted_targets = hosted_targets,
         inputs = provider_inputs,
@@ -576,7 +576,7 @@ def process_top_level_target(
             watch_application = watch_application,
             extensions = extensions,
             app_clips = app_clips,
-            dependencies = dependencies,
+            direct_dependencies = direct_dependencies,
             transitive_dependencies = transitive_dependencies,
             outputs = target_outputs,
             lldb_context = lldb_context,

--- a/xcodeproj/internal/unsupported_targets.bzl
+++ b/xcodeproj/internal/unsupported_targets.bzl
@@ -8,16 +8,16 @@ load("@build_bazel_rules_swift//swift:swift.bzl", "SwiftInfo")
 load(":compilation_providers.bzl", "compilation_providers")
 load(":configuration.bzl", "calculate_configuration")
 load(":input_files.bzl", "input_files")
+load(
+    ":legacy_target_properties.bzl",
+    "process_dependencies",
+    "process_swiftmodules",
+)
 load(":linker_input_files.bzl", "linker_input_files")
 load(":lldb_contexts.bzl", "lldb_contexts")
 load(":output_files.bzl", "output_files")
 load(":processed_target.bzl", "processed_target")
 load(":target_id.bzl", "get_id")
-load(
-    ":target_properties.bzl",
-    "process_dependencies",
-    "process_swiftmodules",
-)
 
 def process_unsupported_target(
         *,
@@ -85,7 +85,7 @@ def process_unsupported_target(
     )
     swiftmodules = process_swiftmodules(swift_info = swift_info)
 
-    dependencies, transitive_dependencies = process_dependencies(
+    direct_dependencies, transitive_dependencies = process_dependencies(
         build_mode = build_mode,
         transitive_infos = transitive_infos,
     )
@@ -110,7 +110,7 @@ def process_unsupported_target(
 
     return processed_target(
         compilation_providers = provider_compilation_providers,
-        dependencies = dependencies,
+        direct_dependencies = direct_dependencies,
         inputs = provider_inputs,
         lldb_context = lldb_contexts.collect(
             build_mode = build_mode,

--- a/xcodeproj/internal/xcodeprojinfo.bzl
+++ b/xcodeproj/internal/xcodeprojinfo.bzl
@@ -23,7 +23,7 @@ target ID (see `xcode_target.id`) of the target and `arg` values for the target
         "compilation_providers": """\
 A value returned from `compilation_providers.{collect,merge}`.
 """,
-        "dependencies": """\
+        "direct_dependencies": """\
 A `depset` of target IDs (see `xcode_target.id`) that this target directly
 depends on.
 """,


### PR DESCRIPTION
Less confusing since `transitive_dependencies` also exists.

Also rename `target_properties.bzl` to `legacy_target_properties.bzl`, in preparation of incremental generation mode.