### PR TITLE
Conditionally propagate `compilation_providers`

### DIFF
--- a/xcodeproj/internal/compilation_providers.bzl
+++ b/xcodeproj/internal/compilation_providers.bzl
@@ -176,6 +176,7 @@ def _merge_compilation_providers(
         *,
         apple_dynamic_framework_info = None,
         cc_info = None,
+        propagate_providers,
         transitive_compilation_providers):
     """Merges compilation providers from the deps of a target.
 
@@ -183,6 +184,8 @@ def _merge_compilation_providers(
         apple_dynamic_framework_info: The
             `apple_common.AppleDynamicFrameworkInfo` of the target, or `None`.
         cc_info: The `CcInfo` of the target, or `None`.
+        propagate_providers: A `bool` indicating whether providers should be
+            propagated to downstream targets.
         transitive_compilation_providers: A `list` of
             `(xcode_target, XcodeProjInfo)` tuples of transitive dependencies
             that should have compilation providers merged.
@@ -252,9 +255,9 @@ def _merge_compilation_providers(
             objc = objc,
         ),
         struct(
-            _cc_info = merged_cc_info,
+            _cc_info = merged_cc_info if propagate_providers else None,
             _propagated_framework_files = propagated_framework_files,
-            _propagated_objc = propagated_objc,
+            _propagated_objc = propagated_objc if propagate_providers else None,
         ),
     )
 

--- a/xcodeproj/internal/input_files.bzl
+++ b/xcodeproj/internal/input_files.bzl
@@ -509,6 +509,7 @@ def _collect_input_files(
     if should_include_non_xcode_outputs(ctx = ctx):
         if unfocused == None:
             (dep_compilation_providers, _) = compilation_providers.merge(
+                propagate_providers = False,
                 transitive_compilation_providers = [
                     (info.xcode_target, info.compilation_providers)
                     for info in transitive_infos

--- a/xcodeproj/internal/legacy_xcodeprojinfos.bzl
+++ b/xcodeproj/internal/legacy_xcodeprojinfos.bzl
@@ -260,6 +260,7 @@ def _make_skipped_target_xcodeprojinfo(
         _,
         provider_compilation_providers,
     ) = compilation_providers.merge(
+        propagate_providers = False,
         transitive_compilation_providers = [
             (
                 dep[XcodeProjInfo].xcode_target,

--- a/xcodeproj/internal/top_level_targets.bzl
+++ b/xcodeproj/internal/top_level_targets.bzl
@@ -348,6 +348,7 @@ def process_top_level_target(
 
     if avoid_compilation_providers_list:
         (avoid_compilation_providers, _) = compilation_providers.merge(
+            propagate_providers = True,
             transitive_compilation_providers = avoid_compilation_providers_list,
         )
     else:
@@ -373,6 +374,7 @@ def process_top_level_target(
     ) = compilation_providers.merge(
         apple_dynamic_framework_info = apple_dynamic_framework_info,
         cc_info = cc_info,
+        propagate_providers = True,
         transitive_compilation_providers = [
             (info.xcode_target, info.compilation_providers)
             for info in deps_infos


### PR DESCRIPTION
Allows for some retained memory reduction. This is mainly going to be leveraged by incremental generation mode, but we get a small benefit now for test targets.