### PR TITLE
Use correct transitive deps in `resource_bundle_labels`

### DIFF
--- a/xcodeproj/internal/input_files.bzl
+++ b/xcodeproj/internal/input_files.bzl
@@ -471,8 +471,8 @@ def _collect_input_files(
     else:
         resource_bundle_labels = memory_efficient_depset(
             transitive = [
-                dep[XcodeProjInfo].inputs._resource_bundle_labels
-                for dep in avoid_deps
+                info.inputs._resource_bundle_labels
+                for info in transitive_infos
             ],
         )
 


### PR DESCRIPTION
I’m not sure if this really affects anything, but noticed it while working on incremental generation.