### PR TITLE
Simplify `target_compilation_providers`

### DIFF
--- a/xcodeproj/internal/compilation_providers.bzl
+++ b/xcodeproj/internal/compilation_providers.bzl
@@ -122,14 +122,12 @@ def _collect_compilation_providers(
         *,
         cc_info,
         objc,
-        is_xcode_target,
         transitive_implementation_providers):
     """Collects compilation providers for a non top-level target.
 
     Args:
         cc_info: The `CcInfo` of the target, or `None`.
         objc: The `ObjcProvider` of the target, or `None`.
-        is_xcode_target: Whether the target is an Xcode target.
         transitive_implementation_providers: A `list` of
             `XcodeProjInfo`s of transitive implementation deps that should have
             compilation providers merged.
@@ -143,8 +141,6 @@ def _collect_compilation_providers(
         -   The implementation deps aware `CcCompilationContext` for `target`.
 
     """
-    is_xcode_library_target = cc_info and is_xcode_target
-
     implementation_compilation_context = _merge_cc_compilation_context(
         direct_compilation_context = (
             cc_info.compilation_context if cc_info else None
@@ -166,8 +162,6 @@ def _collect_compilation_providers(
             implementation_compilation_context = (
                 implementation_compilation_context
             ),
-            is_top_level = False,
-            is_xcode_library_target = is_xcode_library_target,
             objc = objc,
         ),
         struct(
@@ -259,8 +253,6 @@ def _merge_compilation_providers(
                 # no top-level rules have (or will need) implementation deps
                 cc_info.compilation_context if cc_info else None
             ),
-            is_top_level = True,
-            is_xcode_library_target = False,
             objc = objc,
         ),
         struct(

--- a/xcodeproj/internal/library_targets.bzl
+++ b/xcodeproj/internal/library_targets.bzl
@@ -87,7 +87,6 @@ def process_library_target(
     ) = comp_providers.collect(
         cc_info = target[CcInfo],
         objc = objc,
-        is_xcode_target = True,
         transitive_implementation_providers = [
             info.compilation_providers
             for info in deps_infos

--- a/xcodeproj/internal/linker_input_files.bzl
+++ b/xcodeproj/internal/linker_input_files.bzl
@@ -18,21 +18,23 @@ _SKIP_INPUT_EXTENSIONS = {
 
 def _collect_linker_inputs(
         *,
-        target,
         automatic_target_info,
+        avoid_compilation_providers = None,
+        target,
         compilation_providers,
-        avoid_compilation_providers = None):
+        is_top_level = False):
     """Collects linker input files for a target.
 
     Args:
-        target: The `Target`.
         automatic_target_info:  The `XcodeProjAutomaticTargetProcessingInfo` for
             `target`.
-        compilation_providers: A value returned by
-            `compilation_providers.collect`.
         avoid_compilation_providers: A value returned from
             `compilation_providers.collect`. The linker inputs from these
             providers will be excluded from the return list.
+        compilation_providers: A value returned by
+            `compilation_providers.collect`.
+        is_top_level: Whether `target` is the top-level target.
+        target: The `Target`.
 
     Returns:
         An opaque `struct` containing the linker input files for a target. The
@@ -43,7 +45,7 @@ def _collect_linker_inputs(
         compilation_providers = compilation_providers,
     )
 
-    if compilation_providers.is_top_level:
+    if is_top_level:
         primary_static_library = None
         top_level_values = _extract_top_level_values(
             target = target,
@@ -53,14 +55,11 @@ def _collect_linker_inputs(
             objc_libraries = objc_libraries,
             cc_linker_inputs = cc_linker_inputs,
         )
-    elif compilation_providers.is_xcode_library_target:
+    else:
         primary_static_library = _compute_primary_static_library(
             objc_libraries = objc_libraries,
             cc_linker_inputs = cc_linker_inputs,
         )
-        top_level_values = None
-    else:
-        primary_static_library = None
         top_level_values = None
 
     return struct(

--- a/xcodeproj/internal/top_level_targets.bzl
+++ b/xcodeproj/internal/top_level_targets.bzl
@@ -377,10 +377,11 @@ def process_top_level_target(
         ] + avoid_compilation_providers_list,
     )
     linker_inputs = linker_input_files.collect(
-        target = target,
         automatic_target_info = automatic_target_info,
-        compilation_providers = target_compilation_providers,
         avoid_compilation_providers = avoid_compilation_providers,
+        compilation_providers = target_compilation_providers,
+        target = target,
+        is_top_level = True,
     )
 
     codesign_opts, codesign_inputs = _get_codesign_opts(

--- a/xcodeproj/internal/unsupported_targets.bzl
+++ b/xcodeproj/internal/unsupported_targets.bzl
@@ -73,7 +73,6 @@ def process_unsupported_target(
     ) = compilation_providers.collect(
         cc_info = cc_info,
         objc = objc,
-        is_xcode_target = False,
         # Since we don't use the returned `implementation_compilation_context`,
         # we can pass `[]` here
         transitive_implementation_providers = [],


### PR DESCRIPTION
`is_top_level` can be passed into `linker_input_files.collect`. `is_xcode_library_target` isn’t needed.