### PR TITLE
Clean up `products.bzl`

### DIFF
--- a/xcodeproj/internal/library_targets.bzl
+++ b/xcodeproj/internal/library_targets.bzl
@@ -49,7 +49,8 @@ def process_library_target(
     Returns:
         A value from `processed_target`.
     """
-    configuration = calculate_configuration(bin_dir_path = ctx.bin_dir.path)
+    bin_dir_path = ctx.bin_dir.path
+    configuration = calculate_configuration(bin_dir_path = bin_dir_path)
     label = target.label
     id = get_id(label = label, configuration = configuration)
 
@@ -107,12 +108,13 @@ def process_library_target(
 
     platform = platforms.collect(ctx = ctx)
     product = process_product(
-        ctx = ctx,
-        target = target,
+        actions = ctx.actions,
+        bin_dir_path = bin_dir_path,
+        linker_inputs = linker_inputs,
+        module_name_attribute = module_name_attribute,
         product_name = product_name,
         product_type = "com.apple.product-type.library.static",
-        module_name_attribute = module_name_attribute,
-        linker_inputs = linker_inputs,
+        target = target,
     )
 
     modulemaps = process_modulemaps(swift_info = swift_info)
@@ -150,7 +152,7 @@ def process_library_target(
         )
 
     package_bin_dir = join_paths_ignoring_empty(
-        ctx.bin_dir.path,
+        bin_dir_path,
         label.workspace_root,
         label.package,
     )

--- a/xcodeproj/internal/resource_target.bzl
+++ b/xcodeproj/internal/resource_target.bzl
@@ -34,18 +34,19 @@ def _process_resource_bundle(bundle, *, bundle_id):
     bundle_path = paths.join(package_bin_dir, "{}.bundle".format(name))
 
     product = process_product(
-        ctx = None,
-        target = None,
-        product_name = name,
-        product_type = "com.apple.product-type.bundle",
-        # For resource bundles, we want to use the bundle name instead of
-        # `module_name`
-        module_name_attribute = name,
-        is_resource_bundle = True,
+        actions = None,
+        bin_dir_path = None,
         bundle_file = None,
         bundle_path = bundle_path,
         bundle_file_path = bundle_path,
+        is_resource_bundle = True,
         linker_inputs = None,
+        # For resource bundles, we want to use the bundle name instead of
+        # `module_name`
+        module_name_attribute = name,
+        product_name = name,
+        product_type = "com.apple.product-type.bundle",
+        target = None,
     )
 
     (target_outputs, _) = output_files.collect(

--- a/xcodeproj/internal/top_level_targets.bzl
+++ b/xcodeproj/internal/top_level_targets.bzl
@@ -205,7 +205,8 @@ def process_top_level_target(
     Returns:
         A value from `processed_target`.
     """
-    configuration = calculate_configuration(bin_dir_path = ctx.bin_dir.path)
+    bin_dir_path = ctx.bin_dir.path
+    configuration = calculate_configuration(bin_dir_path = bin_dir_path)
     label = target.label
     id = get_id(label = label, configuration = configuration)
 
@@ -403,21 +404,22 @@ def process_top_level_target(
     )
 
     product = process_product(
-        ctx = ctx,
-        target = target,
-        product_name = props.product_name,
-        product_type = props.product_type,
+        actions = ctx.actions,
+        archive_file_path = props.archive_file_path,
+        bin_dir_path = bin_dir_path,
+        bundle_file = props.bundle_file,
+        bundle_path = props.bundle_path,
+        bundle_file_path = props.bundle_file_path,
+        executable_name = props.executable_name,
         # For bundle targets, we want to use the product name instead of
         # `module_name`
         module_name_attribute = (
             props.product_name if is_bundle else module_name_attribute
         ),
-        bundle_file = props.bundle_file,
-        bundle_path = props.bundle_path,
-        bundle_file_path = props.bundle_file_path,
-        archive_file_path = props.archive_file_path,
-        executable_name = props.executable_name,
+        product_name = props.product_name,
+        product_type = props.product_type,
         linker_inputs = linker_inputs,
+        target = target,
     )
 
     (target_inputs, provider_inputs) = input_files.collect(
@@ -458,7 +460,7 @@ def process_top_level_target(
         )
 
     package_bin_dir = join_paths_ignoring_empty(
-        ctx.bin_dir.path,
+        bin_dir_path,
         label.workspace_root,
         label.package,
     )


### PR DESCRIPTION
This is a step closer to being able to co-exist with incremental generation mode code.