### PR TITLE
Extract bundles in Bazel instead of `copy_outputs.sh`

### DIFF
--- a/examples/integration/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -21227,8 +21227,8 @@
 					"\"bazel-out/CONFIGURATION-STABLE-8/bin/Lib/LibFramework.watchOS.framework.dSYM\"",
 					"\"bazel-out/CONFIGURATION-STABLE-8/bin/UI/UIFramework.watchOS.framework.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-4/bin/UI/UIFramework.watchOS.zip";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=watchos*]" = "bazel-out/CONFIGURATION-STABLE-8/bin/UI/UIFramework.watchOS.zip";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-4/bin/UI/UIFramework.watchOS.framework";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=watchos*]" = "bazel-out/CONFIGURATION-STABLE-8/bin/UI/UIFramework.watchOS.framework";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = UIFramework.watchOS.framework;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-4/bin/UI";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=watchos*]" = "bazel-out/CONFIGURATION-STABLE-8/bin/UI";
@@ -21250,11 +21250,11 @@
 				"PREVIEWS_SWIFT_INCLUDE__YES[sdk=watchos*]" = "-I bazel-out/CONFIGURATION-STABLE-8/bin/UI";
 				PREVIEW_FRAMEWORK_PATHS = (
 					"\"$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator/CryptoSwift.framework\"",
-					"\"$(BAZEL_OUT)/CONFIGURATION-STABLE-4/bin/Lib/LibFramework.watchOS.zip\"",
+					"\"$(BAZEL_OUT)/CONFIGURATION-STABLE-4/bin/Lib/LibFramework.watchOS.framework\"",
 				);
 				"PREVIEW_FRAMEWORK_PATHS[sdk=watchos*]" = (
 					"\"$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k/CryptoSwift.framework\"",
-					"\"$(BAZEL_OUT)/CONFIGURATION-STABLE-8/bin/Lib/LibFramework.watchOS.zip\"",
+					"\"$(BAZEL_OUT)/CONFIGURATION-STABLE-8/bin/Lib/LibFramework.watchOS.framework\"",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "rules-xcodeproj.UIFramework";
 				PRODUCT_MODULE_NAME = UI;
@@ -21308,8 +21308,8 @@
 				ARCHS = x86_64;
 				"ARCHS[sdk=iphoneos*]" = arm64;
 				BAZEL_LABEL = "@@//Lib/dist/dynamic:iOS";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-10/bin/Lib/dist/dynamic/iOS.zip";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-14/bin/Lib/dist/dynamic/iOS.zip";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-10/bin/Lib/dist/dynamic/Lib.framework";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-14/bin/Lib/dist/dynamic/Lib.framework";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = Lib.framework;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-10/bin/Lib/dist/dynamic";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-14/bin/Lib/dist/dynamic";
@@ -21355,7 +21355,7 @@
 					"\"bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Source/iOSApp.app.dSYM\"",
 					"\"bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/UITests/iOSAppUITestSuite.xctest.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/UITests/iOSAppUITestSuite.__internal__.__test_bundle.zip";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/UITests/iOSAppUITestSuite.xctest";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = iOSAppUITestSuite.xctest;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/UITests";
 				BAZEL_TARGET_ID = "@@//iOSApp/Test/UITests:iOSAppUITestSuite.__internal__.__test_bundle CONFIGURATION-STABLE-10";
@@ -21413,8 +21413,8 @@
 				ARCHS = x86_64;
 				"ARCHS[sdk=appletvos*]" = arm64;
 				BAZEL_LABEL = "@@//Lib/dist/dynamic:tvOS";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-12/bin/Lib/dist/dynamic/tvOS.zip";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=appletvos*]" = "bazel-out/CONFIGURATION-STABLE-16/bin/Lib/dist/dynamic/tvOS.zip";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-12/bin/Lib/dist/dynamic/Lib.framework";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=appletvos*]" = "bazel-out/CONFIGURATION-STABLE-16/bin/Lib/dist/dynamic/Lib.framework";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = Lib.framework;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-12/bin/Lib/dist/dynamic";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=appletvos*]" = "bazel-out/CONFIGURATION-STABLE-16/bin/Lib/dist/dynamic";
@@ -21447,8 +21447,8 @@
 				ARCHS = x86_64;
 				"ARCHS[sdk=iphoneos*]" = arm64;
 				BAZEL_LABEL = "@@//Lib/dist/dynamic:iOS";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-3/bin/Lib/dist/dynamic/iOS.zip";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-7/bin/Lib/dist/dynamic/iOS.zip";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-3/bin/Lib/dist/dynamic/Lib.framework";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-7/bin/Lib/dist/dynamic/Lib.framework";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = Lib.framework;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-3/bin/Lib/dist/dynamic";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-7/bin/Lib/dist/dynamic";
@@ -21525,8 +21525,8 @@
 				ARCHS = x86_64;
 				"ARCHS[sdk=watchos*]" = arm64_32;
 				BAZEL_LABEL = "@@//Lib/dist/dynamic:watchOS";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-11/bin/Lib/dist/dynamic/watchOS.zip";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=watchos*]" = "bazel-out/CONFIGURATION-STABLE-15/bin/Lib/dist/dynamic/watchOS.zip";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-11/bin/Lib/dist/dynamic/Lib.framework";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=watchos*]" = "bazel-out/CONFIGURATION-STABLE-15/bin/Lib/dist/dynamic/Lib.framework";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = Lib.framework;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-11/bin/Lib/dist/dynamic";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=watchos*]" = "bazel-out/CONFIGURATION-STABLE-15/bin/Lib/dist/dynamic";
@@ -21609,8 +21609,8 @@
 					"\"bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Source/iOSApp.app.dSYM\"",
 					"\"bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.xctest.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.__internal__.__test_bundle.zip";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.__internal__.__test_bundle.zip";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.xctest";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.xctest";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = iOSAppObjCUnitTests.xctest;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/ObjCUnitTests";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Test/ObjCUnitTests";
@@ -21721,8 +21721,8 @@
 					"\"bazel-out/CONFIGURATION-STABLE-8/bin/watchOSAppExtension/watchOSAppExtension.appex.dSYM\"",
 					"\"bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Source/iOSApp.app.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Source/iOSApp.ipa";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Source/iOSApp.ipa";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Source/iOSApp.app";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Source/iOSApp.app";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = iOSApp.app;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Source";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Source";
@@ -22043,8 +22043,8 @@
 					"\"bazel-out/CONFIGURATION-STABLE-15/bin/watchOSAppExtension/watchOSAppExtension.appex.dSYM\"",
 					"\"bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Source/iOSApp.app.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Source/iOSApp.ipa";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Source/iOSApp.ipa";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Source/iOSApp.app";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Source/iOSApp.app";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = iOSApp.app;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Source";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Source";
@@ -22103,8 +22103,8 @@
 					"\"bazel-out/CONFIGURATION-STABLE-9/bin/Lib/LibFramework.tvOS.framework.dSYM\"",
 					"\"bazel-out/CONFIGURATION-STABLE-9/bin/UI/UIFramework.tvOS.framework.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-5/bin/UI/UIFramework.tvOS.zip";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=appletvos*]" = "bazel-out/CONFIGURATION-STABLE-9/bin/UI/UIFramework.tvOS.zip";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-5/bin/UI/UIFramework.tvOS.framework";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=appletvos*]" = "bazel-out/CONFIGURATION-STABLE-9/bin/UI/UIFramework.tvOS.framework";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = UIFramework.tvOS.framework;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-5/bin/UI";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=appletvos*]" = "bazel-out/CONFIGURATION-STABLE-9/bin/UI";
@@ -22126,11 +22126,11 @@
 				"PREVIEWS_SWIFT_INCLUDE__YES[sdk=appletvos*]" = "-I bazel-out/CONFIGURATION-STABLE-9/bin/UI";
 				PREVIEW_FRAMEWORK_PATHS = (
 					"\"$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator/CryptoSwift.framework\"",
-					"\"$(BAZEL_OUT)/CONFIGURATION-STABLE-5/bin/Lib/LibFramework.tvOS.zip\"",
+					"\"$(BAZEL_OUT)/CONFIGURATION-STABLE-5/bin/Lib/LibFramework.tvOS.framework\"",
 				);
 				"PREVIEW_FRAMEWORK_PATHS[sdk=appletvos*]" = (
 					"\"$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64/CryptoSwift.framework\"",
-					"\"$(BAZEL_OUT)/CONFIGURATION-STABLE-9/bin/Lib/LibFramework.tvOS.zip\"",
+					"\"$(BAZEL_OUT)/CONFIGURATION-STABLE-9/bin/Lib/LibFramework.tvOS.framework\"",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "rules-xcodeproj.UIFramework";
 				PRODUCT_MODULE_NAME = UI;
@@ -22436,7 +22436,7 @@
 				"BAZEL_COMPILE_TARGET_IDS[sdk=macosx*]" = "$(BAZEL_COMPILE_TARGET_IDS)";
 				BAZEL_LABEL = "@@//Bundle:Bundle";
 				BAZEL_OUTPUTS_DSYM = "\"bazel-out/CONFIGURATION-STABLE-13/bin/Bundle/Bundle_dsyms/ABundle.aplugin.dSYM\"";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-13/bin/Bundle/Bundle.zip";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-13/bin/Bundle/ABundle.aplugin";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = ABundle.aplugin;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-13/bin/Bundle";
 				BAZEL_TARGET_ID = "@@//Bundle:Bundle CONFIGURATION-STABLE-13";
@@ -22466,7 +22466,7 @@
 				"BAZEL_COMPILE_TARGET_IDS[sdk=watchsimulator*]" = "$(BAZEL_COMPILE_TARGET_IDS)";
 				BAZEL_LABEL = "@@//watchOSAppExtension/Test/UnitTests:watchOSAppExtensionUnitTests";
 				BAZEL_OUTPUTS_DSYM = "\"bazel-out/CONFIGURATION-STABLE-4/bin/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTests.xctest.dSYM\"";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-4/bin/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTests.__internal__.__test_bundle.zip";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-4/bin/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTests.xctest";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = watchOSAppExtensionUnitTests.xctest;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-4/bin/watchOSAppExtension/Test/UnitTests";
 				BAZEL_TARGET_ID = "@@//watchOSAppExtension/Test/UnitTests:watchOSAppExtensionUnitTests.__internal__.__test_bundle CONFIGURATION-STABLE-4";
@@ -22501,8 +22501,8 @@
 				ARCHS = x86_64;
 				"ARCHS[sdk=appletvos*]" = arm64;
 				BAZEL_LABEL = "@@//Lib/dist/dynamic:tvOS";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-5/bin/Lib/dist/dynamic/tvOS.zip";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=appletvos*]" = "bazel-out/CONFIGURATION-STABLE-9/bin/Lib/dist/dynamic/tvOS.zip";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-5/bin/Lib/dist/dynamic/Lib.framework";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=appletvos*]" = "bazel-out/CONFIGURATION-STABLE-9/bin/Lib/dist/dynamic/Lib.framework";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = Lib.framework;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-5/bin/Lib/dist/dynamic";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=appletvos*]" = "bazel-out/CONFIGURATION-STABLE-9/bin/Lib/dist/dynamic";
@@ -22617,8 +22617,8 @@
 					"\"bazel-out/CONFIGURATION-STABLE-8/bin/UI/UIFramework.watchOS.framework.dSYM\"",
 					"\"bazel-out/CONFIGURATION-STABLE-8/bin/watchOSAppExtension/watchOSAppExtension.appex.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-4/bin/watchOSAppExtension/watchOSAppExtension.zip";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=watchos*]" = "bazel-out/CONFIGURATION-STABLE-8/bin/watchOSAppExtension/watchOSAppExtension.zip";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-4/bin/watchOSAppExtension/watchOSAppExtension.appex";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=watchos*]" = "bazel-out/CONFIGURATION-STABLE-8/bin/watchOSAppExtension/watchOSAppExtension.appex";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = watchOSAppExtension.appex;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-4/bin/watchOSAppExtension";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=watchos*]" = "bazel-out/CONFIGURATION-STABLE-8/bin/watchOSAppExtension";
@@ -22677,7 +22677,7 @@
 					"\"bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Source/iOSApp.app.dSYM\"",
 					"\"bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTestSuite.xctest.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTestSuite.__internal__.__test_bundle.zip";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTestSuite.xctest";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = iOSAppObjCUnitTestSuite.xctest;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/ObjCUnitTests";
 				BAZEL_TARGET_ID = "@@//iOSApp/Test/ObjCUnitTests:iOSAppObjCUnitTestSuite.__internal__.__test_bundle CONFIGURATION-STABLE-3";
@@ -22718,7 +22718,7 @@
 					"\"bazel-out/CONFIGURATION-STABLE-5/bin/tvOSApp/Source/tvOSApp.app.dSYM\"",
 					"\"bazel-out/CONFIGURATION-STABLE-5/bin/tvOSApp/Test/UnitTests/tvOSAppUnitTests.xctest.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-5/bin/tvOSApp/Test/UnitTests/tvOSAppUnitTests.__internal__.__test_bundle.zip";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-5/bin/tvOSApp/Test/UnitTests/tvOSAppUnitTests.xctest";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = tvOSAppUnitTests.xctest;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-5/bin/tvOSApp/Test/UnitTests";
 				BAZEL_TARGET_ID = "@@//tvOSApp/Test/UnitTests:tvOSAppUnitTests.__internal__.__test_bundle CONFIGURATION-STABLE-5";
@@ -22754,7 +22754,7 @@
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				ARCHS = x86_64;
 				BAZEL_LABEL = "@@//macOSApp/Source:macOSLib.framework";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-13/bin/macOSApp/Source/macOSLib.framework.zip";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-13/bin/macOSApp/Source/Lib.framework";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = Lib.framework;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-13/bin/macOSApp/Source";
 				BAZEL_TARGET_ID = "@@//macOSApp/Source:macOSLib.framework CONFIGURATION-STABLE-13";
@@ -22928,8 +22928,8 @@
 					"\"bazel-out/CONFIGURATION-STABLE-16/bin/UI/UIFramework.tvOS.framework.dSYM\"",
 					"\"bazel-out/CONFIGURATION-STABLE-16/bin/tvOSApp/Source/tvOSApp.app.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-12/bin/tvOSApp/Source/tvOSApp.ipa";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=appletvos*]" = "bazel-out/CONFIGURATION-STABLE-16/bin/tvOSApp/Source/tvOSApp.ipa";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-12/bin/tvOSApp/Source/tvOSApp.app";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=appletvos*]" = "bazel-out/CONFIGURATION-STABLE-16/bin/tvOSApp/Source/tvOSApp.app";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = tvOSApp.app;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-12/bin/tvOSApp/Source";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=appletvos*]" = "bazel-out/CONFIGURATION-STABLE-16/bin/tvOSApp/Source";
@@ -23142,7 +23142,7 @@
 					"\"bazel-out/CONFIGURATION-STABLE-11/bin/watchOSAppExtension/watchOSAppExtension.appex.dSYM\"",
 					"\"bazel-out/CONFIGURATION-STABLE-11/bin/watchOSApp/Test/UITests/watchOSAppUITests.xctest.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-11/bin/watchOSApp/Test/UITests/watchOSAppUITests.__internal__.__test_bundle.zip";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-11/bin/watchOSApp/Test/UITests/watchOSAppUITests.xctest";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = watchOSAppUITests.xctest;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-11/bin/watchOSApp/Test/UITests";
 				BAZEL_TARGET_ID = "@@//watchOSApp/Test/UITests:watchOSAppUITests.__internal__.__test_bundle CONFIGURATION-STABLE-11";
@@ -23203,8 +23203,8 @@
 					"\"bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Source/iOSApp.app.dSYM\"",
 					"\"bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.xctest.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.__internal__.__test_bundle.zip";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.__internal__.__test_bundle.zip";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.xctest";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.xctest";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = iOSAppSwiftUnitTests.xctest;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/SwiftUnitTests";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Test/SwiftUnitTests";
@@ -23253,7 +23253,7 @@
 				"BAZEL_COMPILE_TARGET_IDS[sdk=watchsimulator*]" = "$(BAZEL_COMPILE_TARGET_IDS)";
 				BAZEL_LABEL = "@@//watchOSAppExtension/Test/UnitTests:watchOSAppExtensionUnitTests";
 				BAZEL_OUTPUTS_DSYM = "\"bazel-out/CONFIGURATION-STABLE-11/bin/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTests.xctest.dSYM\"";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-11/bin/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTests.__internal__.__test_bundle.zip";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-11/bin/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTests.xctest";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = watchOSAppExtensionUnitTests.xctest;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-11/bin/watchOSAppExtension/Test/UnitTests";
 				BAZEL_TARGET_ID = "@@//watchOSAppExtension/Test/UnitTests:watchOSAppExtensionUnitTests.__internal__.__test_bundle CONFIGURATION-STABLE-11";
@@ -23361,8 +23361,8 @@
 				BAZEL_LABEL = "@@//Lib:LibFramework.tvOS";
 				BAZEL_OUTPUTS_DSYM = "\"bazel-out/CONFIGURATION-STABLE-5/bin/Lib/LibFramework.tvOS.framework.dSYM\"";
 				"BAZEL_OUTPUTS_DSYM[sdk=appletvos*]" = "\"bazel-out/CONFIGURATION-STABLE-9/bin/Lib/LibFramework.tvOS.framework.dSYM\"";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-5/bin/Lib/LibFramework.tvOS.zip";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=appletvos*]" = "bazel-out/CONFIGURATION-STABLE-9/bin/Lib/LibFramework.tvOS.zip";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-5/bin/Lib/LibFramework.tvOS.framework";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=appletvos*]" = "bazel-out/CONFIGURATION-STABLE-9/bin/Lib/LibFramework.tvOS.framework";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = LibFramework.tvOS.framework;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-5/bin/Lib";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=appletvos*]" = "bazel-out/CONFIGURATION-STABLE-9/bin/Lib";
@@ -23418,8 +23418,8 @@
 				BAZEL_LABEL = "@@//Lib:LibFramework.tvOS";
 				BAZEL_OUTPUTS_DSYM = "\"bazel-out/CONFIGURATION-STABLE-12/bin/Lib/LibFramework.tvOS.framework.dSYM\"";
 				"BAZEL_OUTPUTS_DSYM[sdk=appletvos*]" = "\"bazel-out/CONFIGURATION-STABLE-16/bin/Lib/LibFramework.tvOS.framework.dSYM\"";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-12/bin/Lib/LibFramework.tvOS.zip";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=appletvos*]" = "bazel-out/CONFIGURATION-STABLE-16/bin/Lib/LibFramework.tvOS.zip";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-12/bin/Lib/LibFramework.tvOS.framework";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=appletvos*]" = "bazel-out/CONFIGURATION-STABLE-16/bin/Lib/LibFramework.tvOS.framework";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = LibFramework.tvOS.framework;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-12/bin/Lib";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=appletvos*]" = "bazel-out/CONFIGURATION-STABLE-16/bin/Lib";
@@ -23500,7 +23500,7 @@
 					"\"bazel-out/CONFIGURATION-STABLE-13/bin/macOSApp/Source/macOSLib.framework_dsyms/Lib.framework.dSYM\"",
 					"\"bazel-out/CONFIGURATION-STABLE-13/bin/macOSApp/Source/macOSApp.app.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-13/bin/macOSApp/Source/macOSApp.zip";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-13/bin/macOSApp/Source/macOSApp.app";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = macOSApp.app;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-13/bin/macOSApp/Source";
 				BAZEL_TARGET_ID = "@@//macOSApp/Source:macOSApp CONFIGURATION-STABLE-13";
@@ -23585,7 +23585,7 @@
 					"\"bazel-out/CONFIGURATION-STABLE-12/bin/tvOSApp/Source/tvOSApp.app.dSYM\"",
 					"\"bazel-out/CONFIGURATION-STABLE-12/bin/tvOSApp/Test/UITests/tvOSAppUITests.xctest.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-12/bin/tvOSApp/Test/UITests/tvOSAppUITests.__internal__.__test_bundle.zip";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-12/bin/tvOSApp/Test/UITests/tvOSAppUITests.xctest";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = tvOSAppUITests.xctest;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-12/bin/tvOSApp/Test/UITests";
 				BAZEL_TARGET_ID = "@@//tvOSApp/Test/UITests:tvOSAppUITests.__internal__.__test_bundle CONFIGURATION-STABLE-12";
@@ -23730,7 +23730,7 @@
 				"BAZEL_COMPILE_TARGET_IDS[sdk=iphonesimulator*]" = "$(BAZEL_COMPILE_TARGET_IDS)";
 				BAZEL_LABEL = "@@//iMessageApp:iMessageAppExtension";
 				BAZEL_OUTPUTS_DSYM = "\"bazel-out/CONFIGURATION-STABLE-10/bin/iMessageApp/iMessageAppExtension.appex.dSYM\"";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-10/bin/iMessageApp/iMessageAppExtension.zip";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-10/bin/iMessageApp/iMessageAppExtension.appex";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = iMessageAppExtension.appex;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-10/bin/iMessageApp";
 				BAZEL_TARGET_ID = "@@//iMessageApp:iMessageAppExtension CONFIGURATION-STABLE-10";
@@ -23779,8 +23779,8 @@
 					"\"bazel-out/CONFIGURATION-STABLE-9/bin/UI/UIFramework.tvOS.framework.dSYM\"",
 					"\"bazel-out/CONFIGURATION-STABLE-9/bin/tvOSApp/Source/tvOSApp.app.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-5/bin/tvOSApp/Source/tvOSApp.ipa";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=appletvos*]" = "bazel-out/CONFIGURATION-STABLE-9/bin/tvOSApp/Source/tvOSApp.ipa";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-5/bin/tvOSApp/Source/tvOSApp.app";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=appletvos*]" = "bazel-out/CONFIGURATION-STABLE-9/bin/tvOSApp/Source/tvOSApp.app";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = tvOSApp.app;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-5/bin/tvOSApp/Source";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=appletvos*]" = "bazel-out/CONFIGURATION-STABLE-9/bin/tvOSApp/Source";
@@ -23835,8 +23835,8 @@
 					"\"bazel-out/CONFIGURATION-STABLE-7/bin/Lib/LibFramework.iOS.framework.dSYM\"",
 					"\"bazel-out/CONFIGURATION-STABLE-7/bin/UI/UIFramework.iOS.framework.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-3/bin/UI/UIFramework.iOS.zip";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-7/bin/UI/UIFramework.iOS.zip";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-3/bin/UI/UIFramework.iOS.framework";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-7/bin/UI/UIFramework.iOS.framework";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = UIFramework.iOS.framework;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-3/bin/UI";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-7/bin/UI";
@@ -23859,11 +23859,11 @@
 				"PREVIEWS_SWIFT_INCLUDE__YES[sdk=iphoneos*]" = "-I bazel-out/CONFIGURATION-STABLE-7/bin/UI";
 				PREVIEW_FRAMEWORK_PATHS = (
 					"\"$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework\"",
-					"\"$(BAZEL_OUT)/CONFIGURATION-STABLE-3/bin/Lib/LibFramework.iOS.zip\"",
+					"\"$(BAZEL_OUT)/CONFIGURATION-STABLE-3/bin/Lib/LibFramework.iOS.framework\"",
 				);
 				"PREVIEW_FRAMEWORK_PATHS[sdk=iphoneos*]" = (
 					"\"$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework\"",
-					"\"$(BAZEL_OUT)/CONFIGURATION-STABLE-7/bin/Lib/LibFramework.iOS.zip\"",
+					"\"$(BAZEL_OUT)/CONFIGURATION-STABLE-7/bin/Lib/LibFramework.iOS.framework\"",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "rules-xcodeproj.UIFramework";
 				PRODUCT_MODULE_NAME = UI;
@@ -23918,8 +23918,8 @@
 				BAZEL_LABEL = "@@//WidgetExtension:WidgetExtension";
 				BAZEL_OUTPUTS_DSYM = "\"bazel-out/CONFIGURATION-STABLE-10/bin/WidgetExtension/WidgetExtension.appex.dSYM\"";
 				"BAZEL_OUTPUTS_DSYM[sdk=iphoneos*]" = "\"bazel-out/CONFIGURATION-STABLE-14/bin/WidgetExtension/WidgetExtension.appex.dSYM\"";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-10/bin/WidgetExtension/WidgetExtension.zip";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-14/bin/WidgetExtension/WidgetExtension.zip";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-10/bin/WidgetExtension/WidgetExtension.appex";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-14/bin/WidgetExtension/WidgetExtension.appex";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = WidgetExtension.appex;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-10/bin/WidgetExtension";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-14/bin/WidgetExtension";
@@ -24027,8 +24027,8 @@
 					"\"bazel-out/CONFIGURATION-STABLE-15/bin/UI/UIFramework.watchOS.framework.dSYM\"",
 					"\"bazel-out/CONFIGURATION-STABLE-15/bin/watchOSAppExtension/watchOSAppExtension.appex.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-11/bin/watchOSAppExtension/watchOSAppExtension.zip";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=watchos*]" = "bazel-out/CONFIGURATION-STABLE-15/bin/watchOSAppExtension/watchOSAppExtension.zip";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-11/bin/watchOSAppExtension/watchOSAppExtension.appex";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=watchos*]" = "bazel-out/CONFIGURATION-STABLE-15/bin/watchOSAppExtension/watchOSAppExtension.appex";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = watchOSAppExtension.appex;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-11/bin/watchOSAppExtension";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=watchos*]" = "bazel-out/CONFIGURATION-STABLE-15/bin/watchOSAppExtension";
@@ -24121,8 +24121,8 @@
 					"\"bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Source/iOSApp.app.dSYM\"",
 					"\"bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.xctest.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.__internal__.__test_bundle.zip";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.__internal__.__test_bundle.zip";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.xctest";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.xctest";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = iOSAppSwiftUnitTests.xctest;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/SwiftUnitTests";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Test/SwiftUnitTests";
@@ -24169,8 +24169,8 @@
 				"ARCHS[sdk=watchos*]" = arm64_32;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				BAZEL_LABEL = "@@//watchOSApp:watchOSApp";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-19/bin/watchOSApp/watchOSApp.zip";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=watchos*]" = "bazel-out/CONFIGURATION-STABLE-20/bin/watchOSApp/watchOSApp.zip";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-19/bin/watchOSApp/watchOSApp.app";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=watchos*]" = "bazel-out/CONFIGURATION-STABLE-20/bin/watchOSApp/watchOSApp.app";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = watchOSApp.app;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-19/bin/watchOSApp";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=watchos*]" = "bazel-out/CONFIGURATION-STABLE-20/bin/watchOSApp";
@@ -24275,7 +24275,7 @@
 				ARCHS = x86_64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				BAZEL_LABEL = "@@//iMessageApp:iMessageApp";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-10/bin/iMessageApp/iMessageApp.ipa";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-10/bin/iMessageApp/iMessageApp.app";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = iMessageApp.app;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-10/bin/iMessageApp";
 				BAZEL_TARGET_ID = "@@//iMessageApp:iMessageApp CONFIGURATION-STABLE-10";
@@ -24308,8 +24308,8 @@
 				BAZEL_LABEL = "@@//AppClip:AppClip";
 				BAZEL_OUTPUTS_DSYM = "\"bazel-out/CONFIGURATION-STABLE-10/bin/AppClip/AppClip.app.dSYM\"";
 				"BAZEL_OUTPUTS_DSYM[sdk=iphoneos*]" = "\"bazel-out/CONFIGURATION-STABLE-14/bin/AppClip/AppClip.app.dSYM\"";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-10/bin/AppClip/AppClip.ipa";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-14/bin/AppClip/AppClip.ipa";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-10/bin/AppClip/AppClip.app";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-14/bin/AppClip/AppClip.app";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = AppClip.app;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-10/bin/AppClip";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-14/bin/AppClip";
@@ -24455,8 +24455,8 @@
 					"\"bazel-out/CONFIGURATION-STABLE-14/bin/Lib/LibFramework.iOS.framework.dSYM\"",
 					"\"bazel-out/CONFIGURATION-STABLE-14/bin/UI/UIFramework.iOS.framework.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-10/bin/UI/UIFramework.iOS.zip";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-14/bin/UI/UIFramework.iOS.zip";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-10/bin/UI/UIFramework.iOS.framework";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-14/bin/UI/UIFramework.iOS.framework";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = UIFramework.iOS.framework;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-10/bin/UI";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-14/bin/UI";
@@ -24479,11 +24479,11 @@
 				"PREVIEWS_SWIFT_INCLUDE__YES[sdk=iphoneos*]" = "-I bazel-out/CONFIGURATION-STABLE-14/bin/UI";
 				PREVIEW_FRAMEWORK_PATHS = (
 					"\"$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework\"",
-					"\"$(BAZEL_OUT)/CONFIGURATION-STABLE-10/bin/Lib/LibFramework.iOS.zip\"",
+					"\"$(BAZEL_OUT)/CONFIGURATION-STABLE-10/bin/Lib/LibFramework.iOS.framework\"",
 				);
 				"PREVIEW_FRAMEWORK_PATHS[sdk=iphoneos*]" = (
 					"\"$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework\"",
-					"\"$(BAZEL_OUT)/CONFIGURATION-STABLE-14/bin/Lib/LibFramework.iOS.zip\"",
+					"\"$(BAZEL_OUT)/CONFIGURATION-STABLE-14/bin/Lib/LibFramework.iOS.framework\"",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "rules-xcodeproj.UIFramework";
 				PRODUCT_MODULE_NAME = UI;
@@ -24556,8 +24556,8 @@
 				ARCHS = x86_64;
 				"ARCHS[sdk=watchos*]" = arm64_32;
 				BAZEL_LABEL = "@@//Lib/dist/dynamic:watchOS";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-4/bin/Lib/dist/dynamic/watchOS.zip";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=watchos*]" = "bazel-out/CONFIGURATION-STABLE-8/bin/Lib/dist/dynamic/watchOS.zip";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-4/bin/Lib/dist/dynamic/Lib.framework";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=watchos*]" = "bazel-out/CONFIGURATION-STABLE-8/bin/Lib/dist/dynamic/Lib.framework";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = Lib.framework;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-4/bin/Lib/dist/dynamic";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=watchos*]" = "bazel-out/CONFIGURATION-STABLE-8/bin/Lib/dist/dynamic";
@@ -24619,8 +24619,8 @@
 					"\"bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Source/iOSApp.app.dSYM\"",
 					"\"bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.xctest.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.__internal__.__test_bundle.zip";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.__internal__.__test_bundle.zip";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.xctest";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.xctest";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = iOSAppObjCUnitTests.xctest;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/ObjCUnitTests";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Test/ObjCUnitTests";
@@ -24739,8 +24739,8 @@
 				BAZEL_LABEL = "@@//AppClip:AppClip";
 				BAZEL_OUTPUTS_DSYM = "\"bazel-out/CONFIGURATION-STABLE-3/bin/AppClip/AppClip.app.dSYM\"";
 				"BAZEL_OUTPUTS_DSYM[sdk=iphoneos*]" = "\"bazel-out/CONFIGURATION-STABLE-7/bin/AppClip/AppClip.app.dSYM\"";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-3/bin/AppClip/AppClip.ipa";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-7/bin/AppClip/AppClip.ipa";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-3/bin/AppClip/AppClip.app";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-7/bin/AppClip/AppClip.app";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = AppClip.app;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-3/bin/AppClip";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-7/bin/AppClip";
@@ -24843,8 +24843,8 @@
 				BAZEL_LABEL = "@@//Lib:LibFramework.watchOS";
 				BAZEL_OUTPUTS_DSYM = "\"bazel-out/CONFIGURATION-STABLE-11/bin/Lib/LibFramework.watchOS.framework.dSYM\"";
 				"BAZEL_OUTPUTS_DSYM[sdk=watchos*]" = "\"bazel-out/CONFIGURATION-STABLE-15/bin/Lib/LibFramework.watchOS.framework.dSYM\"";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-11/bin/Lib/LibFramework.watchOS.zip";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=watchos*]" = "bazel-out/CONFIGURATION-STABLE-15/bin/Lib/LibFramework.watchOS.zip";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-11/bin/Lib/LibFramework.watchOS.framework";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=watchos*]" = "bazel-out/CONFIGURATION-STABLE-15/bin/Lib/LibFramework.watchOS.framework";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = LibFramework.watchOS.framework;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-11/bin/Lib";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=watchos*]" = "bazel-out/CONFIGURATION-STABLE-15/bin/Lib";
@@ -24946,7 +24946,7 @@
 					"\"bazel-out/CONFIGURATION-STABLE-13/bin/macOSApp/Source/macOSApp.app.dSYM\"",
 					"\"bazel-out/CONFIGURATION-STABLE-13/bin/macOSApp/Test/UITests/macOSAppUITests.xctest.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-13/bin/macOSApp/Test/UITests/macOSAppUITests.__internal__.__test_bundle.zip";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-13/bin/macOSApp/Test/UITests/macOSAppUITests.xctest";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = macOSAppUITests.xctest;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-13/bin/macOSApp/Test/UITests";
 				BAZEL_TARGET_ID = "@@//macOSApp/Test/UITests:macOSAppUITests.__internal__.__test_bundle CONFIGURATION-STABLE-13";
@@ -25014,7 +25014,7 @@
 					"\"bazel-out/CONFIGURATION-STABLE-12/bin/tvOSApp/Source/tvOSApp.app.dSYM\"",
 					"\"bazel-out/CONFIGURATION-STABLE-12/bin/tvOSApp/Test/UnitTests/tvOSAppUnitTests.xctest.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-12/bin/tvOSApp/Test/UnitTests/tvOSAppUnitTests.__internal__.__test_bundle.zip";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-12/bin/tvOSApp/Test/UnitTests/tvOSAppUnitTests.xctest";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = tvOSAppUnitTests.xctest;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-12/bin/tvOSApp/Test/UnitTests";
 				BAZEL_TARGET_ID = "@@//tvOSApp/Test/UnitTests:tvOSAppUnitTests.__internal__.__test_bundle CONFIGURATION-STABLE-12";
@@ -25162,7 +25162,7 @@
 				"BAZEL_COMPILE_TARGET_IDS[sdk=macosx*]" = "$(BAZEL_COMPILE_TARGET_IDS)";
 				BAZEL_LABEL = "@@//Bundle:Bundle";
 				BAZEL_OUTPUTS_DSYM = "\"bazel-out/CONFIGURATION-STABLE-6/bin/Bundle/Bundle_dsyms/ABundle.aplugin.dSYM\"";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-6/bin/Bundle/Bundle.zip";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-6/bin/Bundle/ABundle.aplugin";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = ABundle.aplugin;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-6/bin/Bundle";
 				BAZEL_TARGET_ID = "@@//Bundle:Bundle CONFIGURATION-STABLE-6";
@@ -25190,7 +25190,7 @@
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				ARCHS = x86_64;
 				BAZEL_LABEL = "@@//macOSApp/Source:macOSLib.framework";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-6/bin/macOSApp/Source/macOSLib.framework.zip";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-6/bin/macOSApp/Source/Lib.framework";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = Lib.framework;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-6/bin/macOSApp/Source";
 				BAZEL_TARGET_ID = "@@//macOSApp/Source:macOSLib.framework CONFIGURATION-STABLE-6";
@@ -25219,8 +25219,8 @@
 				BAZEL_LABEL = "@@//Lib:LibFramework.watchOS";
 				BAZEL_OUTPUTS_DSYM = "\"bazel-out/CONFIGURATION-STABLE-4/bin/Lib/LibFramework.watchOS.framework.dSYM\"";
 				"BAZEL_OUTPUTS_DSYM[sdk=watchos*]" = "\"bazel-out/CONFIGURATION-STABLE-8/bin/Lib/LibFramework.watchOS.framework.dSYM\"";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-4/bin/Lib/LibFramework.watchOS.zip";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=watchos*]" = "bazel-out/CONFIGURATION-STABLE-8/bin/Lib/LibFramework.watchOS.zip";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-4/bin/Lib/LibFramework.watchOS.framework";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=watchos*]" = "bazel-out/CONFIGURATION-STABLE-8/bin/Lib/LibFramework.watchOS.framework";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = LibFramework.watchOS.framework;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-4/bin/Lib";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=watchos*]" = "bazel-out/CONFIGURATION-STABLE-8/bin/Lib";
@@ -25396,7 +25396,7 @@
 					"\"bazel-out/CONFIGURATION-STABLE-6/bin/macOSApp/Source/macOSApp.app.dSYM\"",
 					"\"bazel-out/CONFIGURATION-STABLE-6/bin/macOSApp/Test/UITests/macOSAppUITests.xctest.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-6/bin/macOSApp/Test/UITests/macOSAppUITests.__internal__.__test_bundle.zip";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-6/bin/macOSApp/Test/UITests/macOSAppUITests.xctest";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = macOSAppUITests.xctest;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-6/bin/macOSApp/Test/UITests";
 				BAZEL_TARGET_ID = "@@//macOSApp/Test/UITests:macOSAppUITests.__internal__.__test_bundle CONFIGURATION-STABLE-6";
@@ -25458,8 +25458,8 @@
 				BAZEL_LABEL = "@@//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC";
 				BAZEL_OUTPUTS_DSYM = "\"bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Source/CoreUtilsObjC/FrameworkCoreUtilsObjC_dsyms/CoreUtilsObjC.framework.dSYM\"";
 				"BAZEL_OUTPUTS_DSYM[sdk=iphoneos*]" = "\"bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Source/CoreUtilsObjC/FrameworkCoreUtilsObjC_dsyms/CoreUtilsObjC.framework.dSYM\"";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Source/CoreUtilsObjC/FrameworkCoreUtilsObjC.zip";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Source/CoreUtilsObjC/FrameworkCoreUtilsObjC.zip";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Source/CoreUtilsObjC/CoreUtilsObjC.framework";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Source/CoreUtilsObjC/CoreUtilsObjC.framework";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = CoreUtilsObjC.framework;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Source/CoreUtilsObjC";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Source/CoreUtilsObjC";
@@ -25499,7 +25499,7 @@
 				"BAZEL_COMPILE_TARGET_IDS[sdk=iphonesimulator*]" = "$(BAZEL_COMPILE_TARGET_IDS)";
 				BAZEL_LABEL = "@@//iMessageApp:iMessageAppExtension";
 				BAZEL_OUTPUTS_DSYM = "\"bazel-out/CONFIGURATION-STABLE-3/bin/iMessageApp/iMessageAppExtension.appex.dSYM\"";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-3/bin/iMessageApp/iMessageAppExtension.zip";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-3/bin/iMessageApp/iMessageAppExtension.appex";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = iMessageAppExtension.appex;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-3/bin/iMessageApp";
 				BAZEL_TARGET_ID = "@@//iMessageApp:iMessageAppExtension CONFIGURATION-STABLE-3";
@@ -25716,7 +25716,7 @@
 					"\"bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Source/iOSApp.app.dSYM\"",
 					"\"bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/UITests/iOSAppUITestSuite.xctest.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/UITests/iOSAppUITestSuite.__internal__.__test_bundle.zip";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/UITests/iOSAppUITestSuite.xctest";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = iOSAppUITestSuite.xctest;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/UITests";
 				BAZEL_TARGET_ID = "@@//iOSApp/Test/UITests:iOSAppUITestSuite.__internal__.__test_bundle CONFIGURATION-STABLE-3";
@@ -25865,8 +25865,8 @@
 					"\"bazel-out/CONFIGURATION-STABLE-15/bin/Lib/LibFramework.watchOS.framework.dSYM\"",
 					"\"bazel-out/CONFIGURATION-STABLE-15/bin/UI/UIFramework.watchOS.framework.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-11/bin/UI/UIFramework.watchOS.zip";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=watchos*]" = "bazel-out/CONFIGURATION-STABLE-15/bin/UI/UIFramework.watchOS.zip";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-11/bin/UI/UIFramework.watchOS.framework";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=watchos*]" = "bazel-out/CONFIGURATION-STABLE-15/bin/UI/UIFramework.watchOS.framework";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = UIFramework.watchOS.framework;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-11/bin/UI";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=watchos*]" = "bazel-out/CONFIGURATION-STABLE-15/bin/UI";
@@ -25888,11 +25888,11 @@
 				"PREVIEWS_SWIFT_INCLUDE__YES[sdk=watchos*]" = "-I bazel-out/CONFIGURATION-STABLE-15/bin/UI";
 				PREVIEW_FRAMEWORK_PATHS = (
 					"\"$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator/CryptoSwift.framework\"",
-					"\"$(BAZEL_OUT)/CONFIGURATION-STABLE-11/bin/Lib/LibFramework.watchOS.zip\"",
+					"\"$(BAZEL_OUT)/CONFIGURATION-STABLE-11/bin/Lib/LibFramework.watchOS.framework\"",
 				);
 				"PREVIEW_FRAMEWORK_PATHS[sdk=watchos*]" = (
 					"\"$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k/CryptoSwift.framework\"",
-					"\"$(BAZEL_OUT)/CONFIGURATION-STABLE-15/bin/Lib/LibFramework.watchOS.zip\"",
+					"\"$(BAZEL_OUT)/CONFIGURATION-STABLE-15/bin/Lib/LibFramework.watchOS.framework\"",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "rules-xcodeproj.UIFramework";
 				PRODUCT_MODULE_NAME = UI;
@@ -25935,7 +25935,7 @@
 				ARCHS = x86_64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				BAZEL_LABEL = "@@//iMessageApp:iMessageApp";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-3/bin/iMessageApp/iMessageApp.ipa";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-3/bin/iMessageApp/iMessageApp.app";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = iMessageApp.app;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-3/bin/iMessageApp";
 				BAZEL_TARGET_ID = "@@//iMessageApp:iMessageApp CONFIGURATION-STABLE-3";
@@ -25964,7 +25964,7 @@
 				"BAZEL_COMPILE_TARGET_IDS[sdk=macosx*]" = "$(BAZEL_COMPILE_TARGET_IDS)";
 				BAZEL_LABEL = "@@//CommandLine/Tests:CommandLineToolTests";
 				BAZEL_OUTPUTS_DSYM = "\"bazel-out/CONFIGURATION-STABLE-26/bin/CommandLine/Tests/CommandLineToolTests.xctest.dSYM\"";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-26/bin/CommandLine/Tests/CommandLineToolTests.__internal__.__test_bundle.zip";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-26/bin/CommandLine/Tests/CommandLineToolTests.xctest";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = CommandLineToolTests.xctest;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-26/bin/CommandLine/Tests";
 				BAZEL_TARGET_ID = "@@//CommandLine/Tests:CommandLineToolTests.__internal__.__test_bundle CONFIGURATION-STABLE-26";
@@ -26184,8 +26184,8 @@
 					"\"bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Source/iOSApp.app.dSYM\"",
 					"\"bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Test/UITests/iOSAppUITests.xctest.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/UITests/iOSAppUITests.__internal__.__test_bundle.zip";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Test/UITests/iOSAppUITests.__internal__.__test_bundle.zip";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/UITests/iOSAppUITests.xctest";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Test/UITests/iOSAppUITests.xctest";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = iOSAppUITests.xctest;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/UITests";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Test/UITests";
@@ -26234,8 +26234,8 @@
 				BAZEL_LABEL = "@@//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC";
 				BAZEL_OUTPUTS_DSYM = "\"bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Source/CoreUtilsObjC/FrameworkCoreUtilsObjC_dsyms/CoreUtilsObjC.framework.dSYM\"";
 				"BAZEL_OUTPUTS_DSYM[sdk=iphoneos*]" = "\"bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Source/CoreUtilsObjC/FrameworkCoreUtilsObjC_dsyms/CoreUtilsObjC.framework.dSYM\"";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Source/CoreUtilsObjC/FrameworkCoreUtilsObjC.zip";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Source/CoreUtilsObjC/FrameworkCoreUtilsObjC.zip";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Source/CoreUtilsObjC/CoreUtilsObjC.framework";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Source/CoreUtilsObjC/CoreUtilsObjC.framework";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = CoreUtilsObjC.framework;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Source/CoreUtilsObjC";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Source/CoreUtilsObjC";
@@ -26384,7 +26384,7 @@
 					"\"bazel-out/CONFIGURATION-STABLE-4/bin/watchOSAppExtension/watchOSAppExtension.appex.dSYM\"",
 					"\"bazel-out/CONFIGURATION-STABLE-4/bin/watchOSApp/Test/UITests/watchOSAppUITests.xctest.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-4/bin/watchOSApp/Test/UITests/watchOSAppUITests.__internal__.__test_bundle.zip";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-4/bin/watchOSApp/Test/UITests/watchOSAppUITests.xctest";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = watchOSAppUITests.xctest;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-4/bin/watchOSApp/Test/UITests";
 				BAZEL_TARGET_ID = "@@//watchOSApp/Test/UITests:watchOSAppUITests.__internal__.__test_bundle CONFIGURATION-STABLE-4";
@@ -26466,8 +26466,8 @@
 					"\"bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Source/iOSApp.app.dSYM\"",
 					"\"bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Test/UITests/iOSAppUITests.xctest.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/UITests/iOSAppUITests.__internal__.__test_bundle.zip";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Test/UITests/iOSAppUITests.__internal__.__test_bundle.zip";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/UITests/iOSAppUITests.xctest";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Test/UITests/iOSAppUITests.xctest";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = iOSAppUITests.xctest;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/UITests";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Test/UITests";
@@ -26520,7 +26520,7 @@
 					"\"bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Source/iOSApp.app.dSYM\"",
 					"\"bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTestSuite.xctest.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTestSuite.__internal__.__test_bundle.zip";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTestSuite.xctest";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = iOSAppSwiftUnitTestSuite.xctest;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/SwiftUnitTests";
 				BAZEL_TARGET_ID = "@@//iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTestSuite.__internal__.__test_bundle CONFIGURATION-STABLE-3";
@@ -26682,7 +26682,7 @@
 					"\"bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Source/iOSApp.app.dSYM\"",
 					"\"bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTestSuite.xctest.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTestSuite.__internal__.__test_bundle.zip";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTestSuite.xctest";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = iOSAppSwiftUnitTestSuite.xctest;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/SwiftUnitTests";
 				BAZEL_TARGET_ID = "@@//iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTestSuite.__internal__.__test_bundle CONFIGURATION-STABLE-10";
@@ -26746,8 +26746,8 @@
 				BAZEL_LABEL = "@@//WidgetExtension:WidgetExtension";
 				BAZEL_OUTPUTS_DSYM = "\"bazel-out/CONFIGURATION-STABLE-3/bin/WidgetExtension/WidgetExtension.appex.dSYM\"";
 				"BAZEL_OUTPUTS_DSYM[sdk=iphoneos*]" = "\"bazel-out/CONFIGURATION-STABLE-7/bin/WidgetExtension/WidgetExtension.appex.dSYM\"";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-3/bin/WidgetExtension/WidgetExtension.zip";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-7/bin/WidgetExtension/WidgetExtension.zip";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-3/bin/WidgetExtension/WidgetExtension.appex";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-7/bin/WidgetExtension/WidgetExtension.appex";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = WidgetExtension.appex;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-3/bin/WidgetExtension";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/CONFIGURATION-STABLE-7/bin/WidgetExtension";
@@ -26875,7 +26875,7 @@
 					"\"bazel-out/CONFIGURATION-STABLE-5/bin/tvOSApp/Source/tvOSApp.app.dSYM\"",
 					"\"bazel-out/CONFIGURATION-STABLE-5/bin/tvOSApp/Test/UITests/tvOSAppUITests.xctest.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-5/bin/tvOSApp/Test/UITests/tvOSAppUITests.__internal__.__test_bundle.zip";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-5/bin/tvOSApp/Test/UITests/tvOSAppUITests.xctest";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = tvOSAppUITests.xctest;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-5/bin/tvOSApp/Test/UITests";
 				BAZEL_TARGET_ID = "@@//tvOSApp/Test/UITests:tvOSAppUITests.__internal__.__test_bundle CONFIGURATION-STABLE-5";
@@ -26954,7 +26954,7 @@
 				"BAZEL_COMPILE_TARGET_IDS[sdk=macosx*]" = "$(BAZEL_COMPILE_TARGET_IDS)";
 				BAZEL_LABEL = "@@//CommandLine/Tests:CommandLineToolTests";
 				BAZEL_OUTPUTS_DSYM = "\"bazel-out/CONFIGURATION-STABLE-23/bin/CommandLine/Tests/CommandLineToolTests.xctest.dSYM\"";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-23/bin/CommandLine/Tests/CommandLineToolTests.__internal__.__test_bundle.zip";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-23/bin/CommandLine/Tests/CommandLineToolTests.xctest";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = CommandLineToolTests.xctest;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-23/bin/CommandLine/Tests";
 				BAZEL_TARGET_ID = "@@//CommandLine/Tests:CommandLineToolTests.__internal__.__test_bundle CONFIGURATION-STABLE-23";
@@ -27119,7 +27119,7 @@
 					"\"bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Source/iOSApp.app.dSYM\"",
 					"\"bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTestSuite.xctest.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTestSuite.__internal__.__test_bundle.zip";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTestSuite.xctest";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = iOSAppObjCUnitTestSuite.xctest;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/ObjCUnitTests";
 				BAZEL_TARGET_ID = "@@//iOSApp/Test/ObjCUnitTests:iOSAppObjCUnitTestSuite.__internal__.__test_bundle CONFIGURATION-STABLE-10";
@@ -27245,7 +27245,7 @@
 					"\"bazel-out/CONFIGURATION-STABLE-6/bin/macOSApp/Source/macOSLib.framework_dsyms/Lib.framework.dSYM\"",
 					"\"bazel-out/CONFIGURATION-STABLE-6/bin/macOSApp/Source/macOSApp.app.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-6/bin/macOSApp/Source/macOSApp.zip";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-6/bin/macOSApp/Source/macOSApp.app";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = macOSApp.app;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-6/bin/macOSApp/Source";
 				BAZEL_TARGET_ID = "@@//macOSApp/Source:macOSApp CONFIGURATION-STABLE-6";
@@ -27302,8 +27302,8 @@
 				"ARCHS[sdk=watchos*]" = arm64_32;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				BAZEL_LABEL = "@@//watchOSApp:watchOSApp";
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-17/bin/watchOSApp/watchOSApp.zip";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=watchos*]" = "bazel-out/CONFIGURATION-STABLE-18/bin/watchOSApp/watchOSApp.zip";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-17/bin/watchOSApp/watchOSApp.app";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=watchos*]" = "bazel-out/CONFIGURATION-STABLE-18/bin/watchOSApp/watchOSApp.app";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = watchOSApp.app;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-17/bin/watchOSApp";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=watchos*]" = "bazel-out/CONFIGURATION-STABLE-18/bin/watchOSApp";
@@ -27427,8 +27427,8 @@
 					"\"bazel-out/CONFIGURATION-STABLE-16/bin/Lib/LibFramework.tvOS.framework.dSYM\"",
 					"\"bazel-out/CONFIGURATION-STABLE-16/bin/UI/UIFramework.tvOS.framework.dSYM\"",
 				);
-				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-12/bin/UI/UIFramework.tvOS.zip";
-				"BAZEL_OUTPUTS_PRODUCT[sdk=appletvos*]" = "bazel-out/CONFIGURATION-STABLE-16/bin/UI/UIFramework.tvOS.zip";
+				BAZEL_OUTPUTS_PRODUCT = "bazel-out/CONFIGURATION-STABLE-12/bin/UI/UIFramework.tvOS.framework";
+				"BAZEL_OUTPUTS_PRODUCT[sdk=appletvos*]" = "bazel-out/CONFIGURATION-STABLE-16/bin/UI/UIFramework.tvOS.framework";
 				BAZEL_OUTPUTS_PRODUCT_BASENAME = UIFramework.tvOS.framework;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/CONFIGURATION-STABLE-12/bin/UI";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=appletvos*]" = "bazel-out/CONFIGURATION-STABLE-16/bin/UI";
@@ -27450,11 +27450,11 @@
 				"PREVIEWS_SWIFT_INCLUDE__YES[sdk=appletvos*]" = "-I bazel-out/CONFIGURATION-STABLE-16/bin/UI";
 				PREVIEW_FRAMEWORK_PATHS = (
 					"\"$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator/CryptoSwift.framework\"",
-					"\"$(BAZEL_OUT)/CONFIGURATION-STABLE-12/bin/Lib/LibFramework.tvOS.zip\"",
+					"\"$(BAZEL_OUT)/CONFIGURATION-STABLE-12/bin/Lib/LibFramework.tvOS.framework\"",
 				);
 				"PREVIEW_FRAMEWORK_PATHS[sdk=appletvos*]" = (
 					"\"$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64/CryptoSwift.framework\"",
-					"\"$(BAZEL_OUT)/CONFIGURATION-STABLE-16/bin/Lib/LibFramework.tvOS.zip\"",
+					"\"$(BAZEL_OUT)/CONFIGURATION-STABLE-16/bin/Lib/LibFramework.tvOS.framework\"",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "rules-xcodeproj.UIFramework";
 				PRODUCT_MODULE_NAME = UI;

--- a/examples/integration/test/fixtures/bwb_targets_spec.json
+++ b/examples/integration/test/fixtures/bwb_targets_spec.json
@@ -188,7 +188,7 @@
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/CONFIGURATION-STABLE-3/bin/AppClip/AppClip.app.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-3/bin/AppClip/AppClip.ipa",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-3/bin/AppClip/AppClip.app",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "AppClip.app",
             "CODE_SIGN_ENTITLEMENTS": "$(BAZEL_OUT)/CONFIGURATION-STABLE-3/bin/AppClip/Entitlements.withbundleid.plist",
             "CODE_SIGN_STYLE": "Manual",
@@ -228,7 +228,7 @@
             "e": "AppClip",
             "m": "AppClip",
             "n": "AppClip",
-            "p": "bazel-out/CONFIGURATION-STABLE-3/bin/AppClip/AppClip_archive-root/Payload/AppClip.app",
+            "p": "bazel-out/CONFIGURATION-STABLE-3/bin/AppClip/AppClip.app",
             "t": "com.apple.product-type.application.on-demand-install-capable"
         }
     },
@@ -317,7 +317,7 @@
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/CONFIGURATION-STABLE-3/bin/WidgetExtension/WidgetExtension.appex.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-3/bin/WidgetExtension/WidgetExtension.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-3/bin/WidgetExtension/WidgetExtension.appex",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "WidgetExtension.appex",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-3/bin/WidgetExtension/rules_xcodeproj/WidgetExtension/Info.plist",
@@ -355,7 +355,7 @@
             "e": "WidgetExtension",
             "m": "WidgetExtension",
             "n": "WidgetExtension",
-            "p": "bazel-out/CONFIGURATION-STABLE-3/bin/WidgetExtension/WidgetExtension_archive-root/WidgetExtension.appex",
+            "p": "bazel-out/CONFIGURATION-STABLE-3/bin/WidgetExtension/WidgetExtension.appex",
             "t": "com.apple.product-type.app-extension"
         }
     },
@@ -380,7 +380,7 @@
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Source/CoreUtilsObjC/FrameworkCoreUtilsObjC_dsyms/CoreUtilsObjC.framework.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Source/CoreUtilsObjC/FrameworkCoreUtilsObjC.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Source/CoreUtilsObjC/CoreUtilsObjC.framework",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "CoreUtilsObjC.framework",
             "CODE_SIGN_STYLE": "Manual",
             "GCC_PREFIX_HEADER": "$(SRCROOT)/iOSApp/Source/CoreUtilsObjC/CoreUtils/CoreUtils.pch",
@@ -411,7 +411,7 @@
             "e": "CoreUtilsObjC",
             "m": "CoreUtilsObjC",
             "n": "CoreUtilsObjC",
-            "p": "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Source/CoreUtilsObjC/FrameworkCoreUtilsObjC_archive-root/CoreUtilsObjC.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Source/CoreUtilsObjC/CoreUtilsObjC.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -443,7 +443,7 @@
                 "\"bazel-out/CONFIGURATION-STABLE-3/bin/Lib/LibFramework.iOS.framework.dSYM\"",
                 "\"bazel-out/CONFIGURATION-STABLE-3/bin/UI/UIFramework.iOS.framework.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-3/bin/UI/UIFramework.iOS.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-3/bin/UI/UIFramework.iOS.framework",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "UIFramework.iOS.framework",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-3/bin/UI/rules_xcodeproj/UIFramework.iOS/Info.plist",
@@ -453,7 +453,7 @@
             "PREVIEWS_SWIFT_INCLUDE__YES": "-I bazel-out/CONFIGURATION-STABLE-3/bin/UI",
             "PREVIEW_FRAMEWORK_PATHS": [
                 "\"$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework\"",
-                "\"$(BAZEL_OUT)/CONFIGURATION-STABLE-3/bin/Lib/LibFramework.iOS.zip\""
+                "\"$(BAZEL_OUT)/CONFIGURATION-STABLE-3/bin/Lib/LibFramework.iOS.framework\""
             ],
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.UIFramework",
             "PRODUCT_MODULE_NAME": "UI",
@@ -484,7 +484,7 @@
             "e": "UIFramework.iOS",
             "m": "UIFramework.iOS",
             "n": "UIFramework.iOS",
-            "p": "bazel-out/CONFIGURATION-STABLE-3/bin/UI/UIFramework.iOS_archive-root/UIFramework.iOS.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-3/bin/UI/UIFramework.iOS.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -542,7 +542,7 @@
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/CONFIGURATION-STABLE-4/bin/Lib/LibFramework.watchOS.framework.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-4/bin/Lib/LibFramework.watchOS.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-4/bin/Lib/LibFramework.watchOS.framework",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "LibFramework.watchOS.framework",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-4/bin/Lib/rules_xcodeproj/LibFramework.watchOS/Info.plist",
@@ -567,7 +567,7 @@
             "e": "LibFramework.watchOS",
             "m": "LibFramework.watchOS",
             "n": "LibFramework.watchOS",
-            "p": "bazel-out/CONFIGURATION-STABLE-4/bin/Lib/LibFramework.watchOS_archive-root/LibFramework.watchOS.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-4/bin/Lib/LibFramework.watchOS.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -602,7 +602,7 @@
                 "\"bazel-out/CONFIGURATION-STABLE-4/bin/Lib/LibFramework.watchOS.framework.dSYM\"",
                 "\"bazel-out/CONFIGURATION-STABLE-4/bin/UI/UIFramework.watchOS.framework.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-4/bin/UI/UIFramework.watchOS.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-4/bin/UI/UIFramework.watchOS.framework",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "UIFramework.watchOS.framework",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-4/bin/UI/rules_xcodeproj/UIFramework.watchOS/Info.plist",
@@ -612,7 +612,7 @@
             "PREVIEWS_SWIFT_INCLUDE__YES": "-I bazel-out/CONFIGURATION-STABLE-4/bin/UI",
             "PREVIEW_FRAMEWORK_PATHS": [
                 "\"$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator/CryptoSwift.framework\"",
-                "\"$(BAZEL_OUT)/CONFIGURATION-STABLE-4/bin/Lib/LibFramework.watchOS.zip\""
+                "\"$(BAZEL_OUT)/CONFIGURATION-STABLE-4/bin/Lib/LibFramework.watchOS.framework\""
             ],
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.UIFramework",
             "PRODUCT_MODULE_NAME": "UI",
@@ -640,7 +640,7 @@
             "e": "UIFramework.watchOS",
             "m": "UIFramework.watchOS",
             "n": "UIFramework.watchOS",
-            "p": "bazel-out/CONFIGURATION-STABLE-4/bin/UI/UIFramework.watchOS_archive-root/UIFramework.watchOS.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-4/bin/UI/UIFramework.watchOS.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -674,7 +674,7 @@
                 "\"bazel-out/CONFIGURATION-STABLE-4/bin/UI/UIFramework.watchOS.framework.dSYM\"",
                 "\"bazel-out/CONFIGURATION-STABLE-4/bin/watchOSAppExtension/watchOSAppExtension.appex.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-4/bin/watchOSAppExtension/watchOSAppExtension.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-4/bin/watchOSAppExtension/watchOSAppExtension.appex",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "watchOSAppExtension.appex",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-4/bin/watchOSAppExtension/rules_xcodeproj/watchOSAppExtension/Info.plist",
@@ -710,7 +710,7 @@
             "e": "watchOSAppExtension",
             "m": "watchOSAppExtension",
             "n": "watchOSAppExtension",
-            "p": "bazel-out/CONFIGURATION-STABLE-4/bin/watchOSAppExtension/watchOSAppExtension_archive-root/watchOSAppExtension.appex",
+            "p": "bazel-out/CONFIGURATION-STABLE-4/bin/watchOSAppExtension/watchOSAppExtension.appex",
             "t": "com.apple.product-type.watchkit2-extension"
         }
     },
@@ -728,7 +728,7 @@
         ],
         "b": {
             "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-17/bin/watchOSApp/watchOSApp.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-17/bin/watchOSApp/watchOSApp.app",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "watchOSApp.app",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-17/bin/watchOSApp/rules_xcodeproj/watchOSApp/Info.plist",
@@ -753,7 +753,7 @@
             "e": "watchOSApp",
             "m": "watchOSApp",
             "n": "watchOSApp",
-            "p": "bazel-out/CONFIGURATION-STABLE-17/bin/watchOSApp/watchOSApp_archive-root/Payload/watchOSApp.app",
+            "p": "bazel-out/CONFIGURATION-STABLE-17/bin/watchOSApp/watchOSApp.app",
             "t": "com.apple.product-type.application.watchapp2"
         }
     },
@@ -803,7 +803,7 @@
                 "\"bazel-out/CONFIGURATION-STABLE-4/bin/watchOSAppExtension/watchOSAppExtension.appex.dSYM\"",
                 "\"bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Source/iOSApp.app.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Source/iOSApp.ipa",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Source/iOSApp.app",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "iOSApp.app",
             "CODE_SIGN_ENTITLEMENTS": "$(SRCROOT)/iOSApp/Source/ios app.entitlements",
             "CODE_SIGN_STYLE": "Manual",
@@ -861,7 +861,7 @@
             "e": "iOSApp_ExecutableName",
             "m": "iOSApp",
             "n": "iOSApp",
-            "p": "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Source/iOSApp_archive-root/Payload/iOSApp.app",
+            "p": "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Source/iOSApp.app",
             "t": "com.apple.product-type.application"
         },
         "w": "@@//watchOSApp:watchOSApp CONFIGURATION-STABLE-17"
@@ -882,7 +882,7 @@
         "6": "bazel-out/CONFIGURATION-STABLE-0/bin/external/rules_xcodeproj~override~internal~rules_xcodeproj_generated/generator/test/fixtures/xcodeproj_bwb/xcodeproj_bwb-params/iOS.18.link.params",
         "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-3/bin/Lib/dist/dynamic/iOS.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-3/bin/Lib/dist/dynamic/Lib.framework",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "Lib.framework",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-3/bin/Lib/dist/dynamic/rules_xcodeproj/iOS/Info.plist",
@@ -907,7 +907,7 @@
             "e": "Lib",
             "m": "Lib",
             "n": "Lib",
-            "p": "bazel-out/CONFIGURATION-STABLE-3/bin/Lib/dist/dynamic/iOS_archive-root/Lib.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-3/bin/Lib/dist/dynamic/Lib.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -962,7 +962,7 @@
         "6": "bazel-out/CONFIGURATION-STABLE-0/bin/external/rules_xcodeproj~override~internal~rules_xcodeproj_generated/generator/test/fixtures/xcodeproj_bwb/xcodeproj_bwb-params/tvOS.20.link.params",
         "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-5/bin/Lib/dist/dynamic/tvOS.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-5/bin/Lib/dist/dynamic/Lib.framework",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "Lib.framework",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-5/bin/Lib/dist/dynamic/rules_xcodeproj/tvOS/Info.plist",
@@ -987,7 +987,7 @@
             "e": "Lib",
             "m": "Lib",
             "n": "Lib",
-            "p": "bazel-out/CONFIGURATION-STABLE-5/bin/Lib/dist/dynamic/tvOS_archive-root/Lib.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-5/bin/Lib/dist/dynamic/Lib.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -1007,7 +1007,7 @@
         "6": "bazel-out/CONFIGURATION-STABLE-0/bin/external/rules_xcodeproj~override~internal~rules_xcodeproj_generated/generator/test/fixtures/xcodeproj_bwb/xcodeproj_bwb-params/watchOS.21.link.params",
         "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-4/bin/Lib/dist/dynamic/watchOS.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-4/bin/Lib/dist/dynamic/Lib.framework",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "Lib.framework",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-4/bin/Lib/dist/dynamic/rules_xcodeproj/watchOS/Info.plist",
@@ -1032,7 +1032,7 @@
             "e": "Lib",
             "m": "Lib",
             "n": "Lib",
-            "p": "bazel-out/CONFIGURATION-STABLE-4/bin/Lib/dist/dynamic/watchOS_archive-root/Lib.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-4/bin/Lib/dist/dynamic/Lib.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -1055,7 +1055,7 @@
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/CONFIGURATION-STABLE-5/bin/Lib/LibFramework.tvOS.framework.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-5/bin/Lib/LibFramework.tvOS.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-5/bin/Lib/LibFramework.tvOS.framework",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "LibFramework.tvOS.framework",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-5/bin/Lib/rules_xcodeproj/LibFramework.tvOS/Info.plist",
@@ -1080,7 +1080,7 @@
             "e": "LibFramework.tvOS",
             "m": "LibFramework.tvOS",
             "n": "LibFramework.tvOS",
-            "p": "bazel-out/CONFIGURATION-STABLE-5/bin/Lib/LibFramework.tvOS_archive-root/LibFramework.tvOS.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-5/bin/Lib/LibFramework.tvOS.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -1115,7 +1115,7 @@
                 "\"bazel-out/CONFIGURATION-STABLE-5/bin/Lib/LibFramework.tvOS.framework.dSYM\"",
                 "\"bazel-out/CONFIGURATION-STABLE-5/bin/UI/UIFramework.tvOS.framework.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-5/bin/UI/UIFramework.tvOS.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-5/bin/UI/UIFramework.tvOS.framework",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "UIFramework.tvOS.framework",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-5/bin/UI/rules_xcodeproj/UIFramework.tvOS/Info.plist",
@@ -1125,7 +1125,7 @@
             "PREVIEWS_SWIFT_INCLUDE__YES": "-I bazel-out/CONFIGURATION-STABLE-5/bin/UI",
             "PREVIEW_FRAMEWORK_PATHS": [
                 "\"$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator/CryptoSwift.framework\"",
-                "\"$(BAZEL_OUT)/CONFIGURATION-STABLE-5/bin/Lib/LibFramework.tvOS.zip\""
+                "\"$(BAZEL_OUT)/CONFIGURATION-STABLE-5/bin/Lib/LibFramework.tvOS.framework\""
             ],
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.UIFramework",
             "PRODUCT_MODULE_NAME": "UI",
@@ -1153,7 +1153,7 @@
             "e": "UIFramework.tvOS",
             "m": "UIFramework.tvOS",
             "n": "UIFramework.tvOS",
-            "p": "bazel-out/CONFIGURATION-STABLE-5/bin/UI/UIFramework.tvOS_archive-root/UIFramework.tvOS.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-5/bin/UI/UIFramework.tvOS.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -1190,7 +1190,7 @@
                 "\"bazel-out/CONFIGURATION-STABLE-5/bin/UI/UIFramework.tvOS.framework.dSYM\"",
                 "\"bazel-out/CONFIGURATION-STABLE-5/bin/tvOSApp/Source/tvOSApp.app.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-5/bin/tvOSApp/Source/tvOSApp.ipa",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-5/bin/tvOSApp/Source/tvOSApp.app",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "tvOSApp.app",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-5/bin/tvOSApp/Source/rules_xcodeproj/tvOSApp/Info.plist",
@@ -1227,7 +1227,7 @@
             "e": "tvOSApp",
             "m": "tvOSApp",
             "n": "tvOSApp",
-            "p": "bazel-out/CONFIGURATION-STABLE-5/bin/tvOSApp/Source/tvOSApp_archive-root/Payload/tvOSApp.app",
+            "p": "bazel-out/CONFIGURATION-STABLE-5/bin/tvOSApp/Source/tvOSApp.app",
             "t": "com.apple.product-type.application"
         }
     },
@@ -1251,7 +1251,7 @@
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/CONFIGURATION-STABLE-6/bin/Bundle/Bundle_dsyms/ABundle.aplugin.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-6/bin/Bundle/Bundle.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-6/bin/Bundle/ABundle.aplugin",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "ABundle.aplugin",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-6/bin/Bundle/rules_xcodeproj/Bundle/Info.plist",
@@ -1273,7 +1273,7 @@
             "e": "ABundle",
             "m": "ABundle",
             "n": "ABundle",
-            "p": "bazel-out/CONFIGURATION-STABLE-6/bin/Bundle/Bundle_archive-root/ABundle.aplugin",
+            "p": "bazel-out/CONFIGURATION-STABLE-6/bin/Bundle/ABundle.aplugin",
             "t": "com.apple.product-type.bundle"
         }
     },
@@ -1412,7 +1412,7 @@
                 "\"bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Source/iOSApp.app.dSYM\"",
                 "\"bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.xctest.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.__internal__.__test_bundle.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.xctest",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "iOSAppObjCUnitTests.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-3/bin/iOSApp/Test/ObjCUnitTests/rules_xcodeproj/iOSAppObjCUnitTests.__internal__.__test_bundle/Info.plist",
@@ -1443,7 +1443,7 @@
             "e": "iOSAppObjCUnitTests",
             "m": "iOSAppObjCUnitTests",
             "n": "iOSAppObjCUnitTests",
-            "p": "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.__internal__.__test_bundle_archive-root/iOSAppObjCUnitTests.xctest",
+            "p": "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         }
     },
@@ -1476,7 +1476,7 @@
                 "\"bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Source/iOSApp.app.dSYM\"",
                 "\"bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/UITests/iOSAppUITests.xctest.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/UITests/iOSAppUITests.__internal__.__test_bundle.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/UITests/iOSAppUITests.xctest",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "iOSAppUITests.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-3/bin/iOSApp/Test/UITests/rules_xcodeproj/iOSAppUITests.__internal__.__test_bundle/Info.plist",
@@ -1510,7 +1510,7 @@
             "e": "iOSAppUITests",
             "m": "iOSAppUITests",
             "n": "iOSAppUITests",
-            "p": "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/UITests/iOSAppUITests.__internal__.__test_bundle_archive-root/iOSAppUITests.xctest",
+            "p": "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/UITests/iOSAppUITests.xctest",
             "t": "com.apple.product-type.bundle.ui-testing"
         }
     },
@@ -1575,7 +1575,7 @@
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/CONFIGURATION-STABLE-3/bin/iMessageApp/iMessageAppExtension.appex.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-3/bin/iMessageApp/iMessageAppExtension.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-3/bin/iMessageApp/iMessageAppExtension.appex",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "iMessageAppExtension.appex",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-3/bin/iMessageApp/rules_xcodeproj/iMessageAppExtension/Info.plist",
@@ -1613,7 +1613,7 @@
             "e": "iMessageAppExtension",
             "m": "iMessageAppExtension",
             "n": "iMessageAppExtension",
-            "p": "bazel-out/CONFIGURATION-STABLE-3/bin/iMessageApp/iMessageAppExtension_archive-root/iMessageAppExtension.appex",
+            "p": "bazel-out/CONFIGURATION-STABLE-3/bin/iMessageApp/iMessageAppExtension.appex",
             "t": "com.apple.product-type.app-extension.messages"
         }
     },
@@ -1627,7 +1627,7 @@
         },
         "b": {
             "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-3/bin/iMessageApp/iMessageApp.ipa",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-3/bin/iMessageApp/iMessageApp.app",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "iMessageApp.app",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-3/bin/iMessageApp/rules_xcodeproj/iMessageApp/Info.plist",
@@ -1649,7 +1649,7 @@
             "e": "iMessageApp",
             "m": "iMessageApp",
             "n": "iMessageApp",
-            "p": "bazel-out/CONFIGURATION-STABLE-3/bin/iMessageApp/iMessageApp_archive-root/Payload/iMessageApp.app",
+            "p": "bazel-out/CONFIGURATION-STABLE-3/bin/iMessageApp/iMessageApp.app",
             "t": "com.apple.product-type.application.messages"
         }
     },
@@ -1697,7 +1697,7 @@
                 "\"bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Source/iOSApp.app.dSYM\"",
                 "\"bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.xctest.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.__internal__.__test_bundle.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.xctest",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "iOSAppSwiftUnitTests.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-3/bin/iOSApp/Test/SwiftUnitTests/rules_xcodeproj/iOSAppSwiftUnitTests.__internal__.__test_bundle/Info.plist",
@@ -1740,7 +1740,7 @@
             "e": "iOSAppSwiftUnitTests",
             "m": "iOSAppSwiftUnitTests",
             "n": "iOSAppSwiftUnitTests",
-            "p": "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.__internal__.__test_bundle_archive-root/iOSAppSwiftUnitTests.xctest",
+            "p": "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         }
     },
@@ -1795,7 +1795,7 @@
         "6": "bazel-out/CONFIGURATION-STABLE-0/bin/external/rules_xcodeproj~override~internal~rules_xcodeproj_generated/generator/test/fixtures/xcodeproj_bwb/xcodeproj_bwb-params/macOSLib.framework.36.link.params",
         "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-6/bin/macOSApp/Source/macOSLib.framework.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-6/bin/macOSApp/Source/Lib.framework",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "Lib.framework",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-6/bin/macOSApp/Source/rules_xcodeproj/macOSLib.framework/Info.plist",
@@ -1819,7 +1819,7 @@
             "e": "Lib",
             "m": "Lib",
             "n": "Lib",
-            "p": "bazel-out/CONFIGURATION-STABLE-6/bin/macOSApp/Source/macOSLib.framework_archive-root/Lib.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-6/bin/macOSApp/Source/Lib.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -1855,7 +1855,7 @@
                 "\"bazel-out/CONFIGURATION-STABLE-6/bin/macOSApp/Source/macOSLib.framework_dsyms/Lib.framework.dSYM\"",
                 "\"bazel-out/CONFIGURATION-STABLE-6/bin/macOSApp/Source/macOSApp.app.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-6/bin/macOSApp/Source/macOSApp.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-6/bin/macOSApp/Source/macOSApp.app",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "macOSApp.app",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-6/bin/macOSApp/Source/rules_xcodeproj/macOSApp/Info.plist",
@@ -1892,7 +1892,7 @@
             "e": "macOSApp",
             "m": "macOSApp",
             "n": "macOSApp",
-            "p": "bazel-out/CONFIGURATION-STABLE-6/bin/macOSApp/Source/macOSApp_archive-root/Payload/macOSApp.app",
+            "p": "bazel-out/CONFIGURATION-STABLE-6/bin/macOSApp/Source/macOSApp.app",
             "t": "com.apple.product-type.application"
         }
     },
@@ -1918,7 +1918,7 @@
                 "\"bazel-out/CONFIGURATION-STABLE-6/bin/macOSApp/Source/macOSApp.app.dSYM\"",
                 "\"bazel-out/CONFIGURATION-STABLE-6/bin/macOSApp/Test/UITests/macOSAppUITests.xctest.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-6/bin/macOSApp/Test/UITests/macOSAppUITests.__internal__.__test_bundle.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-6/bin/macOSApp/Test/UITests/macOSAppUITests.xctest",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "macOSAppUITests.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-6/bin/macOSApp/Test/UITests/rules_xcodeproj/macOSAppUITests.__internal__.__test_bundle/Info.plist",
@@ -1951,7 +1951,7 @@
             "e": "macOSAppUITests",
             "m": "macOSAppUITests",
             "n": "macOSAppUITests",
-            "p": "bazel-out/CONFIGURATION-STABLE-6/bin/macOSApp/Test/UITests/macOSAppUITests.__internal__.__test_bundle_archive-root/macOSAppUITests.xctest",
+            "p": "bazel-out/CONFIGURATION-STABLE-6/bin/macOSApp/Test/UITests/macOSAppUITests.xctest",
             "t": "com.apple.product-type.bundle.ui-testing"
         }
     },
@@ -1978,7 +1978,7 @@
                 "\"bazel-out/CONFIGURATION-STABLE-5/bin/tvOSApp/Source/tvOSApp.app.dSYM\"",
                 "\"bazel-out/CONFIGURATION-STABLE-5/bin/tvOSApp/Test/UITests/tvOSAppUITests.xctest.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-5/bin/tvOSApp/Test/UITests/tvOSAppUITests.__internal__.__test_bundle.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-5/bin/tvOSApp/Test/UITests/tvOSAppUITests.xctest",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "tvOSAppUITests.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-5/bin/tvOSApp/Test/UITests/rules_xcodeproj/tvOSAppUITests.__internal__.__test_bundle/Info.plist",
@@ -2012,7 +2012,7 @@
             "e": "tvOSAppUITests",
             "m": "tvOSAppUITests",
             "n": "tvOSAppUITests",
-            "p": "bazel-out/CONFIGURATION-STABLE-5/bin/tvOSApp/Test/UITests/tvOSAppUITests.__internal__.__test_bundle_archive-root/tvOSAppUITests.xctest",
+            "p": "bazel-out/CONFIGURATION-STABLE-5/bin/tvOSApp/Test/UITests/tvOSAppUITests.xctest",
             "t": "com.apple.product-type.bundle.ui-testing"
         }
     },
@@ -2051,7 +2051,7 @@
                 "\"bazel-out/CONFIGURATION-STABLE-5/bin/tvOSApp/Source/tvOSApp.app.dSYM\"",
                 "\"bazel-out/CONFIGURATION-STABLE-5/bin/tvOSApp/Test/UnitTests/tvOSAppUnitTests.xctest.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-5/bin/tvOSApp/Test/UnitTests/tvOSAppUnitTests.__internal__.__test_bundle.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-5/bin/tvOSApp/Test/UnitTests/tvOSAppUnitTests.xctest",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "tvOSAppUnitTests.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-5/bin/tvOSApp/Test/UnitTests/rules_xcodeproj/tvOSAppUnitTests.__internal__.__test_bundle/Info.plist",
@@ -2088,7 +2088,7 @@
             "e": "tvOSAppUnitTests",
             "m": "tvOSAppUnitTests",
             "n": "tvOSAppUnitTests",
-            "p": "bazel-out/CONFIGURATION-STABLE-5/bin/tvOSApp/Test/UnitTests/tvOSAppUnitTests.__internal__.__test_bundle_archive-root/tvOSAppUnitTests.xctest",
+            "p": "bazel-out/CONFIGURATION-STABLE-5/bin/tvOSApp/Test/UnitTests/tvOSAppUnitTests.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         }
     },
@@ -2115,7 +2115,7 @@
                 "\"bazel-out/CONFIGURATION-STABLE-4/bin/watchOSAppExtension/watchOSAppExtension.appex.dSYM\"",
                 "\"bazel-out/CONFIGURATION-STABLE-4/bin/watchOSApp/Test/UITests/watchOSAppUITests.xctest.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-4/bin/watchOSApp/Test/UITests/watchOSAppUITests.__internal__.__test_bundle.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-4/bin/watchOSApp/Test/UITests/watchOSAppUITests.xctest",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "watchOSAppUITests.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-4/bin/watchOSApp/Test/UITests/rules_xcodeproj/watchOSAppUITests.__internal__.__test_bundle/Info.plist",
@@ -2149,7 +2149,7 @@
             "e": "watchOSAppUITests",
             "m": "watchOSAppUITests",
             "n": "watchOSAppUITests",
-            "p": "bazel-out/CONFIGURATION-STABLE-4/bin/watchOSApp/Test/UITests/watchOSAppUITests.__internal__.__test_bundle_archive-root/watchOSAppUITests.xctest",
+            "p": "bazel-out/CONFIGURATION-STABLE-4/bin/watchOSApp/Test/UITests/watchOSAppUITests.xctest",
             "t": "com.apple.product-type.bundle.ui-testing"
         }
     },
@@ -2184,7 +2184,7 @@
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/CONFIGURATION-STABLE-4/bin/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTests.xctest.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-4/bin/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTests.__internal__.__test_bundle.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-4/bin/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTests.xctest",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "watchOSAppExtensionUnitTests.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-4/bin/watchOSAppExtension/Test/UnitTests/rules_xcodeproj/watchOSAppExtensionUnitTests.__internal__.__test_bundle/Info.plist",
@@ -2217,7 +2217,7 @@
             "e": "watchOSAppExtensionUnitTests",
             "m": "watchOSAppExtensionUnitTests",
             "n": "watchOSAppExtensionUnitTests",
-            "p": "bazel-out/CONFIGURATION-STABLE-4/bin/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTests.__internal__.__test_bundle_archive-root/watchOSAppExtensionUnitTests.xctest",
+            "p": "bazel-out/CONFIGURATION-STABLE-4/bin/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTests.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         }
     },
@@ -2250,7 +2250,7 @@
                 "\"bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Source/iOSApp.app.dSYM\"",
                 "\"bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/UITests/iOSAppUITestSuite.xctest.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/UITests/iOSAppUITestSuite.__internal__.__test_bundle.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/UITests/iOSAppUITestSuite.xctest",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "iOSAppUITestSuite.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-3/bin/iOSApp/Test/UITests/rules_xcodeproj/iOSAppUITestSuite.__internal__.__test_bundle/Info.plist",
@@ -2284,7 +2284,7 @@
             "e": "iOSAppUITestSuite",
             "m": "iOSAppUITestSuite",
             "n": "iOSAppUITestSuite",
-            "p": "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/UITests/iOSAppUITestSuite.__internal__.__test_bundle_archive-root/iOSAppUITestSuite.xctest",
+            "p": "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/UITests/iOSAppUITestSuite.xctest",
             "t": "com.apple.product-type.bundle.ui-testing"
         }
     },
@@ -2332,7 +2332,7 @@
                 "\"bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Source/iOSApp.app.dSYM\"",
                 "\"bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTestSuite.xctest.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTestSuite.__internal__.__test_bundle.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTestSuite.xctest",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "iOSAppObjCUnitTestSuite.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-3/bin/iOSApp/Test/ObjCUnitTests/rules_xcodeproj/iOSAppObjCUnitTestSuite.__internal__.__test_bundle/Info.plist",
@@ -2363,7 +2363,7 @@
             "e": "iOSAppObjCUnitTestSuite",
             "m": "iOSAppObjCUnitTestSuite",
             "n": "iOSAppObjCUnitTestSuite",
-            "p": "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTestSuite.__internal__.__test_bundle_archive-root/iOSAppObjCUnitTestSuite.xctest",
+            "p": "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTestSuite.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         }
     },
@@ -2411,7 +2411,7 @@
                 "\"bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Source/iOSApp.app.dSYM\"",
                 "\"bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTestSuite.xctest.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTestSuite.__internal__.__test_bundle.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTestSuite.xctest",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "iOSAppSwiftUnitTestSuite.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-3/bin/iOSApp/Test/SwiftUnitTests/rules_xcodeproj/iOSAppSwiftUnitTestSuite.__internal__.__test_bundle/Info.plist",
@@ -2454,7 +2454,7 @@
             "e": "iOSAppSwiftUnitTestSuite",
             "m": "iOSAppSwiftUnitTestSuite",
             "n": "iOSAppSwiftUnitTestSuite",
-            "p": "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTestSuite.__internal__.__test_bundle_archive-root/iOSAppSwiftUnitTestSuite.xctest",
+            "p": "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTestSuite.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         }
     },
@@ -5282,7 +5282,7 @@
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/CONFIGURATION-STABLE-23/bin/CommandLine/Tests/CommandLineToolTests.xctest.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-23/bin/CommandLine/Tests/CommandLineToolTests.__internal__.__test_bundle.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-23/bin/CommandLine/Tests/CommandLineToolTests.xctest",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "CommandLineToolTests.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-23/bin/CommandLine/Tests/rules_xcodeproj/CommandLineToolTests.__internal__.__test_bundle/Info.plist",
@@ -5315,7 +5315,7 @@
             "e": "CommandLineToolTests",
             "m": "CommandLineToolTests",
             "n": "CommandLineToolTests",
-            "p": "bazel-out/CONFIGURATION-STABLE-23/bin/CommandLine/Tests/CommandLineToolTests.__internal__.__test_bundle_archive-root/CommandLineToolTests.xctest",
+            "p": "bazel-out/CONFIGURATION-STABLE-23/bin/CommandLine/Tests/CommandLineToolTests.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         }
     },
@@ -5380,7 +5380,7 @@
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/CONFIGURATION-STABLE-7/bin/AppClip/AppClip.app.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-7/bin/AppClip/AppClip.ipa",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-7/bin/AppClip/AppClip.app",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "AppClip.app",
             "CODE_SIGN_ENTITLEMENTS": "$(BAZEL_OUT)/CONFIGURATION-STABLE-7/bin/AppClip/Entitlements.withbundleid.plist",
             "CODE_SIGN_STYLE": "Automatic",
@@ -5421,7 +5421,7 @@
             "e": "AppClip",
             "m": "AppClip",
             "n": "AppClip",
-            "p": "bazel-out/CONFIGURATION-STABLE-7/bin/AppClip/AppClip_archive-root/Payload/AppClip.app",
+            "p": "bazel-out/CONFIGURATION-STABLE-7/bin/AppClip/AppClip.app",
             "t": "com.apple.product-type.application.on-demand-install-capable"
         }
     },
@@ -5510,7 +5510,7 @@
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/CONFIGURATION-STABLE-7/bin/WidgetExtension/WidgetExtension.appex.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-7/bin/WidgetExtension/WidgetExtension.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-7/bin/WidgetExtension/WidgetExtension.appex",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "WidgetExtension.appex",
             "CODE_SIGN_STYLE": "Automatic",
             "DEVELOPMENT_TEAM": "V82V4GQZXM",
@@ -5549,7 +5549,7 @@
             "e": "WidgetExtension",
             "m": "WidgetExtension",
             "n": "WidgetExtension",
-            "p": "bazel-out/CONFIGURATION-STABLE-7/bin/WidgetExtension/WidgetExtension_archive-root/WidgetExtension.appex",
+            "p": "bazel-out/CONFIGURATION-STABLE-7/bin/WidgetExtension/WidgetExtension.appex",
             "t": "com.apple.product-type.app-extension"
         }
     },
@@ -5574,7 +5574,7 @@
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Source/CoreUtilsObjC/FrameworkCoreUtilsObjC_dsyms/CoreUtilsObjC.framework.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Source/CoreUtilsObjC/FrameworkCoreUtilsObjC.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Source/CoreUtilsObjC/CoreUtilsObjC.framework",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "CoreUtilsObjC.framework",
             "CODE_SIGN_STYLE": "Manual",
             "GCC_PREFIX_HEADER": "$(SRCROOT)/iOSApp/Source/CoreUtilsObjC/CoreUtils/CoreUtils.pch",
@@ -5605,7 +5605,7 @@
             "e": "CoreUtilsObjC",
             "m": "CoreUtilsObjC",
             "n": "CoreUtilsObjC",
-            "p": "bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Source/CoreUtilsObjC/FrameworkCoreUtilsObjC_archive-root/CoreUtilsObjC.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Source/CoreUtilsObjC/CoreUtilsObjC.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -5637,7 +5637,7 @@
                 "\"bazel-out/CONFIGURATION-STABLE-7/bin/Lib/LibFramework.iOS.framework.dSYM\"",
                 "\"bazel-out/CONFIGURATION-STABLE-7/bin/UI/UIFramework.iOS.framework.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-7/bin/UI/UIFramework.iOS.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-7/bin/UI/UIFramework.iOS.framework",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "UIFramework.iOS.framework",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-7/bin/UI/rules_xcodeproj/UIFramework.iOS/Info.plist",
@@ -5647,7 +5647,7 @@
             "PREVIEWS_SWIFT_INCLUDE__YES": "-I bazel-out/CONFIGURATION-STABLE-7/bin/UI",
             "PREVIEW_FRAMEWORK_PATHS": [
                 "\"$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework\"",
-                "\"$(BAZEL_OUT)/CONFIGURATION-STABLE-7/bin/Lib/LibFramework.iOS.zip\""
+                "\"$(BAZEL_OUT)/CONFIGURATION-STABLE-7/bin/Lib/LibFramework.iOS.framework\""
             ],
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.UIFramework",
             "PRODUCT_MODULE_NAME": "UI",
@@ -5678,7 +5678,7 @@
             "e": "UIFramework.iOS",
             "m": "UIFramework.iOS",
             "n": "UIFramework.iOS",
-            "p": "bazel-out/CONFIGURATION-STABLE-7/bin/UI/UIFramework.iOS_archive-root/UIFramework.iOS.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-7/bin/UI/UIFramework.iOS.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -5736,7 +5736,7 @@
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/CONFIGURATION-STABLE-8/bin/Lib/LibFramework.watchOS.framework.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-8/bin/Lib/LibFramework.watchOS.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-8/bin/Lib/LibFramework.watchOS.framework",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "LibFramework.watchOS.framework",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-8/bin/Lib/rules_xcodeproj/LibFramework.watchOS/Info.plist",
@@ -5761,7 +5761,7 @@
             "e": "LibFramework.watchOS",
             "m": "LibFramework.watchOS",
             "n": "LibFramework.watchOS",
-            "p": "bazel-out/CONFIGURATION-STABLE-8/bin/Lib/LibFramework.watchOS_archive-root/LibFramework.watchOS.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-8/bin/Lib/LibFramework.watchOS.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -5796,7 +5796,7 @@
                 "\"bazel-out/CONFIGURATION-STABLE-8/bin/Lib/LibFramework.watchOS.framework.dSYM\"",
                 "\"bazel-out/CONFIGURATION-STABLE-8/bin/UI/UIFramework.watchOS.framework.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-8/bin/UI/UIFramework.watchOS.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-8/bin/UI/UIFramework.watchOS.framework",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "UIFramework.watchOS.framework",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-8/bin/UI/rules_xcodeproj/UIFramework.watchOS/Info.plist",
@@ -5806,7 +5806,7 @@
             "PREVIEWS_SWIFT_INCLUDE__YES": "-I bazel-out/CONFIGURATION-STABLE-8/bin/UI",
             "PREVIEW_FRAMEWORK_PATHS": [
                 "\"$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k/CryptoSwift.framework\"",
-                "\"$(BAZEL_OUT)/CONFIGURATION-STABLE-8/bin/Lib/LibFramework.watchOS.zip\""
+                "\"$(BAZEL_OUT)/CONFIGURATION-STABLE-8/bin/Lib/LibFramework.watchOS.framework\""
             ],
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.UIFramework",
             "PRODUCT_MODULE_NAME": "UI",
@@ -5834,7 +5834,7 @@
             "e": "UIFramework.watchOS",
             "m": "UIFramework.watchOS",
             "n": "UIFramework.watchOS",
-            "p": "bazel-out/CONFIGURATION-STABLE-8/bin/UI/UIFramework.watchOS_archive-root/UIFramework.watchOS.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-8/bin/UI/UIFramework.watchOS.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -5868,7 +5868,7 @@
                 "\"bazel-out/CONFIGURATION-STABLE-8/bin/UI/UIFramework.watchOS.framework.dSYM\"",
                 "\"bazel-out/CONFIGURATION-STABLE-8/bin/watchOSAppExtension/watchOSAppExtension.appex.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-8/bin/watchOSAppExtension/watchOSAppExtension.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-8/bin/watchOSAppExtension/watchOSAppExtension.appex",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "watchOSAppExtension.appex",
             "CODE_SIGN_STYLE": "Automatic",
             "DEVELOPMENT_TEAM": "V82V4GQZXM",
@@ -5905,7 +5905,7 @@
             "e": "watchOSAppExtension",
             "m": "watchOSAppExtension",
             "n": "watchOSAppExtension",
-            "p": "bazel-out/CONFIGURATION-STABLE-8/bin/watchOSAppExtension/watchOSAppExtension_archive-root/watchOSAppExtension.appex",
+            "p": "bazel-out/CONFIGURATION-STABLE-8/bin/watchOSAppExtension/watchOSAppExtension.appex",
             "t": "com.apple.product-type.watchkit2-extension"
         }
     },
@@ -5923,7 +5923,7 @@
         ],
         "b": {
             "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-18/bin/watchOSApp/watchOSApp.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-18/bin/watchOSApp/watchOSApp.app",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "watchOSApp.app",
             "CODE_SIGN_STYLE": "Automatic",
             "DEVELOPMENT_TEAM": "V82V4GQZXM",
@@ -5949,7 +5949,7 @@
             "e": "watchOSApp",
             "m": "watchOSApp",
             "n": "watchOSApp",
-            "p": "bazel-out/CONFIGURATION-STABLE-18/bin/watchOSApp/watchOSApp_archive-root/Payload/watchOSApp.app",
+            "p": "bazel-out/CONFIGURATION-STABLE-18/bin/watchOSApp/watchOSApp.app",
             "t": "com.apple.product-type.application.watchapp2"
         }
     },
@@ -5999,7 +5999,7 @@
                 "\"bazel-out/CONFIGURATION-STABLE-8/bin/watchOSAppExtension/watchOSAppExtension.appex.dSYM\"",
                 "\"bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Source/iOSApp.app.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Source/iOSApp.ipa",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Source/iOSApp.app",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "iOSApp.app",
             "CODE_SIGN_ENTITLEMENTS": "$(SRCROOT)/iOSApp/Source/ios app.entitlements",
             "CODE_SIGN_STYLE": "Automatic",
@@ -6058,7 +6058,7 @@
             "e": "iOSApp",
             "m": "iOSApp",
             "n": "iOSApp",
-            "p": "bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Source/iOSApp_archive-root/Payload/iOSApp.app",
+            "p": "bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Source/iOSApp.app",
             "t": "com.apple.product-type.application"
         },
         "w": "@@//watchOSApp:watchOSApp CONFIGURATION-STABLE-18"
@@ -6079,7 +6079,7 @@
         "6": "bazel-out/CONFIGURATION-STABLE-0/bin/external/rules_xcodeproj~override~internal~rules_xcodeproj_generated/generator/test/fixtures/xcodeproj_bwb/xcodeproj_bwb-params/iOS.114.link.params",
         "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-7/bin/Lib/dist/dynamic/iOS.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-7/bin/Lib/dist/dynamic/Lib.framework",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "Lib.framework",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-7/bin/Lib/dist/dynamic/rules_xcodeproj/iOS/Info.plist",
@@ -6104,7 +6104,7 @@
             "e": "Lib",
             "m": "Lib",
             "n": "Lib",
-            "p": "bazel-out/CONFIGURATION-STABLE-7/bin/Lib/dist/dynamic/iOS_archive-root/Lib.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-7/bin/Lib/dist/dynamic/Lib.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -6159,7 +6159,7 @@
         "6": "bazel-out/CONFIGURATION-STABLE-0/bin/external/rules_xcodeproj~override~internal~rules_xcodeproj_generated/generator/test/fixtures/xcodeproj_bwb/xcodeproj_bwb-params/tvOS.116.link.params",
         "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-9/bin/Lib/dist/dynamic/tvOS.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-9/bin/Lib/dist/dynamic/Lib.framework",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "Lib.framework",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-9/bin/Lib/dist/dynamic/rules_xcodeproj/tvOS/Info.plist",
@@ -6184,7 +6184,7 @@
             "e": "Lib",
             "m": "Lib",
             "n": "Lib",
-            "p": "bazel-out/CONFIGURATION-STABLE-9/bin/Lib/dist/dynamic/tvOS_archive-root/Lib.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-9/bin/Lib/dist/dynamic/Lib.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -6204,7 +6204,7 @@
         "6": "bazel-out/CONFIGURATION-STABLE-0/bin/external/rules_xcodeproj~override~internal~rules_xcodeproj_generated/generator/test/fixtures/xcodeproj_bwb/xcodeproj_bwb-params/watchOS.117.link.params",
         "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-8/bin/Lib/dist/dynamic/watchOS.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-8/bin/Lib/dist/dynamic/Lib.framework",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "Lib.framework",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-8/bin/Lib/dist/dynamic/rules_xcodeproj/watchOS/Info.plist",
@@ -6229,7 +6229,7 @@
             "e": "Lib",
             "m": "Lib",
             "n": "Lib",
-            "p": "bazel-out/CONFIGURATION-STABLE-8/bin/Lib/dist/dynamic/watchOS_archive-root/Lib.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-8/bin/Lib/dist/dynamic/Lib.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -6252,7 +6252,7 @@
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/CONFIGURATION-STABLE-9/bin/Lib/LibFramework.tvOS.framework.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-9/bin/Lib/LibFramework.tvOS.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-9/bin/Lib/LibFramework.tvOS.framework",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "LibFramework.tvOS.framework",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-9/bin/Lib/rules_xcodeproj/LibFramework.tvOS/Info.plist",
@@ -6277,7 +6277,7 @@
             "e": "LibFramework.tvOS",
             "m": "LibFramework.tvOS",
             "n": "LibFramework.tvOS",
-            "p": "bazel-out/CONFIGURATION-STABLE-9/bin/Lib/LibFramework.tvOS_archive-root/LibFramework.tvOS.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-9/bin/Lib/LibFramework.tvOS.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -6312,7 +6312,7 @@
                 "\"bazel-out/CONFIGURATION-STABLE-9/bin/Lib/LibFramework.tvOS.framework.dSYM\"",
                 "\"bazel-out/CONFIGURATION-STABLE-9/bin/UI/UIFramework.tvOS.framework.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-9/bin/UI/UIFramework.tvOS.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-9/bin/UI/UIFramework.tvOS.framework",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "UIFramework.tvOS.framework",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-9/bin/UI/rules_xcodeproj/UIFramework.tvOS/Info.plist",
@@ -6322,7 +6322,7 @@
             "PREVIEWS_SWIFT_INCLUDE__YES": "-I bazel-out/CONFIGURATION-STABLE-9/bin/UI",
             "PREVIEW_FRAMEWORK_PATHS": [
                 "\"$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64/CryptoSwift.framework\"",
-                "\"$(BAZEL_OUT)/CONFIGURATION-STABLE-9/bin/Lib/LibFramework.tvOS.zip\""
+                "\"$(BAZEL_OUT)/CONFIGURATION-STABLE-9/bin/Lib/LibFramework.tvOS.framework\""
             ],
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.UIFramework",
             "PRODUCT_MODULE_NAME": "UI",
@@ -6350,7 +6350,7 @@
             "e": "UIFramework.tvOS",
             "m": "UIFramework.tvOS",
             "n": "UIFramework.tvOS",
-            "p": "bazel-out/CONFIGURATION-STABLE-9/bin/UI/UIFramework.tvOS_archive-root/UIFramework.tvOS.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-9/bin/UI/UIFramework.tvOS.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -6387,7 +6387,7 @@
                 "\"bazel-out/CONFIGURATION-STABLE-9/bin/UI/UIFramework.tvOS.framework.dSYM\"",
                 "\"bazel-out/CONFIGURATION-STABLE-9/bin/tvOSApp/Source/tvOSApp.app.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-9/bin/tvOSApp/Source/tvOSApp.ipa",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-9/bin/tvOSApp/Source/tvOSApp.app",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "tvOSApp.app",
             "CODE_SIGN_STYLE": "Automatic",
             "DEVELOPMENT_TEAM": "V82V4GQZXM",
@@ -6425,7 +6425,7 @@
             "e": "tvOSApp",
             "m": "tvOSApp",
             "n": "tvOSApp",
-            "p": "bazel-out/CONFIGURATION-STABLE-9/bin/tvOSApp/Source/tvOSApp_archive-root/Payload/tvOSApp.app",
+            "p": "bazel-out/CONFIGURATION-STABLE-9/bin/tvOSApp/Source/tvOSApp.app",
             "t": "com.apple.product-type.application"
         }
     },
@@ -6564,7 +6564,7 @@
                 "\"bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Source/iOSApp.app.dSYM\"",
                 "\"bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.xctest.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.__internal__.__test_bundle.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.xctest",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "iOSAppObjCUnitTests.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-7/bin/iOSApp/Test/ObjCUnitTests/rules_xcodeproj/iOSAppObjCUnitTests.__internal__.__test_bundle/Info.plist",
@@ -6595,7 +6595,7 @@
             "e": "iOSAppObjCUnitTests",
             "m": "iOSAppObjCUnitTests",
             "n": "iOSAppObjCUnitTests",
-            "p": "bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.__internal__.__test_bundle_archive-root/iOSAppObjCUnitTests.xctest",
+            "p": "bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         }
     },
@@ -6628,7 +6628,7 @@
                 "\"bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Source/iOSApp.app.dSYM\"",
                 "\"bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Test/UITests/iOSAppUITests.xctest.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Test/UITests/iOSAppUITests.__internal__.__test_bundle.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Test/UITests/iOSAppUITests.xctest",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "iOSAppUITests.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-7/bin/iOSApp/Test/UITests/rules_xcodeproj/iOSAppUITests.__internal__.__test_bundle/Info.plist",
@@ -6662,7 +6662,7 @@
             "e": "iOSAppUITests",
             "m": "iOSAppUITests",
             "n": "iOSAppUITests",
-            "p": "bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Test/UITests/iOSAppUITests.__internal__.__test_bundle_archive-root/iOSAppUITests.xctest",
+            "p": "bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Test/UITests/iOSAppUITests.xctest",
             "t": "com.apple.product-type.bundle.ui-testing"
         }
     },
@@ -6710,7 +6710,7 @@
                 "\"bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Source/iOSApp.app.dSYM\"",
                 "\"bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.xctest.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.__internal__.__test_bundle.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.xctest",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "iOSAppSwiftUnitTests.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-7/bin/iOSApp/Test/SwiftUnitTests/rules_xcodeproj/iOSAppSwiftUnitTests.__internal__.__test_bundle/Info.plist",
@@ -6753,7 +6753,7 @@
             "e": "iOSAppSwiftUnitTests",
             "m": "iOSAppSwiftUnitTests",
             "n": "iOSAppSwiftUnitTests",
-            "p": "bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.__internal__.__test_bundle_archive-root/iOSAppSwiftUnitTests.xctest",
+            "p": "bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         }
     },
@@ -6965,7 +6965,7 @@
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/CONFIGURATION-STABLE-10/bin/AppClip/AppClip.app.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-10/bin/AppClip/AppClip.ipa",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-10/bin/AppClip/AppClip.app",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "AppClip.app",
             "CODE_SIGN_ENTITLEMENTS": "$(BAZEL_OUT)/CONFIGURATION-STABLE-10/bin/AppClip/Entitlements.withbundleid.plist",
             "CODE_SIGN_STYLE": "Manual",
@@ -7005,7 +7005,7 @@
             "e": "AppClip",
             "m": "AppClip",
             "n": "AppClip",
-            "p": "bazel-out/CONFIGURATION-STABLE-10/bin/AppClip/AppClip_archive-root/Payload/AppClip.app",
+            "p": "bazel-out/CONFIGURATION-STABLE-10/bin/AppClip/AppClip.app",
             "t": "com.apple.product-type.application.on-demand-install-capable"
         },
         "x": [
@@ -7104,7 +7104,7 @@
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/CONFIGURATION-STABLE-10/bin/WidgetExtension/WidgetExtension.appex.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-10/bin/WidgetExtension/WidgetExtension.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-10/bin/WidgetExtension/WidgetExtension.appex",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "WidgetExtension.appex",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-10/bin/WidgetExtension/rules_xcodeproj/WidgetExtension/Info.plist",
@@ -7143,7 +7143,7 @@
             "e": "WidgetExtension",
             "m": "WidgetExtension",
             "n": "WidgetExtension",
-            "p": "bazel-out/CONFIGURATION-STABLE-10/bin/WidgetExtension/WidgetExtension_archive-root/WidgetExtension.appex",
+            "p": "bazel-out/CONFIGURATION-STABLE-10/bin/WidgetExtension/WidgetExtension.appex",
             "t": "com.apple.product-type.app-extension"
         },
         "x": [
@@ -7171,7 +7171,7 @@
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Source/CoreUtilsObjC/FrameworkCoreUtilsObjC_dsyms/CoreUtilsObjC.framework.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Source/CoreUtilsObjC/FrameworkCoreUtilsObjC.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Source/CoreUtilsObjC/CoreUtilsObjC.framework",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "CoreUtilsObjC.framework",
             "CODE_SIGN_STYLE": "Manual",
             "GCC_PREFIX_HEADER": "$(SRCROOT)/iOSApp/Source/CoreUtilsObjC/CoreUtils/CoreUtils.pch",
@@ -7202,7 +7202,7 @@
             "e": "CoreUtilsObjC",
             "m": "CoreUtilsObjC",
             "n": "CoreUtilsObjC",
-            "p": "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Source/CoreUtilsObjC/FrameworkCoreUtilsObjC_archive-root/CoreUtilsObjC.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Source/CoreUtilsObjC/CoreUtilsObjC.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -7237,7 +7237,7 @@
                 "\"bazel-out/CONFIGURATION-STABLE-10/bin/Lib/LibFramework.iOS.framework.dSYM\"",
                 "\"bazel-out/CONFIGURATION-STABLE-10/bin/UI/UIFramework.iOS.framework.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-10/bin/UI/UIFramework.iOS.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-10/bin/UI/UIFramework.iOS.framework",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "UIFramework.iOS.framework",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-10/bin/UI/rules_xcodeproj/UIFramework.iOS/Info.plist",
@@ -7247,7 +7247,7 @@
             "PREVIEWS_SWIFT_INCLUDE__YES": "-I bazel-out/CONFIGURATION-STABLE-10/bin/UI",
             "PREVIEW_FRAMEWORK_PATHS": [
                 "\"$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework\"",
-                "\"$(BAZEL_OUT)/CONFIGURATION-STABLE-10/bin/Lib/LibFramework.iOS.zip\""
+                "\"$(BAZEL_OUT)/CONFIGURATION-STABLE-10/bin/Lib/LibFramework.iOS.framework\""
             ],
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.UIFramework",
             "PRODUCT_MODULE_NAME": "UI",
@@ -7279,7 +7279,7 @@
             "e": "UIFramework.iOS",
             "m": "UIFramework.iOS",
             "n": "UIFramework.iOS",
-            "p": "bazel-out/CONFIGURATION-STABLE-10/bin/UI/UIFramework.iOS_archive-root/UIFramework.iOS.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-10/bin/UI/UIFramework.iOS.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -7344,7 +7344,7 @@
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/CONFIGURATION-STABLE-11/bin/Lib/LibFramework.watchOS.framework.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-11/bin/Lib/LibFramework.watchOS.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-11/bin/Lib/LibFramework.watchOS.framework",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "LibFramework.watchOS.framework",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-11/bin/Lib/rules_xcodeproj/LibFramework.watchOS/Info.plist",
@@ -7369,7 +7369,7 @@
             "e": "LibFramework.watchOS",
             "m": "LibFramework.watchOS",
             "n": "LibFramework.watchOS",
-            "p": "bazel-out/CONFIGURATION-STABLE-11/bin/Lib/LibFramework.watchOS_archive-root/LibFramework.watchOS.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-11/bin/Lib/LibFramework.watchOS.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -7407,7 +7407,7 @@
                 "\"bazel-out/CONFIGURATION-STABLE-11/bin/Lib/LibFramework.watchOS.framework.dSYM\"",
                 "\"bazel-out/CONFIGURATION-STABLE-11/bin/UI/UIFramework.watchOS.framework.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-11/bin/UI/UIFramework.watchOS.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-11/bin/UI/UIFramework.watchOS.framework",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "UIFramework.watchOS.framework",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-11/bin/UI/rules_xcodeproj/UIFramework.watchOS/Info.plist",
@@ -7417,7 +7417,7 @@
             "PREVIEWS_SWIFT_INCLUDE__YES": "-I bazel-out/CONFIGURATION-STABLE-11/bin/UI",
             "PREVIEW_FRAMEWORK_PATHS": [
                 "\"$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator/CryptoSwift.framework\"",
-                "\"$(BAZEL_OUT)/CONFIGURATION-STABLE-11/bin/Lib/LibFramework.watchOS.zip\""
+                "\"$(BAZEL_OUT)/CONFIGURATION-STABLE-11/bin/Lib/LibFramework.watchOS.framework\""
             ],
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.UIFramework",
             "PRODUCT_MODULE_NAME": "UI",
@@ -7446,7 +7446,7 @@
             "e": "UIFramework.watchOS",
             "m": "UIFramework.watchOS",
             "n": "UIFramework.watchOS",
-            "p": "bazel-out/CONFIGURATION-STABLE-11/bin/UI/UIFramework.watchOS_archive-root/UIFramework.watchOS.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-11/bin/UI/UIFramework.watchOS.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -7483,7 +7483,7 @@
                 "\"bazel-out/CONFIGURATION-STABLE-11/bin/UI/UIFramework.watchOS.framework.dSYM\"",
                 "\"bazel-out/CONFIGURATION-STABLE-11/bin/watchOSAppExtension/watchOSAppExtension.appex.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-11/bin/watchOSAppExtension/watchOSAppExtension.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-11/bin/watchOSAppExtension/watchOSAppExtension.appex",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "watchOSAppExtension.appex",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-11/bin/watchOSAppExtension/rules_xcodeproj/watchOSAppExtension/Info.plist",
@@ -7520,7 +7520,7 @@
             "e": "watchOSAppExtension",
             "m": "watchOSAppExtension",
             "n": "watchOSAppExtension",
-            "p": "bazel-out/CONFIGURATION-STABLE-11/bin/watchOSAppExtension/watchOSAppExtension_archive-root/watchOSAppExtension.appex",
+            "p": "bazel-out/CONFIGURATION-STABLE-11/bin/watchOSAppExtension/watchOSAppExtension.appex",
             "t": "com.apple.product-type.watchkit2-extension"
         },
         "x": [
@@ -7541,7 +7541,7 @@
         ],
         "b": {
             "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-19/bin/watchOSApp/watchOSApp.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-19/bin/watchOSApp/watchOSApp.app",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "watchOSApp.app",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-19/bin/watchOSApp/rules_xcodeproj/watchOSApp/Info.plist",
@@ -7566,7 +7566,7 @@
             "e": "watchOSApp",
             "m": "watchOSApp",
             "n": "watchOSApp",
-            "p": "bazel-out/CONFIGURATION-STABLE-19/bin/watchOSApp/watchOSApp_archive-root/Payload/watchOSApp.app",
+            "p": "bazel-out/CONFIGURATION-STABLE-19/bin/watchOSApp/watchOSApp.app",
             "t": "com.apple.product-type.application.watchapp2"
         },
         "x": [
@@ -7619,7 +7619,7 @@
                 "\"bazel-out/CONFIGURATION-STABLE-11/bin/watchOSAppExtension/watchOSAppExtension.appex.dSYM\"",
                 "\"bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Source/iOSApp.app.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Source/iOSApp.ipa",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Source/iOSApp.app",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "iOSApp.app",
             "CODE_SIGN_ENTITLEMENTS": "$(SRCROOT)/iOSApp/Source/ios app.entitlements",
             "CODE_SIGN_STYLE": "Manual",
@@ -7673,7 +7673,7 @@
             "e": "iOSApp_ExecutableName",
             "m": "iOSApp",
             "n": "iOSApp",
-            "p": "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Source/iOSApp_archive-root/Payload/iOSApp.app",
+            "p": "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Source/iOSApp.app",
             "t": "com.apple.product-type.application"
         },
         "w": "@@//watchOSApp:watchOSApp CONFIGURATION-STABLE-19",
@@ -7697,7 +7697,7 @@
         "6": "bazel-out/CONFIGURATION-STABLE-0/bin/external/rules_xcodeproj~override~internal~rules_xcodeproj_generated/generator/test/fixtures/xcodeproj_bwb/xcodeproj_bwb-params/iOS.145.link.params",
         "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-10/bin/Lib/dist/dynamic/iOS.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-10/bin/Lib/dist/dynamic/Lib.framework",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "Lib.framework",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-10/bin/Lib/dist/dynamic/rules_xcodeproj/iOS/Info.plist",
@@ -7722,7 +7722,7 @@
             "e": "Lib",
             "m": "Lib",
             "n": "Lib",
-            "p": "bazel-out/CONFIGURATION-STABLE-10/bin/Lib/dist/dynamic/iOS_archive-root/Lib.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-10/bin/Lib/dist/dynamic/Lib.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -7784,7 +7784,7 @@
         "6": "bazel-out/CONFIGURATION-STABLE-0/bin/external/rules_xcodeproj~override~internal~rules_xcodeproj_generated/generator/test/fixtures/xcodeproj_bwb/xcodeproj_bwb-params/tvOS.147.link.params",
         "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-12/bin/Lib/dist/dynamic/tvOS.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-12/bin/Lib/dist/dynamic/Lib.framework",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "Lib.framework",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-12/bin/Lib/dist/dynamic/rules_xcodeproj/tvOS/Info.plist",
@@ -7809,7 +7809,7 @@
             "e": "Lib",
             "m": "Lib",
             "n": "Lib",
-            "p": "bazel-out/CONFIGURATION-STABLE-12/bin/Lib/dist/dynamic/tvOS_archive-root/Lib.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-12/bin/Lib/dist/dynamic/Lib.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -7832,7 +7832,7 @@
         "6": "bazel-out/CONFIGURATION-STABLE-0/bin/external/rules_xcodeproj~override~internal~rules_xcodeproj_generated/generator/test/fixtures/xcodeproj_bwb/xcodeproj_bwb-params/watchOS.148.link.params",
         "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-11/bin/Lib/dist/dynamic/watchOS.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-11/bin/Lib/dist/dynamic/Lib.framework",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "Lib.framework",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-11/bin/Lib/dist/dynamic/rules_xcodeproj/watchOS/Info.plist",
@@ -7857,7 +7857,7 @@
             "e": "Lib",
             "m": "Lib",
             "n": "Lib",
-            "p": "bazel-out/CONFIGURATION-STABLE-11/bin/Lib/dist/dynamic/watchOS_archive-root/Lib.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-11/bin/Lib/dist/dynamic/Lib.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -7883,7 +7883,7 @@
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/CONFIGURATION-STABLE-12/bin/Lib/LibFramework.tvOS.framework.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-12/bin/Lib/LibFramework.tvOS.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-12/bin/Lib/LibFramework.tvOS.framework",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "LibFramework.tvOS.framework",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-12/bin/Lib/rules_xcodeproj/LibFramework.tvOS/Info.plist",
@@ -7908,7 +7908,7 @@
             "e": "LibFramework.tvOS",
             "m": "LibFramework.tvOS",
             "n": "LibFramework.tvOS",
-            "p": "bazel-out/CONFIGURATION-STABLE-12/bin/Lib/LibFramework.tvOS_archive-root/LibFramework.tvOS.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-12/bin/Lib/LibFramework.tvOS.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -7946,7 +7946,7 @@
                 "\"bazel-out/CONFIGURATION-STABLE-12/bin/Lib/LibFramework.tvOS.framework.dSYM\"",
                 "\"bazel-out/CONFIGURATION-STABLE-12/bin/UI/UIFramework.tvOS.framework.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-12/bin/UI/UIFramework.tvOS.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-12/bin/UI/UIFramework.tvOS.framework",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "UIFramework.tvOS.framework",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-12/bin/UI/rules_xcodeproj/UIFramework.tvOS/Info.plist",
@@ -7956,7 +7956,7 @@
             "PREVIEWS_SWIFT_INCLUDE__YES": "-I bazel-out/CONFIGURATION-STABLE-12/bin/UI",
             "PREVIEW_FRAMEWORK_PATHS": [
                 "\"$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator/CryptoSwift.framework\"",
-                "\"$(BAZEL_OUT)/CONFIGURATION-STABLE-12/bin/Lib/LibFramework.tvOS.zip\""
+                "\"$(BAZEL_OUT)/CONFIGURATION-STABLE-12/bin/Lib/LibFramework.tvOS.framework\""
             ],
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.UIFramework",
             "PRODUCT_MODULE_NAME": "UI",
@@ -7985,7 +7985,7 @@
             "e": "UIFramework.tvOS",
             "m": "UIFramework.tvOS",
             "n": "UIFramework.tvOS",
-            "p": "bazel-out/CONFIGURATION-STABLE-12/bin/UI/UIFramework.tvOS_archive-root/UIFramework.tvOS.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-12/bin/UI/UIFramework.tvOS.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -8025,7 +8025,7 @@
                 "\"bazel-out/CONFIGURATION-STABLE-12/bin/UI/UIFramework.tvOS.framework.dSYM\"",
                 "\"bazel-out/CONFIGURATION-STABLE-12/bin/tvOSApp/Source/tvOSApp.app.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-12/bin/tvOSApp/Source/tvOSApp.ipa",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-12/bin/tvOSApp/Source/tvOSApp.app",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "tvOSApp.app",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-12/bin/tvOSApp/Source/rules_xcodeproj/tvOSApp/Info.plist",
@@ -8062,7 +8062,7 @@
             "e": "tvOSApp",
             "m": "tvOSApp",
             "n": "tvOSApp",
-            "p": "bazel-out/CONFIGURATION-STABLE-12/bin/tvOSApp/Source/tvOSApp_archive-root/Payload/tvOSApp.app",
+            "p": "bazel-out/CONFIGURATION-STABLE-12/bin/tvOSApp/Source/tvOSApp.app",
             "t": "com.apple.product-type.application"
         },
         "x": [
@@ -8089,7 +8089,7 @@
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/CONFIGURATION-STABLE-13/bin/Bundle/Bundle_dsyms/ABundle.aplugin.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-13/bin/Bundle/Bundle.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-13/bin/Bundle/ABundle.aplugin",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "ABundle.aplugin",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-13/bin/Bundle/rules_xcodeproj/Bundle/Info.plist",
@@ -8111,7 +8111,7 @@
             "e": "ABundle",
             "m": "ABundle",
             "n": "ABundle",
-            "p": "bazel-out/CONFIGURATION-STABLE-13/bin/Bundle/Bundle_archive-root/ABundle.aplugin",
+            "p": "bazel-out/CONFIGURATION-STABLE-13/bin/Bundle/ABundle.aplugin",
             "t": "com.apple.product-type.bundle"
         },
         "x": [
@@ -8263,7 +8263,7 @@
                 "\"bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Source/iOSApp.app.dSYM\"",
                 "\"bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.xctest.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.__internal__.__test_bundle.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.xctest",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "iOSAppObjCUnitTests.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-10/bin/iOSApp/Test/ObjCUnitTests/rules_xcodeproj/iOSAppObjCUnitTests.__internal__.__test_bundle/Info.plist",
@@ -8294,7 +8294,7 @@
             "e": "iOSAppObjCUnitTests",
             "m": "iOSAppObjCUnitTests",
             "n": "iOSAppObjCUnitTests",
-            "p": "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.__internal__.__test_bundle_archive-root/iOSAppObjCUnitTests.xctest",
+            "p": "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         },
         "x": [
@@ -8330,7 +8330,7 @@
                 "\"bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Source/iOSApp.app.dSYM\"",
                 "\"bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/UITests/iOSAppUITests.xctest.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/UITests/iOSAppUITests.__internal__.__test_bundle.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/UITests/iOSAppUITests.xctest",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "iOSAppUITests.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-10/bin/iOSApp/Test/UITests/rules_xcodeproj/iOSAppUITests.__internal__.__test_bundle/Info.plist",
@@ -8365,7 +8365,7 @@
             "e": "iOSAppUITests",
             "m": "iOSAppUITests",
             "n": "iOSAppUITests",
-            "p": "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/UITests/iOSAppUITests.__internal__.__test_bundle_archive-root/iOSAppUITests.xctest",
+            "p": "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/UITests/iOSAppUITests.xctest",
             "t": "com.apple.product-type.bundle.ui-testing"
         },
         "x": [
@@ -8437,7 +8437,7 @@
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/CONFIGURATION-STABLE-10/bin/iMessageApp/iMessageAppExtension.appex.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-10/bin/iMessageApp/iMessageAppExtension.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-10/bin/iMessageApp/iMessageAppExtension.appex",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "iMessageAppExtension.appex",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-10/bin/iMessageApp/rules_xcodeproj/iMessageAppExtension/Info.plist",
@@ -8476,7 +8476,7 @@
             "e": "iMessageAppExtension",
             "m": "iMessageAppExtension",
             "n": "iMessageAppExtension",
-            "p": "bazel-out/CONFIGURATION-STABLE-10/bin/iMessageApp/iMessageAppExtension_archive-root/iMessageAppExtension.appex",
+            "p": "bazel-out/CONFIGURATION-STABLE-10/bin/iMessageApp/iMessageAppExtension.appex",
             "t": "com.apple.product-type.app-extension.messages"
         },
         "x": [
@@ -8493,7 +8493,7 @@
         },
         "b": {
             "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-10/bin/iMessageApp/iMessageApp.ipa",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-10/bin/iMessageApp/iMessageApp.app",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "iMessageApp.app",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-10/bin/iMessageApp/rules_xcodeproj/iMessageApp/Info.plist",
@@ -8515,7 +8515,7 @@
             "e": "iMessageApp",
             "m": "iMessageApp",
             "n": "iMessageApp",
-            "p": "bazel-out/CONFIGURATION-STABLE-10/bin/iMessageApp/iMessageApp_archive-root/Payload/iMessageApp.app",
+            "p": "bazel-out/CONFIGURATION-STABLE-10/bin/iMessageApp/iMessageApp.app",
             "t": "com.apple.product-type.application.messages"
         },
         "x": [
@@ -8566,7 +8566,7 @@
                 "\"bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Source/iOSApp.app.dSYM\"",
                 "\"bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.xctest.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.__internal__.__test_bundle.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.xctest",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "iOSAppSwiftUnitTests.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-10/bin/iOSApp/Test/SwiftUnitTests/rules_xcodeproj/iOSAppSwiftUnitTests.__internal__.__test_bundle/Info.plist",
@@ -8610,7 +8610,7 @@
             "e": "iOSAppSwiftUnitTests",
             "m": "iOSAppSwiftUnitTests",
             "n": "iOSAppSwiftUnitTests",
-            "p": "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.__internal__.__test_bundle_archive-root/iOSAppSwiftUnitTests.xctest",
+            "p": "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         },
         "x": [
@@ -8672,7 +8672,7 @@
         "6": "bazel-out/CONFIGURATION-STABLE-0/bin/external/rules_xcodeproj~override~internal~rules_xcodeproj_generated/generator/test/fixtures/xcodeproj_bwb/xcodeproj_bwb-params/macOSLib.framework.163.link.params",
         "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-13/bin/macOSApp/Source/macOSLib.framework.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-13/bin/macOSApp/Source/Lib.framework",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "Lib.framework",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-13/bin/macOSApp/Source/rules_xcodeproj/macOSLib.framework/Info.plist",
@@ -8696,7 +8696,7 @@
             "e": "Lib",
             "m": "Lib",
             "n": "Lib",
-            "p": "bazel-out/CONFIGURATION-STABLE-13/bin/macOSApp/Source/macOSLib.framework_archive-root/Lib.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-13/bin/macOSApp/Source/Lib.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -8735,7 +8735,7 @@
                 "\"bazel-out/CONFIGURATION-STABLE-13/bin/macOSApp/Source/macOSLib.framework_dsyms/Lib.framework.dSYM\"",
                 "\"bazel-out/CONFIGURATION-STABLE-13/bin/macOSApp/Source/macOSApp.app.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-13/bin/macOSApp/Source/macOSApp.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-13/bin/macOSApp/Source/macOSApp.app",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "macOSApp.app",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-13/bin/macOSApp/Source/rules_xcodeproj/macOSApp/Info.plist",
@@ -8772,7 +8772,7 @@
             "e": "macOSApp",
             "m": "macOSApp",
             "n": "macOSApp",
-            "p": "bazel-out/CONFIGURATION-STABLE-13/bin/macOSApp/Source/macOSApp_archive-root/Payload/macOSApp.app",
+            "p": "bazel-out/CONFIGURATION-STABLE-13/bin/macOSApp/Source/macOSApp.app",
             "t": "com.apple.product-type.application"
         },
         "x": [
@@ -8801,7 +8801,7 @@
                 "\"bazel-out/CONFIGURATION-STABLE-13/bin/macOSApp/Source/macOSApp.app.dSYM\"",
                 "\"bazel-out/CONFIGURATION-STABLE-13/bin/macOSApp/Test/UITests/macOSAppUITests.xctest.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-13/bin/macOSApp/Test/UITests/macOSAppUITests.__internal__.__test_bundle.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-13/bin/macOSApp/Test/UITests/macOSAppUITests.xctest",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "macOSAppUITests.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-13/bin/macOSApp/Test/UITests/rules_xcodeproj/macOSAppUITests.__internal__.__test_bundle/Info.plist",
@@ -8835,7 +8835,7 @@
             "e": "macOSAppUITests",
             "m": "macOSAppUITests",
             "n": "macOSAppUITests",
-            "p": "bazel-out/CONFIGURATION-STABLE-13/bin/macOSApp/Test/UITests/macOSAppUITests.__internal__.__test_bundle_archive-root/macOSAppUITests.xctest",
+            "p": "bazel-out/CONFIGURATION-STABLE-13/bin/macOSApp/Test/UITests/macOSAppUITests.xctest",
             "t": "com.apple.product-type.bundle.ui-testing"
         },
         "x": [
@@ -8865,7 +8865,7 @@
                 "\"bazel-out/CONFIGURATION-STABLE-12/bin/tvOSApp/Source/tvOSApp.app.dSYM\"",
                 "\"bazel-out/CONFIGURATION-STABLE-12/bin/tvOSApp/Test/UITests/tvOSAppUITests.xctest.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-12/bin/tvOSApp/Test/UITests/tvOSAppUITests.__internal__.__test_bundle.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-12/bin/tvOSApp/Test/UITests/tvOSAppUITests.xctest",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "tvOSAppUITests.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-12/bin/tvOSApp/Test/UITests/rules_xcodeproj/tvOSAppUITests.__internal__.__test_bundle/Info.plist",
@@ -8900,7 +8900,7 @@
             "e": "tvOSAppUITests",
             "m": "tvOSAppUITests",
             "n": "tvOSAppUITests",
-            "p": "bazel-out/CONFIGURATION-STABLE-12/bin/tvOSApp/Test/UITests/tvOSAppUITests.__internal__.__test_bundle_archive-root/tvOSAppUITests.xctest",
+            "p": "bazel-out/CONFIGURATION-STABLE-12/bin/tvOSApp/Test/UITests/tvOSAppUITests.xctest",
             "t": "com.apple.product-type.bundle.ui-testing"
         },
         "x": [
@@ -8942,7 +8942,7 @@
                 "\"bazel-out/CONFIGURATION-STABLE-12/bin/tvOSApp/Source/tvOSApp.app.dSYM\"",
                 "\"bazel-out/CONFIGURATION-STABLE-12/bin/tvOSApp/Test/UnitTests/tvOSAppUnitTests.xctest.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-12/bin/tvOSApp/Test/UnitTests/tvOSAppUnitTests.__internal__.__test_bundle.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-12/bin/tvOSApp/Test/UnitTests/tvOSAppUnitTests.xctest",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "tvOSAppUnitTests.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-12/bin/tvOSApp/Test/UnitTests/rules_xcodeproj/tvOSAppUnitTests.__internal__.__test_bundle/Info.plist",
@@ -8980,7 +8980,7 @@
             "e": "tvOSAppUnitTests",
             "m": "tvOSAppUnitTests",
             "n": "tvOSAppUnitTests",
-            "p": "bazel-out/CONFIGURATION-STABLE-12/bin/tvOSApp/Test/UnitTests/tvOSAppUnitTests.__internal__.__test_bundle_archive-root/tvOSAppUnitTests.xctest",
+            "p": "bazel-out/CONFIGURATION-STABLE-12/bin/tvOSApp/Test/UnitTests/tvOSAppUnitTests.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         },
         "x": [
@@ -9010,7 +9010,7 @@
                 "\"bazel-out/CONFIGURATION-STABLE-11/bin/watchOSAppExtension/watchOSAppExtension.appex.dSYM\"",
                 "\"bazel-out/CONFIGURATION-STABLE-11/bin/watchOSApp/Test/UITests/watchOSAppUITests.xctest.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-11/bin/watchOSApp/Test/UITests/watchOSAppUITests.__internal__.__test_bundle.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-11/bin/watchOSApp/Test/UITests/watchOSAppUITests.xctest",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "watchOSAppUITests.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-11/bin/watchOSApp/Test/UITests/rules_xcodeproj/watchOSAppUITests.__internal__.__test_bundle/Info.plist",
@@ -9045,7 +9045,7 @@
             "e": "watchOSAppUITests",
             "m": "watchOSAppUITests",
             "n": "watchOSAppUITests",
-            "p": "bazel-out/CONFIGURATION-STABLE-11/bin/watchOSApp/Test/UITests/watchOSAppUITests.__internal__.__test_bundle_archive-root/watchOSAppUITests.xctest",
+            "p": "bazel-out/CONFIGURATION-STABLE-11/bin/watchOSApp/Test/UITests/watchOSAppUITests.xctest",
             "t": "com.apple.product-type.bundle.ui-testing"
         },
         "x": [
@@ -9083,7 +9083,7 @@
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/CONFIGURATION-STABLE-11/bin/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTests.xctest.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-11/bin/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTests.__internal__.__test_bundle.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-11/bin/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTests.xctest",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "watchOSAppExtensionUnitTests.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-11/bin/watchOSAppExtension/Test/UnitTests/rules_xcodeproj/watchOSAppExtensionUnitTests.__internal__.__test_bundle/Info.plist",
@@ -9117,7 +9117,7 @@
             "e": "watchOSAppExtensionUnitTests",
             "m": "watchOSAppExtensionUnitTests",
             "n": "watchOSAppExtensionUnitTests",
-            "p": "bazel-out/CONFIGURATION-STABLE-11/bin/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTests.__internal__.__test_bundle_archive-root/watchOSAppExtensionUnitTests.xctest",
+            "p": "bazel-out/CONFIGURATION-STABLE-11/bin/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTests.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         },
         "x": [
@@ -9153,7 +9153,7 @@
                 "\"bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Source/iOSApp.app.dSYM\"",
                 "\"bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/UITests/iOSAppUITestSuite.xctest.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/UITests/iOSAppUITestSuite.__internal__.__test_bundle.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/UITests/iOSAppUITestSuite.xctest",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "iOSAppUITestSuite.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-10/bin/iOSApp/Test/UITests/rules_xcodeproj/iOSAppUITestSuite.__internal__.__test_bundle/Info.plist",
@@ -9188,7 +9188,7 @@
             "e": "iOSAppUITestSuite",
             "m": "iOSAppUITestSuite",
             "n": "iOSAppUITestSuite",
-            "p": "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/UITests/iOSAppUITestSuite.__internal__.__test_bundle_archive-root/iOSAppUITestSuite.xctest",
+            "p": "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/UITests/iOSAppUITestSuite.xctest",
             "t": "com.apple.product-type.bundle.ui-testing"
         },
         "x": [
@@ -9239,7 +9239,7 @@
                 "\"bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Source/iOSApp.app.dSYM\"",
                 "\"bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTestSuite.xctest.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTestSuite.__internal__.__test_bundle.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTestSuite.xctest",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "iOSAppObjCUnitTestSuite.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-10/bin/iOSApp/Test/ObjCUnitTests/rules_xcodeproj/iOSAppObjCUnitTestSuite.__internal__.__test_bundle/Info.plist",
@@ -9270,7 +9270,7 @@
             "e": "iOSAppObjCUnitTestSuite",
             "m": "iOSAppObjCUnitTestSuite",
             "n": "iOSAppObjCUnitTestSuite",
-            "p": "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTestSuite.__internal__.__test_bundle_archive-root/iOSAppObjCUnitTestSuite.xctest",
+            "p": "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTestSuite.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         },
         "x": [
@@ -9321,7 +9321,7 @@
                 "\"bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Source/iOSApp.app.dSYM\"",
                 "\"bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTestSuite.xctest.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTestSuite.__internal__.__test_bundle.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTestSuite.xctest",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "iOSAppSwiftUnitTestSuite.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-10/bin/iOSApp/Test/SwiftUnitTests/rules_xcodeproj/iOSAppSwiftUnitTestSuite.__internal__.__test_bundle/Info.plist",
@@ -9365,7 +9365,7 @@
             "e": "iOSAppSwiftUnitTestSuite",
             "m": "iOSAppSwiftUnitTestSuite",
             "n": "iOSAppSwiftUnitTestSuite",
-            "p": "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTestSuite.__internal__.__test_bundle_archive-root/iOSAppSwiftUnitTestSuite.xctest",
+            "p": "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTestSuite.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         },
         "x": [
@@ -12389,7 +12389,7 @@
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/CONFIGURATION-STABLE-26/bin/CommandLine/Tests/CommandLineToolTests.xctest.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-26/bin/CommandLine/Tests/CommandLineToolTests.__internal__.__test_bundle.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-26/bin/CommandLine/Tests/CommandLineToolTests.xctest",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "CommandLineToolTests.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-26/bin/CommandLine/Tests/rules_xcodeproj/CommandLineToolTests.__internal__.__test_bundle/Info.plist",
@@ -12423,7 +12423,7 @@
             "e": "CommandLineToolTests",
             "m": "CommandLineToolTests",
             "n": "CommandLineToolTests",
-            "p": "bazel-out/CONFIGURATION-STABLE-26/bin/CommandLine/Tests/CommandLineToolTests.__internal__.__test_bundle_archive-root/CommandLineToolTests.xctest",
+            "p": "bazel-out/CONFIGURATION-STABLE-26/bin/CommandLine/Tests/CommandLineToolTests.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         },
         "x": [
@@ -12495,7 +12495,7 @@
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/CONFIGURATION-STABLE-14/bin/AppClip/AppClip.app.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-14/bin/AppClip/AppClip.ipa",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-14/bin/AppClip/AppClip.app",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "AppClip.app",
             "CODE_SIGN_ENTITLEMENTS": "$(BAZEL_OUT)/CONFIGURATION-STABLE-14/bin/AppClip/Entitlements.withbundleid.plist",
             "CODE_SIGN_STYLE": "Automatic",
@@ -12536,7 +12536,7 @@
             "e": "AppClip",
             "m": "AppClip",
             "n": "AppClip",
-            "p": "bazel-out/CONFIGURATION-STABLE-14/bin/AppClip/AppClip_archive-root/Payload/AppClip.app",
+            "p": "bazel-out/CONFIGURATION-STABLE-14/bin/AppClip/AppClip.app",
             "t": "com.apple.product-type.application.on-demand-install-capable"
         },
         "x": [
@@ -12635,7 +12635,7 @@
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/CONFIGURATION-STABLE-14/bin/WidgetExtension/WidgetExtension.appex.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-14/bin/WidgetExtension/WidgetExtension.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-14/bin/WidgetExtension/WidgetExtension.appex",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "WidgetExtension.appex",
             "CODE_SIGN_STYLE": "Automatic",
             "DEVELOPMENT_TEAM": "V82V4GQZXM",
@@ -12675,7 +12675,7 @@
             "e": "WidgetExtension",
             "m": "WidgetExtension",
             "n": "WidgetExtension",
-            "p": "bazel-out/CONFIGURATION-STABLE-14/bin/WidgetExtension/WidgetExtension_archive-root/WidgetExtension.appex",
+            "p": "bazel-out/CONFIGURATION-STABLE-14/bin/WidgetExtension/WidgetExtension.appex",
             "t": "com.apple.product-type.app-extension"
         },
         "x": [
@@ -12703,7 +12703,7 @@
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Source/CoreUtilsObjC/FrameworkCoreUtilsObjC_dsyms/CoreUtilsObjC.framework.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Source/CoreUtilsObjC/FrameworkCoreUtilsObjC.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Source/CoreUtilsObjC/CoreUtilsObjC.framework",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "CoreUtilsObjC.framework",
             "CODE_SIGN_STYLE": "Manual",
             "GCC_PREFIX_HEADER": "$(SRCROOT)/iOSApp/Source/CoreUtilsObjC/CoreUtils/CoreUtils.pch",
@@ -12734,7 +12734,7 @@
             "e": "CoreUtilsObjC",
             "m": "CoreUtilsObjC",
             "n": "CoreUtilsObjC",
-            "p": "bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Source/CoreUtilsObjC/FrameworkCoreUtilsObjC_archive-root/CoreUtilsObjC.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Source/CoreUtilsObjC/CoreUtilsObjC.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -12769,7 +12769,7 @@
                 "\"bazel-out/CONFIGURATION-STABLE-14/bin/Lib/LibFramework.iOS.framework.dSYM\"",
                 "\"bazel-out/CONFIGURATION-STABLE-14/bin/UI/UIFramework.iOS.framework.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-14/bin/UI/UIFramework.iOS.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-14/bin/UI/UIFramework.iOS.framework",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "UIFramework.iOS.framework",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-14/bin/UI/rules_xcodeproj/UIFramework.iOS/Info.plist",
@@ -12779,7 +12779,7 @@
             "PREVIEWS_SWIFT_INCLUDE__YES": "-I bazel-out/CONFIGURATION-STABLE-14/bin/UI",
             "PREVIEW_FRAMEWORK_PATHS": [
                 "\"$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework\"",
-                "\"$(BAZEL_OUT)/CONFIGURATION-STABLE-14/bin/Lib/LibFramework.iOS.zip\""
+                "\"$(BAZEL_OUT)/CONFIGURATION-STABLE-14/bin/Lib/LibFramework.iOS.framework\""
             ],
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.UIFramework",
             "PRODUCT_MODULE_NAME": "UI",
@@ -12811,7 +12811,7 @@
             "e": "UIFramework.iOS",
             "m": "UIFramework.iOS",
             "n": "UIFramework.iOS",
-            "p": "bazel-out/CONFIGURATION-STABLE-14/bin/UI/UIFramework.iOS_archive-root/UIFramework.iOS.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-14/bin/UI/UIFramework.iOS.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -12876,7 +12876,7 @@
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/CONFIGURATION-STABLE-15/bin/Lib/LibFramework.watchOS.framework.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-15/bin/Lib/LibFramework.watchOS.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-15/bin/Lib/LibFramework.watchOS.framework",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "LibFramework.watchOS.framework",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-15/bin/Lib/rules_xcodeproj/LibFramework.watchOS/Info.plist",
@@ -12901,7 +12901,7 @@
             "e": "LibFramework.watchOS",
             "m": "LibFramework.watchOS",
             "n": "LibFramework.watchOS",
-            "p": "bazel-out/CONFIGURATION-STABLE-15/bin/Lib/LibFramework.watchOS_archive-root/LibFramework.watchOS.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-15/bin/Lib/LibFramework.watchOS.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -12939,7 +12939,7 @@
                 "\"bazel-out/CONFIGURATION-STABLE-15/bin/Lib/LibFramework.watchOS.framework.dSYM\"",
                 "\"bazel-out/CONFIGURATION-STABLE-15/bin/UI/UIFramework.watchOS.framework.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-15/bin/UI/UIFramework.watchOS.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-15/bin/UI/UIFramework.watchOS.framework",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "UIFramework.watchOS.framework",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-15/bin/UI/rules_xcodeproj/UIFramework.watchOS/Info.plist",
@@ -12949,7 +12949,7 @@
             "PREVIEWS_SWIFT_INCLUDE__YES": "-I bazel-out/CONFIGURATION-STABLE-15/bin/UI",
             "PREVIEW_FRAMEWORK_PATHS": [
                 "\"$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k/CryptoSwift.framework\"",
-                "\"$(BAZEL_OUT)/CONFIGURATION-STABLE-15/bin/Lib/LibFramework.watchOS.zip\""
+                "\"$(BAZEL_OUT)/CONFIGURATION-STABLE-15/bin/Lib/LibFramework.watchOS.framework\""
             ],
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.UIFramework",
             "PRODUCT_MODULE_NAME": "UI",
@@ -12978,7 +12978,7 @@
             "e": "UIFramework.watchOS",
             "m": "UIFramework.watchOS",
             "n": "UIFramework.watchOS",
-            "p": "bazel-out/CONFIGURATION-STABLE-15/bin/UI/UIFramework.watchOS_archive-root/UIFramework.watchOS.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-15/bin/UI/UIFramework.watchOS.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -13015,7 +13015,7 @@
                 "\"bazel-out/CONFIGURATION-STABLE-15/bin/UI/UIFramework.watchOS.framework.dSYM\"",
                 "\"bazel-out/CONFIGURATION-STABLE-15/bin/watchOSAppExtension/watchOSAppExtension.appex.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-15/bin/watchOSAppExtension/watchOSAppExtension.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-15/bin/watchOSAppExtension/watchOSAppExtension.appex",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "watchOSAppExtension.appex",
             "CODE_SIGN_STYLE": "Automatic",
             "DEVELOPMENT_TEAM": "V82V4GQZXM",
@@ -13053,7 +13053,7 @@
             "e": "watchOSAppExtension",
             "m": "watchOSAppExtension",
             "n": "watchOSAppExtension",
-            "p": "bazel-out/CONFIGURATION-STABLE-15/bin/watchOSAppExtension/watchOSAppExtension_archive-root/watchOSAppExtension.appex",
+            "p": "bazel-out/CONFIGURATION-STABLE-15/bin/watchOSAppExtension/watchOSAppExtension.appex",
             "t": "com.apple.product-type.watchkit2-extension"
         },
         "x": [
@@ -13074,7 +13074,7 @@
         ],
         "b": {
             "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-20/bin/watchOSApp/watchOSApp.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-20/bin/watchOSApp/watchOSApp.app",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "watchOSApp.app",
             "CODE_SIGN_STYLE": "Automatic",
             "DEVELOPMENT_TEAM": "V82V4GQZXM",
@@ -13100,7 +13100,7 @@
             "e": "watchOSApp",
             "m": "watchOSApp",
             "n": "watchOSApp",
-            "p": "bazel-out/CONFIGURATION-STABLE-20/bin/watchOSApp/watchOSApp_archive-root/Payload/watchOSApp.app",
+            "p": "bazel-out/CONFIGURATION-STABLE-20/bin/watchOSApp/watchOSApp.app",
             "t": "com.apple.product-type.application.watchapp2"
         },
         "x": [
@@ -13153,7 +13153,7 @@
                 "\"bazel-out/CONFIGURATION-STABLE-15/bin/watchOSAppExtension/watchOSAppExtension.appex.dSYM\"",
                 "\"bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Source/iOSApp.app.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Source/iOSApp.ipa",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Source/iOSApp.app",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "iOSApp.app",
             "CODE_SIGN_ENTITLEMENTS": "$(SRCROOT)/iOSApp/Source/ios app.entitlements",
             "CODE_SIGN_STYLE": "Automatic",
@@ -13208,7 +13208,7 @@
             "e": "iOSApp",
             "m": "iOSApp",
             "n": "iOSApp",
-            "p": "bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Source/iOSApp_archive-root/Payload/iOSApp.app",
+            "p": "bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Source/iOSApp.app",
             "t": "com.apple.product-type.application"
         },
         "w": "@@//watchOSApp:watchOSApp CONFIGURATION-STABLE-20",
@@ -13232,7 +13232,7 @@
         "6": "bazel-out/CONFIGURATION-STABLE-0/bin/external/rules_xcodeproj~override~internal~rules_xcodeproj_generated/generator/test/fixtures/xcodeproj_bwb/xcodeproj_bwb-params/iOS.241.link.params",
         "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-14/bin/Lib/dist/dynamic/iOS.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-14/bin/Lib/dist/dynamic/Lib.framework",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "Lib.framework",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-14/bin/Lib/dist/dynamic/rules_xcodeproj/iOS/Info.plist",
@@ -13257,7 +13257,7 @@
             "e": "Lib",
             "m": "Lib",
             "n": "Lib",
-            "p": "bazel-out/CONFIGURATION-STABLE-14/bin/Lib/dist/dynamic/iOS_archive-root/Lib.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-14/bin/Lib/dist/dynamic/Lib.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -13319,7 +13319,7 @@
         "6": "bazel-out/CONFIGURATION-STABLE-0/bin/external/rules_xcodeproj~override~internal~rules_xcodeproj_generated/generator/test/fixtures/xcodeproj_bwb/xcodeproj_bwb-params/tvOS.243.link.params",
         "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-16/bin/Lib/dist/dynamic/tvOS.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-16/bin/Lib/dist/dynamic/Lib.framework",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "Lib.framework",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-16/bin/Lib/dist/dynamic/rules_xcodeproj/tvOS/Info.plist",
@@ -13344,7 +13344,7 @@
             "e": "Lib",
             "m": "Lib",
             "n": "Lib",
-            "p": "bazel-out/CONFIGURATION-STABLE-16/bin/Lib/dist/dynamic/tvOS_archive-root/Lib.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-16/bin/Lib/dist/dynamic/Lib.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -13367,7 +13367,7 @@
         "6": "bazel-out/CONFIGURATION-STABLE-0/bin/external/rules_xcodeproj~override~internal~rules_xcodeproj_generated/generator/test/fixtures/xcodeproj_bwb/xcodeproj_bwb-params/watchOS.244.link.params",
         "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-15/bin/Lib/dist/dynamic/watchOS.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-15/bin/Lib/dist/dynamic/Lib.framework",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "Lib.framework",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-15/bin/Lib/dist/dynamic/rules_xcodeproj/watchOS/Info.plist",
@@ -13392,7 +13392,7 @@
             "e": "Lib",
             "m": "Lib",
             "n": "Lib",
-            "p": "bazel-out/CONFIGURATION-STABLE-15/bin/Lib/dist/dynamic/watchOS_archive-root/Lib.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-15/bin/Lib/dist/dynamic/Lib.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -13418,7 +13418,7 @@
             "BAZEL_OUTPUTS_DSYM": [
                 "\"bazel-out/CONFIGURATION-STABLE-16/bin/Lib/LibFramework.tvOS.framework.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-16/bin/Lib/LibFramework.tvOS.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-16/bin/Lib/LibFramework.tvOS.framework",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "LibFramework.tvOS.framework",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-16/bin/Lib/rules_xcodeproj/LibFramework.tvOS/Info.plist",
@@ -13443,7 +13443,7 @@
             "e": "LibFramework.tvOS",
             "m": "LibFramework.tvOS",
             "n": "LibFramework.tvOS",
-            "p": "bazel-out/CONFIGURATION-STABLE-16/bin/Lib/LibFramework.tvOS_archive-root/LibFramework.tvOS.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-16/bin/Lib/LibFramework.tvOS.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -13481,7 +13481,7 @@
                 "\"bazel-out/CONFIGURATION-STABLE-16/bin/Lib/LibFramework.tvOS.framework.dSYM\"",
                 "\"bazel-out/CONFIGURATION-STABLE-16/bin/UI/UIFramework.tvOS.framework.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-16/bin/UI/UIFramework.tvOS.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-16/bin/UI/UIFramework.tvOS.framework",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "UIFramework.tvOS.framework",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-16/bin/UI/rules_xcodeproj/UIFramework.tvOS/Info.plist",
@@ -13491,7 +13491,7 @@
             "PREVIEWS_SWIFT_INCLUDE__YES": "-I bazel-out/CONFIGURATION-STABLE-16/bin/UI",
             "PREVIEW_FRAMEWORK_PATHS": [
                 "\"$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64/CryptoSwift.framework\"",
-                "\"$(BAZEL_OUT)/CONFIGURATION-STABLE-16/bin/Lib/LibFramework.tvOS.zip\""
+                "\"$(BAZEL_OUT)/CONFIGURATION-STABLE-16/bin/Lib/LibFramework.tvOS.framework\""
             ],
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.UIFramework",
             "PRODUCT_MODULE_NAME": "UI",
@@ -13520,7 +13520,7 @@
             "e": "UIFramework.tvOS",
             "m": "UIFramework.tvOS",
             "n": "UIFramework.tvOS",
-            "p": "bazel-out/CONFIGURATION-STABLE-16/bin/UI/UIFramework.tvOS_archive-root/UIFramework.tvOS.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-16/bin/UI/UIFramework.tvOS.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -13560,7 +13560,7 @@
                 "\"bazel-out/CONFIGURATION-STABLE-16/bin/UI/UIFramework.tvOS.framework.dSYM\"",
                 "\"bazel-out/CONFIGURATION-STABLE-16/bin/tvOSApp/Source/tvOSApp.app.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-16/bin/tvOSApp/Source/tvOSApp.ipa",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-16/bin/tvOSApp/Source/tvOSApp.app",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "tvOSApp.app",
             "CODE_SIGN_STYLE": "Automatic",
             "DEVELOPMENT_TEAM": "V82V4GQZXM",
@@ -13598,7 +13598,7 @@
             "e": "tvOSApp",
             "m": "tvOSApp",
             "n": "tvOSApp",
-            "p": "bazel-out/CONFIGURATION-STABLE-16/bin/tvOSApp/Source/tvOSApp_archive-root/Payload/tvOSApp.app",
+            "p": "bazel-out/CONFIGURATION-STABLE-16/bin/tvOSApp/Source/tvOSApp.app",
             "t": "com.apple.product-type.application"
         },
         "x": [
@@ -13750,7 +13750,7 @@
                 "\"bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Source/iOSApp.app.dSYM\"",
                 "\"bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.xctest.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.__internal__.__test_bundle.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.xctest",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "iOSAppObjCUnitTests.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-14/bin/iOSApp/Test/ObjCUnitTests/rules_xcodeproj/iOSAppObjCUnitTests.__internal__.__test_bundle/Info.plist",
@@ -13781,7 +13781,7 @@
             "e": "iOSAppObjCUnitTests",
             "m": "iOSAppObjCUnitTests",
             "n": "iOSAppObjCUnitTests",
-            "p": "bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.__internal__.__test_bundle_archive-root/iOSAppObjCUnitTests.xctest",
+            "p": "bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         },
         "x": [
@@ -13817,7 +13817,7 @@
                 "\"bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Source/iOSApp.app.dSYM\"",
                 "\"bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Test/UITests/iOSAppUITests.xctest.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Test/UITests/iOSAppUITests.__internal__.__test_bundle.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Test/UITests/iOSAppUITests.xctest",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "iOSAppUITests.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-14/bin/iOSApp/Test/UITests/rules_xcodeproj/iOSAppUITests.__internal__.__test_bundle/Info.plist",
@@ -13852,7 +13852,7 @@
             "e": "iOSAppUITests",
             "m": "iOSAppUITests",
             "n": "iOSAppUITests",
-            "p": "bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Test/UITests/iOSAppUITests.__internal__.__test_bundle_archive-root/iOSAppUITests.xctest",
+            "p": "bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Test/UITests/iOSAppUITests.xctest",
             "t": "com.apple.product-type.bundle.ui-testing"
         },
         "x": [
@@ -13903,7 +13903,7 @@
                 "\"bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Source/iOSApp.app.dSYM\"",
                 "\"bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.xctest.dSYM\""
             ],
-            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.__internal__.__test_bundle.zip",
+            "BAZEL_OUTPUTS_PRODUCT": "bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.xctest",
             "BAZEL_OUTPUTS_PRODUCT_BASENAME": "iOSAppSwiftUnitTests.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "INFOPLIST_FILE": "$(BAZEL_OUT)/CONFIGURATION-STABLE-14/bin/iOSApp/Test/SwiftUnitTests/rules_xcodeproj/iOSAppSwiftUnitTests.__internal__.__test_bundle/Info.plist",
@@ -13947,7 +13947,7 @@
             "e": "iOSAppSwiftUnitTests",
             "m": "iOSAppSwiftUnitTests",
             "n": "iOSAppSwiftUnitTests",
-            "p": "bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.__internal__.__test_bundle_archive-root/iOSAppSwiftUnitTests.xctest",
+            "p": "bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         },
         "x": [

--- a/examples/integration/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -23222,8 +23222,8 @@
 				"OTHER_SWIFT_FLAGS[sdk=iphoneos*]" = "-Xcc -ivfsoverlay -Xcc $(DERIVED_FILE_DIR)/xcode-overlay.yaml -Xcc -ivfsoverlay -Xcc $(OBJROOT)/bazel-out-overlay.yaml -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml $(PREVIEWS_SWIFT_INCLUDE__$(ENABLE_PREVIEWS)) @$(DERIVED_FILE_DIR)/swift.compile.params -F$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7 -Xcc -F -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7 -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(BAZEL_OUT)/CONFIGURATION-STABLE-14/bin/external/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(PROJECT_DIR) -Xcc -iquote -Xcc $(BAZEL_OUT)/CONFIGURATION-STABLE-14/bin -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework/Modules/module.modulemap -Xcc -Os -Xcc -DNDEBUG=1 -Xcc -Wno-unused-variable -Xcc -Winit-self -Xcc -Wno-extra";
 				PREVIEWS_SWIFT_INCLUDE__ = "";
 				PREVIEWS_SWIFT_INCLUDE__NO = "";
-				PREVIEWS_SWIFT_INCLUDE__YES = "-I $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-10/bin/UI/UIFramework.iOS.zip/Modules";
-				"PREVIEWS_SWIFT_INCLUDE__YES[sdk=iphoneos*]" = "-I $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-14/bin/UI/UIFramework.iOS.zip/Modules";
+				PREVIEWS_SWIFT_INCLUDE__YES = "-I $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-10/bin/UI/UIFramework.iOS.framework/Modules";
+				"PREVIEWS_SWIFT_INCLUDE__YES[sdk=iphoneos*]" = "-I $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-14/bin/UI/UIFramework.iOS.framework/Modules";
 				PRODUCT_BUNDLE_IDENTIFIER = "rules-xcodeproj.UIFramework";
 				PRODUCT_MODULE_NAME = UI;
 				PRODUCT_NAME = UIFramework.iOS;
@@ -23484,8 +23484,8 @@
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-10/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-10/bin/UI/UIFramework.iOS.zip/Modules $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer";
-				"SWIFT_INCLUDE_PATHS[sdk=iphoneos*]" = "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-14/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-14/bin/UI/UIFramework.iOS.zip/Modules $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer";
+				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-10/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-10/bin/UI/UIFramework.iOS.framework/Modules $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer";
+				"SWIFT_INCLUDE_PATHS[sdk=iphoneos*]" = "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-14/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-14/bin/UI/UIFramework.iOS.framework/Modules $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer";
 				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/CONFIGURATION-STABLE-10/bin/iOSApp/Source/iOSApp.library.rules_xcodeproj.swift.compile.params";
 				"SWIFT_PARAMS_FILE[sdk=iphoneos*]" = "$(BAZEL_OUT)/CONFIGURATION-STABLE-14/bin/iOSApp/Source/iOSApp.library.rules_xcodeproj.swift.compile.params";
 				TARGETED_DEVICE_FAMILY = 1;
@@ -23836,7 +23836,7 @@
 				PRODUCT_NAME = watchOSAppExtensionUnitTests;
 				SDKROOT = watchos;
 				SUPPORTED_PLATFORMS = watchsimulator;
-				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-4/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-4/bin/UI/UIFramework.watchOS.zip/Modules";
+				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-4/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-4/bin/UI/UIFramework.watchOS.framework/Modules";
 				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/CONFIGURATION-STABLE-4/bin/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTests.library.rules_xcodeproj.swift.compile.params";
 				TARGETED_DEVICE_FAMILY = 4;
 				TARGET_NAME = watchOSAppExtensionUnitTests;
@@ -23888,8 +23888,8 @@
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-10/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-10/bin/UI/UIFramework.iOS.zip/Modules $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Source $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/TestingUtils";
-				"SWIFT_INCLUDE_PATHS[sdk=iphoneos*]" = "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-14/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-14/bin/UI/UIFramework.iOS.zip/Modules $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Source $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Test/TestingUtils";
+				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-10/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-10/bin/UI/UIFramework.iOS.framework/Modules $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Source $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/TestingUtils";
+				"SWIFT_INCLUDE_PATHS[sdk=iphoneos*]" = "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-14/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-14/bin/UI/UIFramework.iOS.framework/Modules $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Source $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Test/TestingUtils";
 				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/CONFIGURATION-STABLE-10/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.library.rules_xcodeproj.swift.compile.params";
 				"SWIFT_PARAMS_FILE[sdk=iphoneos*]" = "$(BAZEL_OUT)/CONFIGURATION-STABLE-14/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.library.rules_xcodeproj.swift.compile.params";
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -23929,7 +23929,7 @@
 				SDKROOT = watchos;
 				SUPPORTED_PLATFORMS = watchsimulator;
 				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-11/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-11/bin/UI/UIFramework.watchOS.zip/Modules";
+				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-11/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-11/bin/UI/UIFramework.watchOS.framework/Modules";
 				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/CONFIGURATION-STABLE-11/bin/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTests.library.rules_xcodeproj.swift.compile.params";
 				TARGETED_DEVICE_FAMILY = 4;
 				TARGET_NAME = watchOSAppExtensionUnitTests;
@@ -24125,8 +24125,8 @@
 				SDKROOT = appletvos;
 				SUPPORTED_PLATFORMS = "appletvsimulator appletvos";
 				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-12/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-12/bin/UI/UIFramework.tvOS.zip/Modules";
-				"SWIFT_INCLUDE_PATHS[sdk=appletvos*]" = "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-16/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-16/bin/UI/UIFramework.tvOS.zip/Modules";
+				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-12/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-12/bin/UI/UIFramework.tvOS.framework/Modules";
+				"SWIFT_INCLUDE_PATHS[sdk=appletvos*]" = "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-16/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-16/bin/UI/UIFramework.tvOS.framework/Modules";
 				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/CONFIGURATION-STABLE-12/bin/tvOSApp/Source/tvOSApp.library.rules_xcodeproj.swift.compile.params";
 				"SWIFT_PARAMS_FILE[sdk=appletvos*]" = "$(BAZEL_OUT)/CONFIGURATION-STABLE-16/bin/tvOSApp/Source/tvOSApp.library.rules_xcodeproj.swift.compile.params";
 				TARGETED_DEVICE_FAMILY = 3;
@@ -24519,8 +24519,8 @@
 				"OTHER_SWIFT_FLAGS[sdk=appletvos*]" = "-Xcc -ivfsoverlay -Xcc $(DERIVED_FILE_DIR)/xcode-overlay.yaml -Xcc -ivfsoverlay -Xcc $(OBJROOT)/bazel-out-overlay.yaml -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml $(PREVIEWS_SWIFT_INCLUDE__$(ENABLE_PREVIEWS)) @$(DERIVED_FILE_DIR)/swift.compile.params -F$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64 -Xcc -F -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64 -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(BAZEL_OUT)/CONFIGURATION-STABLE-9/bin/external/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(PROJECT_DIR) -Xcc -iquote -Xcc $(BAZEL_OUT)/CONFIGURATION-STABLE-9/bin -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64/CryptoSwift.framework/Modules/module.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all";
 				PREVIEWS_SWIFT_INCLUDE__ = "";
 				PREVIEWS_SWIFT_INCLUDE__NO = "";
-				PREVIEWS_SWIFT_INCLUDE__YES = "-I $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-5/bin/UI/UIFramework.tvOS.zip/Modules";
-				"PREVIEWS_SWIFT_INCLUDE__YES[sdk=appletvos*]" = "-I $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-9/bin/UI/UIFramework.tvOS.zip/Modules";
+				PREVIEWS_SWIFT_INCLUDE__YES = "-I $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-5/bin/UI/UIFramework.tvOS.framework/Modules";
+				"PREVIEWS_SWIFT_INCLUDE__YES[sdk=appletvos*]" = "-I $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-9/bin/UI/UIFramework.tvOS.framework/Modules";
 				PRODUCT_BUNDLE_IDENTIFIER = "rules-xcodeproj.UIFramework";
 				PRODUCT_MODULE_NAME = UI;
 				PRODUCT_NAME = UIFramework.tvOS;
@@ -24886,8 +24886,8 @@
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
-				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-3/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-3/bin/UI/UIFramework.iOS.zip/Modules $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer";
-				"SWIFT_INCLUDE_PATHS[sdk=iphoneos*]" = "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-7/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-7/bin/UI/UIFramework.iOS.zip/Modules $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer";
+				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-3/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-3/bin/UI/UIFramework.iOS.framework/Modules $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer";
+				"SWIFT_INCLUDE_PATHS[sdk=iphoneos*]" = "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-7/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-7/bin/UI/UIFramework.iOS.framework/Modules $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer";
 				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/CONFIGURATION-STABLE-3/bin/iOSApp/Source/iOSApp.library.rules_xcodeproj.swift.compile.params";
 				"SWIFT_PARAMS_FILE[sdk=iphoneos*]" = "$(BAZEL_OUT)/CONFIGURATION-STABLE-7/bin/iOSApp/Source/iOSApp.library.rules_xcodeproj.swift.compile.params";
 				TARGETED_DEVICE_FAMILY = 1;
@@ -24982,7 +24982,7 @@
 				SDKROOT = appletvos;
 				SUPPORTED_PLATFORMS = appletvsimulator;
 				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-12/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-12/bin/UI/UIFramework.tvOS.zip/Modules $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-12/bin/tvOSApp/Source";
+				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-12/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-12/bin/UI/UIFramework.tvOS.framework/Modules $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-12/bin/tvOSApp/Source";
 				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/CONFIGURATION-STABLE-12/bin/tvOSApp/Test/UnitTests/tvOSAppUnitTests.library.rules_xcodeproj.swift.compile.params";
 				TARGETED_DEVICE_FAMILY = 3;
 				TARGET_BUILD_DIR = "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-12/bin/tvOSApp/Source$(TARGET_BUILD_SUBPATH)";
@@ -25663,8 +25663,8 @@
 				SDKROOT = watchos;
 				SUPPORTED_PLATFORMS = "watchsimulator watchos";
 				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-11/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-11/bin/UI/UIFramework.watchOS.zip/Modules";
-				"SWIFT_INCLUDE_PATHS[sdk=watchos*]" = "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-15/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-15/bin/UI/UIFramework.watchOS.zip/Modules";
+				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-11/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-11/bin/UI/UIFramework.watchOS.framework/Modules";
+				"SWIFT_INCLUDE_PATHS[sdk=watchos*]" = "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-15/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-15/bin/UI/UIFramework.watchOS.framework/Modules";
 				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/CONFIGURATION-STABLE-11/bin/watchOSAppExtension/watchOSAppExtension.library.rules_xcodeproj.swift.compile.params";
 				"SWIFT_PARAMS_FILE[sdk=watchos*]" = "$(BAZEL_OUT)/CONFIGURATION-STABLE-15/bin/watchOSAppExtension/watchOSAppExtension.library.rules_xcodeproj.swift.compile.params";
 				TARGETED_DEVICE_FAMILY = 4;
@@ -25905,8 +25905,8 @@
 				PRODUCT_NAME = tvOSApp;
 				SDKROOT = appletvos;
 				SUPPORTED_PLATFORMS = "appletvsimulator appletvos";
-				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-5/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-5/bin/UI/UIFramework.tvOS.zip/Modules";
-				"SWIFT_INCLUDE_PATHS[sdk=appletvos*]" = "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-9/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-9/bin/UI/UIFramework.tvOS.zip/Modules";
+				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-5/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-5/bin/UI/UIFramework.tvOS.framework/Modules";
+				"SWIFT_INCLUDE_PATHS[sdk=appletvos*]" = "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-9/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-9/bin/UI/UIFramework.tvOS.framework/Modules";
 				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/CONFIGURATION-STABLE-5/bin/tvOSApp/Source/tvOSApp.library.rules_xcodeproj.swift.compile.params";
 				"SWIFT_PARAMS_FILE[sdk=appletvos*]" = "$(BAZEL_OUT)/CONFIGURATION-STABLE-9/bin/tvOSApp/Source/tvOSApp.library.rules_xcodeproj.swift.compile.params";
 				TARGETED_DEVICE_FAMILY = 3;
@@ -26282,8 +26282,8 @@
 				"OTHER_SWIFT_FLAGS[sdk=watchos*]" = "-Xcc -ivfsoverlay -Xcc $(DERIVED_FILE_DIR)/xcode-overlay.yaml -Xcc -ivfsoverlay -Xcc $(OBJROOT)/bazel-out-overlay.yaml -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml $(PREVIEWS_SWIFT_INCLUDE__$(ENABLE_PREVIEWS)) @$(DERIVED_FILE_DIR)/swift.compile.params -F$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k -Xcc -F -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(BAZEL_OUT)/CONFIGURATION-STABLE-8/bin/external/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(PROJECT_DIR) -Xcc -iquote -Xcc $(BAZEL_OUT)/CONFIGURATION-STABLE-8/bin -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k/CryptoSwift.framework/Modules/module.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all";
 				PREVIEWS_SWIFT_INCLUDE__ = "";
 				PREVIEWS_SWIFT_INCLUDE__NO = "";
-				PREVIEWS_SWIFT_INCLUDE__YES = "-I $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-4/bin/UI/UIFramework.watchOS.zip/Modules";
-				"PREVIEWS_SWIFT_INCLUDE__YES[sdk=watchos*]" = "-I $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-8/bin/UI/UIFramework.watchOS.zip/Modules";
+				PREVIEWS_SWIFT_INCLUDE__YES = "-I $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-4/bin/UI/UIFramework.watchOS.framework/Modules";
+				"PREVIEWS_SWIFT_INCLUDE__YES[sdk=watchos*]" = "-I $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-8/bin/UI/UIFramework.watchOS.framework/Modules";
 				PRODUCT_BUNDLE_IDENTIFIER = "rules-xcodeproj.UIFramework";
 				PRODUCT_MODULE_NAME = UI;
 				PRODUCT_NAME = UIFramework.watchOS;
@@ -26363,7 +26363,7 @@
 				SUPPORTED_PLATFORMS = iphonesimulator;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-10/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-10/bin/UI/UIFramework.iOS.zip/Modules $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Source $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/TestingUtils";
+				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-10/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-10/bin/UI/UIFramework.iOS.framework/Modules $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Source $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/TestingUtils";
 				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/CONFIGURATION-STABLE-10/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTestSuite.library.rules_xcodeproj.swift.compile.params";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TARGET_BUILD_DIR = "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Source$(TARGET_BUILD_SUBPATH)";
@@ -26772,8 +26772,8 @@
 				"OTHER_SWIFT_FLAGS[sdk=appletvos*]" = "-Xcc -ivfsoverlay -Xcc $(DERIVED_FILE_DIR)/xcode-overlay.yaml -Xcc -ivfsoverlay -Xcc $(OBJROOT)/bazel-out-overlay.yaml -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml $(PREVIEWS_SWIFT_INCLUDE__$(ENABLE_PREVIEWS)) @$(DERIVED_FILE_DIR)/swift.compile.params -F$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64 -Xcc -F -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64 -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(BAZEL_OUT)/CONFIGURATION-STABLE-16/bin/external/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(PROJECT_DIR) -Xcc -iquote -Xcc $(BAZEL_OUT)/CONFIGURATION-STABLE-16/bin -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64/CryptoSwift.framework/Modules/module.modulemap -Xcc -Os -Xcc -DNDEBUG=1 -Xcc -Wno-unused-variable -Xcc -Winit-self -Xcc -Wno-extra";
 				PREVIEWS_SWIFT_INCLUDE__ = "";
 				PREVIEWS_SWIFT_INCLUDE__NO = "";
-				PREVIEWS_SWIFT_INCLUDE__YES = "-I $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-12/bin/UI/UIFramework.tvOS.zip/Modules";
-				"PREVIEWS_SWIFT_INCLUDE__YES[sdk=appletvos*]" = "-I $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-16/bin/UI/UIFramework.tvOS.zip/Modules";
+				PREVIEWS_SWIFT_INCLUDE__YES = "-I $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-12/bin/UI/UIFramework.tvOS.framework/Modules";
+				"PREVIEWS_SWIFT_INCLUDE__YES[sdk=appletvos*]" = "-I $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-16/bin/UI/UIFramework.tvOS.framework/Modules";
 				PRODUCT_BUNDLE_IDENTIFIER = "rules-xcodeproj.UIFramework";
 				PRODUCT_MODULE_NAME = UI;
 				PRODUCT_NAME = UIFramework.tvOS;
@@ -26912,7 +26912,7 @@
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphonesimulator;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
-				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-3/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-3/bin/UI/UIFramework.iOS.zip/Modules $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Source $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/TestingUtils";
+				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-3/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-3/bin/UI/UIFramework.iOS.framework/Modules $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Source $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/TestingUtils";
 				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/CONFIGURATION-STABLE-3/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTestSuite.library.rules_xcodeproj.swift.compile.params";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TARGET_BUILD_DIR = "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Source$(TARGET_BUILD_SUBPATH)";
@@ -27321,8 +27321,8 @@
 				"OTHER_SWIFT_FLAGS[sdk=watchos*]" = "-Xcc -ivfsoverlay -Xcc $(DERIVED_FILE_DIR)/xcode-overlay.yaml -Xcc -ivfsoverlay -Xcc $(OBJROOT)/bazel-out-overlay.yaml -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml $(PREVIEWS_SWIFT_INCLUDE__$(ENABLE_PREVIEWS)) @$(DERIVED_FILE_DIR)/swift.compile.params -F$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k -Xcc -F -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(BAZEL_OUT)/CONFIGURATION-STABLE-15/bin/external/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(PROJECT_DIR) -Xcc -iquote -Xcc $(BAZEL_OUT)/CONFIGURATION-STABLE-15/bin -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k/CryptoSwift.framework/Modules/module.modulemap -Xcc -Os -Xcc -DNDEBUG=1 -Xcc -Wno-unused-variable -Xcc -Winit-self -Xcc -Wno-extra";
 				PREVIEWS_SWIFT_INCLUDE__ = "";
 				PREVIEWS_SWIFT_INCLUDE__NO = "";
-				PREVIEWS_SWIFT_INCLUDE__YES = "-I $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-11/bin/UI/UIFramework.watchOS.zip/Modules";
-				"PREVIEWS_SWIFT_INCLUDE__YES[sdk=watchos*]" = "-I $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-15/bin/UI/UIFramework.watchOS.zip/Modules";
+				PREVIEWS_SWIFT_INCLUDE__YES = "-I $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-11/bin/UI/UIFramework.watchOS.framework/Modules";
+				"PREVIEWS_SWIFT_INCLUDE__YES[sdk=watchos*]" = "-I $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-15/bin/UI/UIFramework.watchOS.framework/Modules";
 				PRODUCT_BUNDLE_IDENTIFIER = "rules-xcodeproj.UIFramework";
 				PRODUCT_MODULE_NAME = UI;
 				PRODUCT_NAME = UIFramework.watchOS;
@@ -27902,8 +27902,8 @@
 				PRODUCT_NAME = watchOSAppExtension;
 				SDKROOT = watchos;
 				SUPPORTED_PLATFORMS = "watchsimulator watchos";
-				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-4/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-4/bin/UI/UIFramework.watchOS.zip/Modules";
-				"SWIFT_INCLUDE_PATHS[sdk=watchos*]" = "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-8/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-8/bin/UI/UIFramework.watchOS.zip/Modules";
+				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-4/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-4/bin/UI/UIFramework.watchOS.framework/Modules";
+				"SWIFT_INCLUDE_PATHS[sdk=watchos*]" = "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-8/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-8/bin/UI/UIFramework.watchOS.framework/Modules";
 				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/CONFIGURATION-STABLE-4/bin/watchOSAppExtension/watchOSAppExtension.library.rules_xcodeproj.swift.compile.params";
 				"SWIFT_PARAMS_FILE[sdk=watchos*]" = "$(BAZEL_OUT)/CONFIGURATION-STABLE-8/bin/watchOSAppExtension/watchOSAppExtension.library.rules_xcodeproj.swift.compile.params";
 				TARGETED_DEVICE_FAMILY = 4;
@@ -28004,8 +28004,8 @@
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
-				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-3/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-3/bin/UI/UIFramework.iOS.zip/Modules $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Source $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/TestingUtils";
-				"SWIFT_INCLUDE_PATHS[sdk=iphoneos*]" = "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-7/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-7/bin/UI/UIFramework.iOS.zip/Modules $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Source $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Test/TestingUtils";
+				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-3/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-3/bin/UI/UIFramework.iOS.framework/Modules $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Source $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/TestingUtils";
+				"SWIFT_INCLUDE_PATHS[sdk=iphoneos*]" = "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-7/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-7/bin/UI/UIFramework.iOS.framework/Modules $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Source $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Test/TestingUtils";
 				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/CONFIGURATION-STABLE-3/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.library.rules_xcodeproj.swift.compile.params";
 				"SWIFT_PARAMS_FILE[sdk=iphoneos*]" = "$(BAZEL_OUT)/CONFIGURATION-STABLE-7/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.library.rules_xcodeproj.swift.compile.params";
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -28672,7 +28672,7 @@
 				PRODUCT_NAME = tvOSAppUnitTests;
 				SDKROOT = appletvos;
 				SUPPORTED_PLATFORMS = appletvsimulator;
-				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-5/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-5/bin/UI/UIFramework.tvOS.zip/Modules $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-5/bin/tvOSApp/Source";
+				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-5/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-5/bin/UI/UIFramework.tvOS.framework/Modules $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-5/bin/tvOSApp/Source";
 				SWIFT_PARAMS_FILE = "$(BAZEL_OUT)/CONFIGURATION-STABLE-5/bin/tvOSApp/Test/UnitTests/tvOSAppUnitTests.library.rules_xcodeproj.swift.compile.params";
 				TARGETED_DEVICE_FAMILY = 3;
 				TARGET_BUILD_DIR = "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-5/bin/tvOSApp/Source$(TARGET_BUILD_SUBPATH)";
@@ -28832,8 +28832,8 @@
 				"OTHER_SWIFT_FLAGS[sdk=iphoneos*]" = "-Xcc -ivfsoverlay -Xcc $(DERIVED_FILE_DIR)/xcode-overlay.yaml -Xcc -ivfsoverlay -Xcc $(OBJROOT)/bazel-out-overlay.yaml -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml $(PREVIEWS_SWIFT_INCLUDE__$(ENABLE_PREVIEWS)) @$(DERIVED_FILE_DIR)/swift.compile.params -F$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7 -Xcc -F -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7 -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(BAZEL_OUT)/CONFIGURATION-STABLE-7/bin/external/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(PROJECT_DIR) -Xcc -iquote -Xcc $(BAZEL_OUT)/CONFIGURATION-STABLE-7/bin -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework/Modules/module.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all";
 				PREVIEWS_SWIFT_INCLUDE__ = "";
 				PREVIEWS_SWIFT_INCLUDE__NO = "";
-				PREVIEWS_SWIFT_INCLUDE__YES = "-I $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-3/bin/UI/UIFramework.iOS.zip/Modules";
-				"PREVIEWS_SWIFT_INCLUDE__YES[sdk=iphoneos*]" = "-I $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-7/bin/UI/UIFramework.iOS.zip/Modules";
+				PREVIEWS_SWIFT_INCLUDE__YES = "-I $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-3/bin/UI/UIFramework.iOS.framework/Modules";
+				"PREVIEWS_SWIFT_INCLUDE__YES[sdk=iphoneos*]" = "-I $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-7/bin/UI/UIFramework.iOS.framework/Modules";
 				PRODUCT_BUNDLE_IDENTIFIER = "rules-xcodeproj.UIFramework";
 				PRODUCT_MODULE_NAME = UI;
 				PRODUCT_NAME = UIFramework.iOS;

--- a/examples/integration/test/fixtures/bwx_targets_spec.json
+++ b/examples/integration/test/fixtures/bwx_targets_spec.json
@@ -794,7 +794,7 @@
             "e": "AppClip",
             "m": "AppClip",
             "n": "AppClip",
-            "p": "bazel-out/CONFIGURATION-STABLE-3/bin/AppClip/AppClip_archive-root/Payload/AppClip.app",
+            "p": "bazel-out/CONFIGURATION-STABLE-3/bin/AppClip/AppClip.app",
             "t": "com.apple.product-type.application.on-demand-install-capable"
         }
     },
@@ -928,7 +928,7 @@
             "e": "WidgetExtension",
             "m": "WidgetExtension",
             "n": "WidgetExtension",
-            "p": "bazel-out/CONFIGURATION-STABLE-3/bin/WidgetExtension/WidgetExtension_archive-root/WidgetExtension.appex",
+            "p": "bazel-out/CONFIGURATION-STABLE-3/bin/WidgetExtension/WidgetExtension.appex",
             "t": "com.apple.product-type.app-extension"
         }
     },
@@ -979,7 +979,7 @@
             "e": "CoreUtilsObjC",
             "m": "CoreUtilsObjC",
             "n": "CoreUtilsObjC",
-            "p": "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Source/CoreUtilsObjC/FrameworkCoreUtilsObjC_archive-root/CoreUtilsObjC.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Source/CoreUtilsObjC/CoreUtilsObjC.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -1023,7 +1023,7 @@
             "e": "LibFramework.iOS",
             "m": "LibFramework.iOS",
             "n": "LibFramework.iOS",
-            "p": "bazel-out/CONFIGURATION-STABLE-3/bin/Lib/LibFramework.iOS_archive-root/LibFramework.iOS.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-3/bin/Lib/LibFramework.iOS.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -1057,7 +1057,7 @@
             "OTHER_SWIFT_FLAGS": "-F$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator -Xcc -F -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(BAZEL_OUT)/CONFIGURATION-STABLE-3/bin/external/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(PROJECT_DIR) -Xcc -iquote -Xcc $(BAZEL_OUT)/CONFIGURATION-STABLE-3/bin -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all",
             "PREVIEWS_SWIFT_INCLUDE__": "",
             "PREVIEWS_SWIFT_INCLUDE__NO": "",
-            "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-3/bin/UI/UIFramework.iOS.zip/Modules",
+            "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-3/bin/UI/UIFramework.iOS.framework/Modules",
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.UIFramework",
             "PRODUCT_MODULE_NAME": "UI",
             "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-3/bin/Lib",
@@ -1092,7 +1092,7 @@
             "e": "UIFramework.iOS",
             "m": "UIFramework.iOS",
             "n": "UIFramework.iOS",
-            "p": "bazel-out/CONFIGURATION-STABLE-3/bin/UI/UIFramework.iOS_archive-root/UIFramework.iOS.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-3/bin/UI/UIFramework.iOS.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -1172,7 +1172,7 @@
             "e": "LibFramework.watchOS",
             "m": "LibFramework.watchOS",
             "n": "LibFramework.watchOS",
-            "p": "bazel-out/CONFIGURATION-STABLE-4/bin/Lib/LibFramework.watchOS_archive-root/LibFramework.watchOS.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-4/bin/Lib/LibFramework.watchOS.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -1206,7 +1206,7 @@
             "OTHER_SWIFT_FLAGS": "-F$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator -Xcc -F -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(BAZEL_OUT)/CONFIGURATION-STABLE-4/bin/external/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(PROJECT_DIR) -Xcc -iquote -Xcc $(BAZEL_OUT)/CONFIGURATION-STABLE-4/bin -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all",
             "PREVIEWS_SWIFT_INCLUDE__": "",
             "PREVIEWS_SWIFT_INCLUDE__NO": "",
-            "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-4/bin/UI/UIFramework.watchOS.zip/Modules",
+            "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-4/bin/UI/UIFramework.watchOS.framework/Modules",
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.UIFramework",
             "PRODUCT_MODULE_NAME": "UI",
             "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-4/bin/Lib",
@@ -1238,7 +1238,7 @@
             "e": "UIFramework.watchOS",
             "m": "UIFramework.watchOS",
             "n": "UIFramework.watchOS",
-            "p": "bazel-out/CONFIGURATION-STABLE-4/bin/UI/UIFramework.watchOS_archive-root/UIFramework.watchOS.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-4/bin/UI/UIFramework.watchOS.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -1276,7 +1276,7 @@
             "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-4/bin/watchOSAppExtension",
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.example.watch.extension",
             "PRODUCT_MODULE_NAME": "watchOSAppExtension",
-            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-4/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-4/bin/UI/UIFramework.watchOS.zip/Modules",
+            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-4/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-4/bin/UI/UIFramework.watchOS.framework/Modules",
             "TARGETED_DEVICE_FAMILY": "4"
         },
         "c": "CONFIGURATION-STABLE-4",
@@ -1307,7 +1307,7 @@
             "e": "watchOSAppExtension",
             "m": "watchOSAppExtension",
             "n": "watchOSAppExtension",
-            "p": "bazel-out/CONFIGURATION-STABLE-4/bin/watchOSAppExtension/watchOSAppExtension_archive-root/watchOSAppExtension.appex",
+            "p": "bazel-out/CONFIGURATION-STABLE-4/bin/watchOSAppExtension/watchOSAppExtension.appex",
             "t": "com.apple.product-type.watchkit2-extension"
         }
     },
@@ -1345,7 +1345,7 @@
             "e": "watchOSApp",
             "m": "watchOSApp",
             "n": "watchOSApp",
-            "p": "bazel-out/CONFIGURATION-STABLE-17/bin/watchOSApp/watchOSApp_archive-root/Payload/watchOSApp.app",
+            "p": "bazel-out/CONFIGURATION-STABLE-17/bin/watchOSApp/watchOSApp.app",
             "t": "com.apple.product-type.application.watchapp2"
         }
     },
@@ -1392,7 +1392,7 @@
             "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Source",
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.example",
             "PRODUCT_MODULE_NAME": "iOSApp",
-            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-3/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-3/bin/UI/UIFramework.iOS.zip/Modules $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer",
+            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-3/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-3/bin/UI/UIFramework.iOS.framework/Modules $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer",
             "TARGETED_DEVICE_FAMILY": "1"
         },
         "c": "CONFIGURATION-STABLE-3",
@@ -1446,7 +1446,7 @@
             "e": "iOSApp_ExecutableName",
             "m": "iOSApp",
             "n": "iOSApp",
-            "p": "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Source/iOSApp_archive-root/Payload/iOSApp.app",
+            "p": "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Source/iOSApp.app",
             "t": "com.apple.product-type.application"
         },
         "r": [
@@ -1495,7 +1495,7 @@
             "e": "Lib",
             "m": "Lib",
             "n": "Lib",
-            "p": "bazel-out/CONFIGURATION-STABLE-3/bin/Lib/dist/dynamic/iOS_archive-root/Lib.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-3/bin/Lib/dist/dynamic/Lib.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -1575,7 +1575,7 @@
             "e": "Lib",
             "m": "Lib",
             "n": "Lib",
-            "p": "bazel-out/CONFIGURATION-STABLE-5/bin/Lib/dist/dynamic/tvOS_archive-root/Lib.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-5/bin/Lib/dist/dynamic/Lib.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -1619,7 +1619,7 @@
             "e": "Lib",
             "m": "Lib",
             "n": "Lib",
-            "p": "bazel-out/CONFIGURATION-STABLE-4/bin/Lib/dist/dynamic/watchOS_archive-root/Lib.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-4/bin/Lib/dist/dynamic/Lib.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -1663,7 +1663,7 @@
             "e": "LibFramework.tvOS",
             "m": "LibFramework.tvOS",
             "n": "LibFramework.tvOS",
-            "p": "bazel-out/CONFIGURATION-STABLE-5/bin/Lib/LibFramework.tvOS_archive-root/LibFramework.tvOS.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-5/bin/Lib/LibFramework.tvOS.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -1697,7 +1697,7 @@
             "OTHER_SWIFT_FLAGS": "-F$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator -Xcc -F -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(BAZEL_OUT)/CONFIGURATION-STABLE-5/bin/external/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(PROJECT_DIR) -Xcc -iquote -Xcc $(BAZEL_OUT)/CONFIGURATION-STABLE-5/bin -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all",
             "PREVIEWS_SWIFT_INCLUDE__": "",
             "PREVIEWS_SWIFT_INCLUDE__NO": "",
-            "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-5/bin/UI/UIFramework.tvOS.zip/Modules",
+            "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-5/bin/UI/UIFramework.tvOS.framework/Modules",
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.UIFramework",
             "PRODUCT_MODULE_NAME": "UI",
             "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-5/bin/Lib",
@@ -1729,7 +1729,7 @@
             "e": "UIFramework.tvOS",
             "m": "UIFramework.tvOS",
             "n": "UIFramework.tvOS",
-            "p": "bazel-out/CONFIGURATION-STABLE-5/bin/UI/UIFramework.tvOS_archive-root/UIFramework.tvOS.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-5/bin/UI/UIFramework.tvOS.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -1766,7 +1766,7 @@
             "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-5/bin/tvOSApp/Source",
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.example",
             "PRODUCT_MODULE_NAME": "tvOSApp",
-            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-5/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-5/bin/UI/UIFramework.tvOS.zip/Modules",
+            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-5/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-5/bin/UI/UIFramework.tvOS.framework/Modules",
             "TARGETED_DEVICE_FAMILY": "3"
         },
         "c": "CONFIGURATION-STABLE-5",
@@ -1798,7 +1798,7 @@
             "e": "tvOSApp",
             "m": "tvOSApp",
             "n": "tvOSApp",
-            "p": "bazel-out/CONFIGURATION-STABLE-5/bin/tvOSApp/Source/tvOSApp_archive-root/Payload/tvOSApp.app",
+            "p": "bazel-out/CONFIGURATION-STABLE-5/bin/tvOSApp/Source/tvOSApp.app",
             "t": "com.apple.product-type.application"
         }
     },
@@ -1840,7 +1840,7 @@
             "e": "ABundle",
             "m": "ABundle",
             "n": "ABundle",
-            "p": "bazel-out/CONFIGURATION-STABLE-6/bin/Bundle/Bundle_archive-root/ABundle.aplugin",
+            "p": "bazel-out/CONFIGURATION-STABLE-6/bin/Bundle/ABundle.aplugin",
             "t": "com.apple.product-type.bundle"
         }
     },
@@ -2000,7 +2000,7 @@
             "e": "iOSAppObjCUnitTests",
             "m": "iOSAppObjCUnitTests",
             "n": "iOSAppObjCUnitTests",
-            "p": "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.__internal__.__test_bundle_archive-root/iOSAppObjCUnitTests.xctest",
+            "p": "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         },
         "r": [
@@ -2057,7 +2057,7 @@
             "e": "iOSAppUITests",
             "m": "iOSAppUITests",
             "n": "iOSAppUITests",
-            "p": "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/UITests/iOSAppUITests.__internal__.__test_bundle_archive-root/iOSAppUITests.xctest",
+            "p": "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/UITests/iOSAppUITests.xctest",
             "t": "com.apple.product-type.bundle.ui-testing"
         },
         "r": [
@@ -2164,7 +2164,7 @@
             "e": "iMessageAppExtension",
             "m": "iMessageAppExtension",
             "n": "iMessageAppExtension",
-            "p": "bazel-out/CONFIGURATION-STABLE-3/bin/iMessageApp/iMessageAppExtension_archive-root/iMessageAppExtension.appex",
+            "p": "bazel-out/CONFIGURATION-STABLE-3/bin/iMessageApp/iMessageAppExtension.appex",
             "t": "com.apple.product-type.app-extension.messages"
         }
     },
@@ -2202,7 +2202,7 @@
             "e": "iMessageApp",
             "m": "iMessageApp",
             "n": "iMessageApp",
-            "p": "bazel-out/CONFIGURATION-STABLE-3/bin/iMessageApp/iMessageApp_archive-root/Payload/iMessageApp.app",
+            "p": "bazel-out/CONFIGURATION-STABLE-3/bin/iMessageApp/iMessageApp.app",
             "t": "com.apple.product-type.application.messages"
         }
     },
@@ -2240,7 +2240,7 @@
             "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/SwiftUnitTests",
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.example.tests",
             "PRODUCT_MODULE_NAME": "iOSAppSwiftUnitTests",
-            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-3/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-3/bin/UI/UIFramework.iOS.zip/Modules $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Source $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/TestingUtils",
+            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-3/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-3/bin/UI/UIFramework.iOS.framework/Modules $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Source $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/TestingUtils",
             "TARGETED_DEVICE_FAMILY": "1,2"
         },
         "c": "CONFIGURATION-STABLE-3",
@@ -2277,7 +2277,7 @@
             "e": "iOSAppSwiftUnitTests",
             "m": "iOSAppSwiftUnitTests",
             "n": "iOSAppSwiftUnitTests",
-            "p": "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.__internal__.__test_bundle_archive-root/iOSAppSwiftUnitTests.xctest",
+            "p": "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         }
     },
@@ -2356,7 +2356,7 @@
             "e": "Lib",
             "m": "Lib",
             "n": "Lib",
-            "p": "bazel-out/CONFIGURATION-STABLE-6/bin/macOSApp/Source/macOSLib.framework_archive-root/Lib.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-6/bin/macOSApp/Source/Lib.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -2426,7 +2426,7 @@
             "e": "macOSApp",
             "m": "macOSApp",
             "n": "macOSApp",
-            "p": "bazel-out/CONFIGURATION-STABLE-6/bin/macOSApp/Source/macOSApp_archive-root/Payload/macOSApp.app",
+            "p": "bazel-out/CONFIGURATION-STABLE-6/bin/macOSApp/Source/macOSApp.app",
             "t": "com.apple.product-type.application"
         }
     },
@@ -2479,7 +2479,7 @@
             "e": "macOSAppUITests",
             "m": "macOSAppUITests",
             "n": "macOSAppUITests",
-            "p": "bazel-out/CONFIGURATION-STABLE-6/bin/macOSApp/Test/UITests/macOSAppUITests.__internal__.__test_bundle_archive-root/macOSAppUITests.xctest",
+            "p": "bazel-out/CONFIGURATION-STABLE-6/bin/macOSApp/Test/UITests/macOSAppUITests.xctest",
             "t": "com.apple.product-type.bundle.ui-testing"
         }
     },
@@ -2533,7 +2533,7 @@
             "e": "tvOSAppUITests",
             "m": "tvOSAppUITests",
             "n": "tvOSAppUITests",
-            "p": "bazel-out/CONFIGURATION-STABLE-5/bin/tvOSApp/Test/UITests/tvOSAppUITests.__internal__.__test_bundle_archive-root/tvOSAppUITests.xctest",
+            "p": "bazel-out/CONFIGURATION-STABLE-5/bin/tvOSApp/Test/UITests/tvOSAppUITests.xctest",
             "t": "com.apple.product-type.bundle.ui-testing"
         }
     },
@@ -2570,7 +2570,7 @@
             "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-5/bin/tvOSApp/Test/UnitTests",
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.example.tests",
             "PRODUCT_MODULE_NAME": "tvOSAppUnitTests",
-            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-5/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-5/bin/UI/UIFramework.tvOS.zip/Modules $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-5/bin/tvOSApp/Source",
+            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-5/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-5/bin/UI/UIFramework.tvOS.framework/Modules $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-5/bin/tvOSApp/Source",
             "TARGETED_DEVICE_FAMILY": "3"
         },
         "c": "CONFIGURATION-STABLE-5",
@@ -2599,7 +2599,7 @@
             "e": "tvOSAppUnitTests",
             "m": "tvOSAppUnitTests",
             "n": "tvOSAppUnitTests",
-            "p": "bazel-out/CONFIGURATION-STABLE-5/bin/tvOSApp/Test/UnitTests/tvOSAppUnitTests.__internal__.__test_bundle_archive-root/tvOSAppUnitTests.xctest",
+            "p": "bazel-out/CONFIGURATION-STABLE-5/bin/tvOSApp/Test/UnitTests/tvOSAppUnitTests.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         }
     },
@@ -2653,7 +2653,7 @@
             "e": "watchOSAppUITests",
             "m": "watchOSAppUITests",
             "n": "watchOSAppUITests",
-            "p": "bazel-out/CONFIGURATION-STABLE-4/bin/watchOSApp/Test/UITests/watchOSAppUITests.__internal__.__test_bundle_archive-root/watchOSAppUITests.xctest",
+            "p": "bazel-out/CONFIGURATION-STABLE-4/bin/watchOSApp/Test/UITests/watchOSAppUITests.xctest",
             "t": "com.apple.product-type.bundle.ui-testing"
         }
     },
@@ -2690,7 +2690,7 @@
             "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-4/bin/watchOSAppExtension/Test/UnitTests",
             "PRODUCT_BUNDLE_IDENTIFIER": "com.bazelbuild.rulesapple.Tests",
             "PRODUCT_MODULE_NAME": "watchOSAppExtensionUnitTestsLibrary",
-            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-4/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-4/bin/UI/UIFramework.watchOS.zip/Modules",
+            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-4/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-4/bin/UI/UIFramework.watchOS.framework/Modules",
             "TARGETED_DEVICE_FAMILY": "4"
         },
         "c": "CONFIGURATION-STABLE-4",
@@ -2718,7 +2718,7 @@
             "e": "watchOSAppExtensionUnitTests",
             "m": "watchOSAppExtensionUnitTests",
             "n": "watchOSAppExtensionUnitTests",
-            "p": "bazel-out/CONFIGURATION-STABLE-4/bin/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTests.__internal__.__test_bundle_archive-root/watchOSAppExtensionUnitTests.xctest",
+            "p": "bazel-out/CONFIGURATION-STABLE-4/bin/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTests.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         }
     },
@@ -2772,7 +2772,7 @@
             "e": "iOSAppUITestSuite",
             "m": "iOSAppUITestSuite",
             "n": "iOSAppUITestSuite",
-            "p": "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/UITests/iOSAppUITestSuite.__internal__.__test_bundle_archive-root/iOSAppUITestSuite.xctest",
+            "p": "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/UITests/iOSAppUITestSuite.xctest",
             "t": "com.apple.product-type.bundle.ui-testing"
         },
         "r": [
@@ -2837,7 +2837,7 @@
             "e": "iOSAppObjCUnitTestSuite",
             "m": "iOSAppObjCUnitTestSuite",
             "n": "iOSAppObjCUnitTestSuite",
-            "p": "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTestSuite.__internal__.__test_bundle_archive-root/iOSAppObjCUnitTestSuite.xctest",
+            "p": "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTestSuite.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         },
         "r": [
@@ -2878,7 +2878,7 @@
             "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/SwiftUnitTests",
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.example.tests",
             "PRODUCT_MODULE_NAME": "iOSAppSwiftUnitTestSuite",
-            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-3/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-3/bin/UI/UIFramework.iOS.zip/Modules $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Source $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/TestingUtils",
+            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-3/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-3/bin/UI/UIFramework.iOS.framework/Modules $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Source $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/TestingUtils",
             "TARGETED_DEVICE_FAMILY": "1,2"
         },
         "c": "CONFIGURATION-STABLE-3",
@@ -2915,7 +2915,7 @@
             "e": "iOSAppSwiftUnitTestSuite",
             "m": "iOSAppSwiftUnitTestSuite",
             "n": "iOSAppSwiftUnitTestSuite",
-            "p": "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTestSuite.__internal__.__test_bundle_archive-root/iOSAppSwiftUnitTestSuite.xctest",
+            "p": "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTestSuite.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         }
     },
@@ -6006,7 +6006,7 @@
             "e": "CommandLineToolTests",
             "m": "CommandLineToolTests",
             "n": "CommandLineToolTests",
-            "p": "bazel-out/CONFIGURATION-STABLE-23/bin/CommandLine/Tests/CommandLineToolTests.__internal__.__test_bundle_archive-root/CommandLineToolTests.xctest",
+            "p": "bazel-out/CONFIGURATION-STABLE-23/bin/CommandLine/Tests/CommandLineToolTests.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         }
     },
@@ -6113,7 +6113,7 @@
             "e": "AppClip",
             "m": "AppClip",
             "n": "AppClip",
-            "p": "bazel-out/CONFIGURATION-STABLE-7/bin/AppClip/AppClip_archive-root/Payload/AppClip.app",
+            "p": "bazel-out/CONFIGURATION-STABLE-7/bin/AppClip/AppClip.app",
             "t": "com.apple.product-type.application.on-demand-install-capable"
         }
     },
@@ -6248,7 +6248,7 @@
             "e": "WidgetExtension",
             "m": "WidgetExtension",
             "n": "WidgetExtension",
-            "p": "bazel-out/CONFIGURATION-STABLE-7/bin/WidgetExtension/WidgetExtension_archive-root/WidgetExtension.appex",
+            "p": "bazel-out/CONFIGURATION-STABLE-7/bin/WidgetExtension/WidgetExtension.appex",
             "t": "com.apple.product-type.app-extension"
         }
     },
@@ -6299,7 +6299,7 @@
             "e": "CoreUtilsObjC",
             "m": "CoreUtilsObjC",
             "n": "CoreUtilsObjC",
-            "p": "bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Source/CoreUtilsObjC/FrameworkCoreUtilsObjC_archive-root/CoreUtilsObjC.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Source/CoreUtilsObjC/CoreUtilsObjC.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -6343,7 +6343,7 @@
             "e": "LibFramework.iOS",
             "m": "LibFramework.iOS",
             "n": "LibFramework.iOS",
-            "p": "bazel-out/CONFIGURATION-STABLE-7/bin/Lib/LibFramework.iOS_archive-root/LibFramework.iOS.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-7/bin/Lib/LibFramework.iOS.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -6377,7 +6377,7 @@
             "OTHER_SWIFT_FLAGS": "-F$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7 -Xcc -F -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7 -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(BAZEL_OUT)/CONFIGURATION-STABLE-7/bin/external/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(PROJECT_DIR) -Xcc -iquote -Xcc $(BAZEL_OUT)/CONFIGURATION-STABLE-7/bin -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework/Modules/module.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all",
             "PREVIEWS_SWIFT_INCLUDE__": "",
             "PREVIEWS_SWIFT_INCLUDE__NO": "",
-            "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-7/bin/UI/UIFramework.iOS.zip/Modules",
+            "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-7/bin/UI/UIFramework.iOS.framework/Modules",
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.UIFramework",
             "PRODUCT_MODULE_NAME": "UI",
             "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-7/bin/Lib",
@@ -6412,7 +6412,7 @@
             "e": "UIFramework.iOS",
             "m": "UIFramework.iOS",
             "n": "UIFramework.iOS",
-            "p": "bazel-out/CONFIGURATION-STABLE-7/bin/UI/UIFramework.iOS_archive-root/UIFramework.iOS.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-7/bin/UI/UIFramework.iOS.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -6492,7 +6492,7 @@
             "e": "LibFramework.watchOS",
             "m": "LibFramework.watchOS",
             "n": "LibFramework.watchOS",
-            "p": "bazel-out/CONFIGURATION-STABLE-8/bin/Lib/LibFramework.watchOS_archive-root/LibFramework.watchOS.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-8/bin/Lib/LibFramework.watchOS.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -6526,7 +6526,7 @@
             "OTHER_SWIFT_FLAGS": "-F$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k -Xcc -F -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(BAZEL_OUT)/CONFIGURATION-STABLE-8/bin/external/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(PROJECT_DIR) -Xcc -iquote -Xcc $(BAZEL_OUT)/CONFIGURATION-STABLE-8/bin -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k/CryptoSwift.framework/Modules/module.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all",
             "PREVIEWS_SWIFT_INCLUDE__": "",
             "PREVIEWS_SWIFT_INCLUDE__NO": "",
-            "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-8/bin/UI/UIFramework.watchOS.zip/Modules",
+            "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-8/bin/UI/UIFramework.watchOS.framework/Modules",
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.UIFramework",
             "PRODUCT_MODULE_NAME": "UI",
             "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-8/bin/Lib",
@@ -6558,7 +6558,7 @@
             "e": "UIFramework.watchOS",
             "m": "UIFramework.watchOS",
             "n": "UIFramework.watchOS",
-            "p": "bazel-out/CONFIGURATION-STABLE-8/bin/UI/UIFramework.watchOS_archive-root/UIFramework.watchOS.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-8/bin/UI/UIFramework.watchOS.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -6597,7 +6597,7 @@
             "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-8/bin/watchOSAppExtension",
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.example.watch.extension",
             "PRODUCT_MODULE_NAME": "watchOSAppExtension",
-            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-8/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-8/bin/UI/UIFramework.watchOS.zip/Modules",
+            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-8/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-8/bin/UI/UIFramework.watchOS.framework/Modules",
             "TARGETED_DEVICE_FAMILY": "4"
         },
         "c": "CONFIGURATION-STABLE-8",
@@ -6628,7 +6628,7 @@
             "e": "watchOSAppExtension",
             "m": "watchOSAppExtension",
             "n": "watchOSAppExtension",
-            "p": "bazel-out/CONFIGURATION-STABLE-8/bin/watchOSAppExtension/watchOSAppExtension_archive-root/watchOSAppExtension.appex",
+            "p": "bazel-out/CONFIGURATION-STABLE-8/bin/watchOSAppExtension/watchOSAppExtension.appex",
             "t": "com.apple.product-type.watchkit2-extension"
         }
     },
@@ -6667,7 +6667,7 @@
             "e": "watchOSApp",
             "m": "watchOSApp",
             "n": "watchOSApp",
-            "p": "bazel-out/CONFIGURATION-STABLE-18/bin/watchOSApp/watchOSApp_archive-root/Payload/watchOSApp.app",
+            "p": "bazel-out/CONFIGURATION-STABLE-18/bin/watchOSApp/watchOSApp.app",
             "t": "com.apple.product-type.application.watchapp2"
         }
     },
@@ -6715,7 +6715,7 @@
             "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Source",
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.example",
             "PRODUCT_MODULE_NAME": "iOSApp",
-            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-7/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-7/bin/UI/UIFramework.iOS.zip/Modules $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer",
+            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-7/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-7/bin/UI/UIFramework.iOS.framework/Modules $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer",
             "TARGETED_DEVICE_FAMILY": "1"
         },
         "c": "CONFIGURATION-STABLE-7",
@@ -6769,7 +6769,7 @@
             "e": "iOSApp",
             "m": "iOSApp",
             "n": "iOSApp",
-            "p": "bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Source/iOSApp_archive-root/Payload/iOSApp.app",
+            "p": "bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Source/iOSApp.app",
             "t": "com.apple.product-type.application"
         },
         "r": [
@@ -6818,7 +6818,7 @@
             "e": "Lib",
             "m": "Lib",
             "n": "Lib",
-            "p": "bazel-out/CONFIGURATION-STABLE-7/bin/Lib/dist/dynamic/iOS_archive-root/Lib.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-7/bin/Lib/dist/dynamic/Lib.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -6898,7 +6898,7 @@
             "e": "Lib",
             "m": "Lib",
             "n": "Lib",
-            "p": "bazel-out/CONFIGURATION-STABLE-9/bin/Lib/dist/dynamic/tvOS_archive-root/Lib.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-9/bin/Lib/dist/dynamic/Lib.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -6942,7 +6942,7 @@
             "e": "Lib",
             "m": "Lib",
             "n": "Lib",
-            "p": "bazel-out/CONFIGURATION-STABLE-8/bin/Lib/dist/dynamic/watchOS_archive-root/Lib.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-8/bin/Lib/dist/dynamic/Lib.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -6986,7 +6986,7 @@
             "e": "LibFramework.tvOS",
             "m": "LibFramework.tvOS",
             "n": "LibFramework.tvOS",
-            "p": "bazel-out/CONFIGURATION-STABLE-9/bin/Lib/LibFramework.tvOS_archive-root/LibFramework.tvOS.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-9/bin/Lib/LibFramework.tvOS.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -7020,7 +7020,7 @@
             "OTHER_SWIFT_FLAGS": "-F$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64 -Xcc -F -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64 -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(BAZEL_OUT)/CONFIGURATION-STABLE-9/bin/external/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(PROJECT_DIR) -Xcc -iquote -Xcc $(BAZEL_OUT)/CONFIGURATION-STABLE-9/bin -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64/CryptoSwift.framework/Modules/module.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all",
             "PREVIEWS_SWIFT_INCLUDE__": "",
             "PREVIEWS_SWIFT_INCLUDE__NO": "",
-            "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-9/bin/UI/UIFramework.tvOS.zip/Modules",
+            "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-9/bin/UI/UIFramework.tvOS.framework/Modules",
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.UIFramework",
             "PRODUCT_MODULE_NAME": "UI",
             "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-9/bin/Lib",
@@ -7052,7 +7052,7 @@
             "e": "UIFramework.tvOS",
             "m": "UIFramework.tvOS",
             "n": "UIFramework.tvOS",
-            "p": "bazel-out/CONFIGURATION-STABLE-9/bin/UI/UIFramework.tvOS_archive-root/UIFramework.tvOS.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-9/bin/UI/UIFramework.tvOS.framework",
             "t": "com.apple.product-type.framework"
         }
     },
@@ -7090,7 +7090,7 @@
             "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-9/bin/tvOSApp/Source",
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.example",
             "PRODUCT_MODULE_NAME": "tvOSApp",
-            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-9/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-9/bin/UI/UIFramework.tvOS.zip/Modules",
+            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-9/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-9/bin/UI/UIFramework.tvOS.framework/Modules",
             "TARGETED_DEVICE_FAMILY": "3"
         },
         "c": "CONFIGURATION-STABLE-9",
@@ -7122,7 +7122,7 @@
             "e": "tvOSApp",
             "m": "tvOSApp",
             "n": "tvOSApp",
-            "p": "bazel-out/CONFIGURATION-STABLE-9/bin/tvOSApp/Source/tvOSApp_archive-root/Payload/tvOSApp.app",
+            "p": "bazel-out/CONFIGURATION-STABLE-9/bin/tvOSApp/Source/tvOSApp.app",
             "t": "com.apple.product-type.application"
         }
     },
@@ -7282,7 +7282,7 @@
             "e": "iOSAppObjCUnitTests",
             "m": "iOSAppObjCUnitTests",
             "n": "iOSAppObjCUnitTests",
-            "p": "bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.__internal__.__test_bundle_archive-root/iOSAppObjCUnitTests.xctest",
+            "p": "bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         },
         "r": [
@@ -7339,7 +7339,7 @@
             "e": "iOSAppUITests",
             "m": "iOSAppUITests",
             "n": "iOSAppUITests",
-            "p": "bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Test/UITests/iOSAppUITests.__internal__.__test_bundle_archive-root/iOSAppUITests.xctest",
+            "p": "bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Test/UITests/iOSAppUITests.xctest",
             "t": "com.apple.product-type.bundle.ui-testing"
         },
         "r": [
@@ -7380,7 +7380,7 @@
             "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Test/SwiftUnitTests",
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.example.tests",
             "PRODUCT_MODULE_NAME": "iOSAppSwiftUnitTests",
-            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-7/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-7/bin/UI/UIFramework.iOS.zip/Modules $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Source $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Test/TestingUtils",
+            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-7/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-7/bin/UI/UIFramework.iOS.framework/Modules $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Source $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Test/TestingUtils",
             "TARGETED_DEVICE_FAMILY": "1,2"
         },
         "c": "CONFIGURATION-STABLE-7",
@@ -7417,7 +7417,7 @@
             "e": "iOSAppSwiftUnitTests",
             "m": "iOSAppSwiftUnitTests",
             "n": "iOSAppSwiftUnitTests",
-            "p": "bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.__internal__.__test_bundle_archive-root/iOSAppSwiftUnitTests.xctest",
+            "p": "bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         }
     },
@@ -7689,7 +7689,7 @@
             "e": "AppClip",
             "m": "AppClip",
             "n": "AppClip",
-            "p": "bazel-out/CONFIGURATION-STABLE-10/bin/AppClip/AppClip_archive-root/Payload/AppClip.app",
+            "p": "bazel-out/CONFIGURATION-STABLE-10/bin/AppClip/AppClip.app",
             "t": "com.apple.product-type.application.on-demand-install-capable"
         },
         "x": [
@@ -7834,7 +7834,7 @@
             "e": "WidgetExtension",
             "m": "WidgetExtension",
             "n": "WidgetExtension",
-            "p": "bazel-out/CONFIGURATION-STABLE-10/bin/WidgetExtension/WidgetExtension_archive-root/WidgetExtension.appex",
+            "p": "bazel-out/CONFIGURATION-STABLE-10/bin/WidgetExtension/WidgetExtension.appex",
             "t": "com.apple.product-type.app-extension"
         },
         "x": [
@@ -7888,7 +7888,7 @@
             "e": "CoreUtilsObjC",
             "m": "CoreUtilsObjC",
             "n": "CoreUtilsObjC",
-            "p": "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Source/CoreUtilsObjC/FrameworkCoreUtilsObjC_archive-root/CoreUtilsObjC.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Source/CoreUtilsObjC/CoreUtilsObjC.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -7935,7 +7935,7 @@
             "e": "LibFramework.iOS",
             "m": "LibFramework.iOS",
             "n": "LibFramework.iOS",
-            "p": "bazel-out/CONFIGURATION-STABLE-10/bin/Lib/LibFramework.iOS_archive-root/LibFramework.iOS.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-10/bin/Lib/LibFramework.iOS.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -7972,7 +7972,7 @@
             "OTHER_SWIFT_FLAGS": "-F$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator -Xcc -F -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(BAZEL_OUT)/CONFIGURATION-STABLE-10/bin/external/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(PROJECT_DIR) -Xcc -iquote -Xcc $(BAZEL_OUT)/CONFIGURATION-STABLE-10/bin -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap -Xcc -Os -Xcc -DNDEBUG=1 -Xcc -Wno-unused-variable -Xcc -Winit-self -Xcc -Wno-extra",
             "PREVIEWS_SWIFT_INCLUDE__": "",
             "PREVIEWS_SWIFT_INCLUDE__NO": "",
-            "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-10/bin/UI/UIFramework.iOS.zip/Modules",
+            "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-10/bin/UI/UIFramework.iOS.framework/Modules",
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.UIFramework",
             "PRODUCT_MODULE_NAME": "UI",
             "SWIFT_COMPILATION_MODE": "wholemodule",
@@ -8008,7 +8008,7 @@
             "e": "UIFramework.iOS",
             "m": "UIFramework.iOS",
             "n": "UIFramework.iOS",
-            "p": "bazel-out/CONFIGURATION-STABLE-10/bin/UI/UIFramework.iOS_archive-root/UIFramework.iOS.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-10/bin/UI/UIFramework.iOS.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -8095,7 +8095,7 @@
             "e": "LibFramework.watchOS",
             "m": "LibFramework.watchOS",
             "n": "LibFramework.watchOS",
-            "p": "bazel-out/CONFIGURATION-STABLE-11/bin/Lib/LibFramework.watchOS_archive-root/LibFramework.watchOS.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-11/bin/Lib/LibFramework.watchOS.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -8132,7 +8132,7 @@
             "OTHER_SWIFT_FLAGS": "-F$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator -Xcc -F -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(BAZEL_OUT)/CONFIGURATION-STABLE-11/bin/external/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(PROJECT_DIR) -Xcc -iquote -Xcc $(BAZEL_OUT)/CONFIGURATION-STABLE-11/bin -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap -Xcc -Os -Xcc -DNDEBUG=1 -Xcc -Wno-unused-variable -Xcc -Winit-self -Xcc -Wno-extra",
             "PREVIEWS_SWIFT_INCLUDE__": "",
             "PREVIEWS_SWIFT_INCLUDE__NO": "",
-            "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-11/bin/UI/UIFramework.watchOS.zip/Modules",
+            "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-11/bin/UI/UIFramework.watchOS.framework/Modules",
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.UIFramework",
             "PRODUCT_MODULE_NAME": "UI",
             "SWIFT_COMPILATION_MODE": "wholemodule",
@@ -8165,7 +8165,7 @@
             "e": "UIFramework.watchOS",
             "m": "UIFramework.watchOS",
             "n": "UIFramework.watchOS",
-            "p": "bazel-out/CONFIGURATION-STABLE-11/bin/UI/UIFramework.watchOS_archive-root/UIFramework.watchOS.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-11/bin/UI/UIFramework.watchOS.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -8207,7 +8207,7 @@
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.example.watch.extension",
             "PRODUCT_MODULE_NAME": "watchOSAppExtension",
             "SWIFT_COMPILATION_MODE": "wholemodule",
-            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-11/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-11/bin/UI/UIFramework.watchOS.zip/Modules",
+            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-11/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-11/bin/UI/UIFramework.watchOS.framework/Modules",
             "TARGETED_DEVICE_FAMILY": "4"
         },
         "c": "CONFIGURATION-STABLE-11",
@@ -8238,7 +8238,7 @@
             "e": "watchOSAppExtension",
             "m": "watchOSAppExtension",
             "n": "watchOSAppExtension",
-            "p": "bazel-out/CONFIGURATION-STABLE-11/bin/watchOSAppExtension/watchOSAppExtension_archive-root/watchOSAppExtension.appex",
+            "p": "bazel-out/CONFIGURATION-STABLE-11/bin/watchOSAppExtension/watchOSAppExtension.appex",
             "t": "com.apple.product-type.watchkit2-extension"
         },
         "x": [
@@ -8279,7 +8279,7 @@
             "e": "watchOSApp",
             "m": "watchOSApp",
             "n": "watchOSApp",
-            "p": "bazel-out/CONFIGURATION-STABLE-19/bin/watchOSApp/watchOSApp_archive-root/Payload/watchOSApp.app",
+            "p": "bazel-out/CONFIGURATION-STABLE-19/bin/watchOSApp/watchOSApp.app",
             "t": "com.apple.product-type.application.watchapp2"
         },
         "x": [
@@ -8326,7 +8326,7 @@
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.example",
             "PRODUCT_MODULE_NAME": "iOSApp",
             "SWIFT_COMPILATION_MODE": "wholemodule",
-            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-10/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-10/bin/UI/UIFramework.iOS.zip/Modules $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer",
+            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-10/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-10/bin/UI/UIFramework.iOS.framework/Modules $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer",
             "TARGETED_DEVICE_FAMILY": "1"
         },
         "c": "CONFIGURATION-STABLE-10",
@@ -8379,7 +8379,7 @@
             "e": "iOSApp_ExecutableName",
             "m": "iOSApp",
             "n": "iOSApp",
-            "p": "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Source/iOSApp_archive-root/Payload/iOSApp.app",
+            "p": "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Source/iOSApp.app",
             "t": "com.apple.product-type.application"
         },
         "r": [
@@ -8431,7 +8431,7 @@
             "e": "Lib",
             "m": "Lib",
             "n": "Lib",
-            "p": "bazel-out/CONFIGURATION-STABLE-10/bin/Lib/dist/dynamic/iOS_archive-root/Lib.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-10/bin/Lib/dist/dynamic/Lib.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -8518,7 +8518,7 @@
             "e": "Lib",
             "m": "Lib",
             "n": "Lib",
-            "p": "bazel-out/CONFIGURATION-STABLE-12/bin/Lib/dist/dynamic/tvOS_archive-root/Lib.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-12/bin/Lib/dist/dynamic/Lib.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -8565,7 +8565,7 @@
             "e": "Lib",
             "m": "Lib",
             "n": "Lib",
-            "p": "bazel-out/CONFIGURATION-STABLE-11/bin/Lib/dist/dynamic/watchOS_archive-root/Lib.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-11/bin/Lib/dist/dynamic/Lib.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -8612,7 +8612,7 @@
             "e": "LibFramework.tvOS",
             "m": "LibFramework.tvOS",
             "n": "LibFramework.tvOS",
-            "p": "bazel-out/CONFIGURATION-STABLE-12/bin/Lib/LibFramework.tvOS_archive-root/LibFramework.tvOS.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-12/bin/Lib/LibFramework.tvOS.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -8649,7 +8649,7 @@
             "OTHER_SWIFT_FLAGS": "-F$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator -Xcc -F -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(BAZEL_OUT)/CONFIGURATION-STABLE-12/bin/external/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(PROJECT_DIR) -Xcc -iquote -Xcc $(BAZEL_OUT)/CONFIGURATION-STABLE-12/bin -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap -Xcc -Os -Xcc -DNDEBUG=1 -Xcc -Wno-unused-variable -Xcc -Winit-self -Xcc -Wno-extra",
             "PREVIEWS_SWIFT_INCLUDE__": "",
             "PREVIEWS_SWIFT_INCLUDE__NO": "",
-            "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-12/bin/UI/UIFramework.tvOS.zip/Modules",
+            "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-12/bin/UI/UIFramework.tvOS.framework/Modules",
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.UIFramework",
             "PRODUCT_MODULE_NAME": "UI",
             "SWIFT_COMPILATION_MODE": "wholemodule",
@@ -8682,7 +8682,7 @@
             "e": "UIFramework.tvOS",
             "m": "UIFramework.tvOS",
             "n": "UIFramework.tvOS",
-            "p": "bazel-out/CONFIGURATION-STABLE-12/bin/UI/UIFramework.tvOS_archive-root/UIFramework.tvOS.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-12/bin/UI/UIFramework.tvOS.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -8723,7 +8723,7 @@
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.example",
             "PRODUCT_MODULE_NAME": "tvOSApp",
             "SWIFT_COMPILATION_MODE": "wholemodule",
-            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-12/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-12/bin/UI/UIFramework.tvOS.zip/Modules",
+            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-12/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-12/bin/UI/UIFramework.tvOS.framework/Modules",
             "TARGETED_DEVICE_FAMILY": "3"
         },
         "c": "CONFIGURATION-STABLE-12",
@@ -8754,7 +8754,7 @@
             "e": "tvOSApp",
             "m": "tvOSApp",
             "n": "tvOSApp",
-            "p": "bazel-out/CONFIGURATION-STABLE-12/bin/tvOSApp/Source/tvOSApp_archive-root/Payload/tvOSApp.app",
+            "p": "bazel-out/CONFIGURATION-STABLE-12/bin/tvOSApp/Source/tvOSApp.app",
             "t": "com.apple.product-type.application"
         },
         "x": [
@@ -8799,7 +8799,7 @@
             "e": "ABundle",
             "m": "ABundle",
             "n": "ABundle",
-            "p": "bazel-out/CONFIGURATION-STABLE-13/bin/Bundle/Bundle_archive-root/ABundle.aplugin",
+            "p": "bazel-out/CONFIGURATION-STABLE-13/bin/Bundle/ABundle.aplugin",
             "t": "com.apple.product-type.bundle"
         },
         "x": [
@@ -8972,7 +8972,7 @@
             "e": "iOSAppObjCUnitTests",
             "m": "iOSAppObjCUnitTests",
             "n": "iOSAppObjCUnitTests",
-            "p": "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.__internal__.__test_bundle_archive-root/iOSAppObjCUnitTests.xctest",
+            "p": "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         },
         "r": [
@@ -9033,7 +9033,7 @@
             "e": "iOSAppUITests",
             "m": "iOSAppUITests",
             "n": "iOSAppUITests",
-            "p": "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/UITests/iOSAppUITests.__internal__.__test_bundle_archive-root/iOSAppUITests.xctest",
+            "p": "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/UITests/iOSAppUITests.xctest",
             "t": "com.apple.product-type.bundle.ui-testing"
         },
         "r": [
@@ -9148,7 +9148,7 @@
             "e": "iMessageAppExtension",
             "m": "iMessageAppExtension",
             "n": "iMessageAppExtension",
-            "p": "bazel-out/CONFIGURATION-STABLE-10/bin/iMessageApp/iMessageAppExtension_archive-root/iMessageAppExtension.appex",
+            "p": "bazel-out/CONFIGURATION-STABLE-10/bin/iMessageApp/iMessageAppExtension.appex",
             "t": "com.apple.product-type.app-extension.messages"
         },
         "x": [
@@ -9189,7 +9189,7 @@
             "e": "iMessageApp",
             "m": "iMessageApp",
             "n": "iMessageApp",
-            "p": "bazel-out/CONFIGURATION-STABLE-10/bin/iMessageApp/iMessageApp_archive-root/Payload/iMessageApp.app",
+            "p": "bazel-out/CONFIGURATION-STABLE-10/bin/iMessageApp/iMessageApp.app",
             "t": "com.apple.product-type.application.messages"
         },
         "x": [
@@ -9231,7 +9231,7 @@
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.example.tests",
             "PRODUCT_MODULE_NAME": "iOSAppSwiftUnitTests",
             "SWIFT_COMPILATION_MODE": "wholemodule",
-            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-10/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-10/bin/UI/UIFramework.iOS.zip/Modules $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Source $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/TestingUtils",
+            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-10/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-10/bin/UI/UIFramework.iOS.framework/Modules $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Source $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/TestingUtils",
             "TARGETED_DEVICE_FAMILY": "1,2"
         },
         "c": "CONFIGURATION-STABLE-10",
@@ -9268,7 +9268,7 @@
             "e": "iOSAppSwiftUnitTests",
             "m": "iOSAppSwiftUnitTests",
             "n": "iOSAppSwiftUnitTests",
-            "p": "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.__internal__.__test_bundle_archive-root/iOSAppSwiftUnitTests.xctest",
+            "p": "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         },
         "x": [
@@ -9354,7 +9354,7 @@
             "e": "Lib",
             "m": "Lib",
             "n": "Lib",
-            "p": "bazel-out/CONFIGURATION-STABLE-13/bin/macOSApp/Source/macOSLib.framework_archive-root/Lib.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-13/bin/macOSApp/Source/Lib.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -9427,7 +9427,7 @@
             "e": "macOSApp",
             "m": "macOSApp",
             "n": "macOSApp",
-            "p": "bazel-out/CONFIGURATION-STABLE-13/bin/macOSApp/Source/macOSApp_archive-root/Payload/macOSApp.app",
+            "p": "bazel-out/CONFIGURATION-STABLE-13/bin/macOSApp/Source/macOSApp.app",
             "t": "com.apple.product-type.application"
         },
         "x": [
@@ -9484,7 +9484,7 @@
             "e": "macOSAppUITests",
             "m": "macOSAppUITests",
             "n": "macOSAppUITests",
-            "p": "bazel-out/CONFIGURATION-STABLE-13/bin/macOSApp/Test/UITests/macOSAppUITests.__internal__.__test_bundle_archive-root/macOSAppUITests.xctest",
+            "p": "bazel-out/CONFIGURATION-STABLE-13/bin/macOSApp/Test/UITests/macOSAppUITests.xctest",
             "t": "com.apple.product-type.bundle.ui-testing"
         },
         "x": [
@@ -9542,7 +9542,7 @@
             "e": "tvOSAppUITests",
             "m": "tvOSAppUITests",
             "n": "tvOSAppUITests",
-            "p": "bazel-out/CONFIGURATION-STABLE-12/bin/tvOSApp/Test/UITests/tvOSAppUITests.__internal__.__test_bundle_archive-root/tvOSAppUITests.xctest",
+            "p": "bazel-out/CONFIGURATION-STABLE-12/bin/tvOSApp/Test/UITests/tvOSAppUITests.xctest",
             "t": "com.apple.product-type.bundle.ui-testing"
         },
         "x": [
@@ -9583,7 +9583,7 @@
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.example.tests",
             "PRODUCT_MODULE_NAME": "tvOSAppUnitTests",
             "SWIFT_COMPILATION_MODE": "wholemodule",
-            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-12/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-12/bin/UI/UIFramework.tvOS.zip/Modules $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-12/bin/tvOSApp/Source",
+            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-12/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-12/bin/UI/UIFramework.tvOS.framework/Modules $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-12/bin/tvOSApp/Source",
             "TARGETED_DEVICE_FAMILY": "3"
         },
         "c": "CONFIGURATION-STABLE-12",
@@ -9612,7 +9612,7 @@
             "e": "tvOSAppUnitTests",
             "m": "tvOSAppUnitTests",
             "n": "tvOSAppUnitTests",
-            "p": "bazel-out/CONFIGURATION-STABLE-12/bin/tvOSApp/Test/UnitTests/tvOSAppUnitTests.__internal__.__test_bundle_archive-root/tvOSAppUnitTests.xctest",
+            "p": "bazel-out/CONFIGURATION-STABLE-12/bin/tvOSApp/Test/UnitTests/tvOSAppUnitTests.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         },
         "x": [
@@ -9670,7 +9670,7 @@
             "e": "watchOSAppUITests",
             "m": "watchOSAppUITests",
             "n": "watchOSAppUITests",
-            "p": "bazel-out/CONFIGURATION-STABLE-11/bin/watchOSApp/Test/UITests/watchOSAppUITests.__internal__.__test_bundle_archive-root/watchOSAppUITests.xctest",
+            "p": "bazel-out/CONFIGURATION-STABLE-11/bin/watchOSApp/Test/UITests/watchOSAppUITests.xctest",
             "t": "com.apple.product-type.bundle.ui-testing"
         },
         "x": [
@@ -9711,7 +9711,7 @@
             "PRODUCT_BUNDLE_IDENTIFIER": "com.bazelbuild.rulesapple.Tests",
             "PRODUCT_MODULE_NAME": "watchOSAppExtensionUnitTestsLibrary",
             "SWIFT_COMPILATION_MODE": "wholemodule",
-            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-11/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-11/bin/UI/UIFramework.watchOS.zip/Modules",
+            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-11/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-11/bin/UI/UIFramework.watchOS.framework/Modules",
             "TARGETED_DEVICE_FAMILY": "4"
         },
         "c": "CONFIGURATION-STABLE-11",
@@ -9739,7 +9739,7 @@
             "e": "watchOSAppExtensionUnitTests",
             "m": "watchOSAppExtensionUnitTests",
             "n": "watchOSAppExtensionUnitTests",
-            "p": "bazel-out/CONFIGURATION-STABLE-11/bin/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTests.__internal__.__test_bundle_archive-root/watchOSAppExtensionUnitTests.xctest",
+            "p": "bazel-out/CONFIGURATION-STABLE-11/bin/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTests.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         },
         "x": [
@@ -9797,7 +9797,7 @@
             "e": "iOSAppUITestSuite",
             "m": "iOSAppUITestSuite",
             "n": "iOSAppUITestSuite",
-            "p": "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/UITests/iOSAppUITestSuite.__internal__.__test_bundle_archive-root/iOSAppUITestSuite.xctest",
+            "p": "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/UITests/iOSAppUITestSuite.xctest",
             "t": "com.apple.product-type.bundle.ui-testing"
         },
         "r": [
@@ -9865,7 +9865,7 @@
             "e": "iOSAppObjCUnitTestSuite",
             "m": "iOSAppObjCUnitTestSuite",
             "n": "iOSAppObjCUnitTestSuite",
-            "p": "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTestSuite.__internal__.__test_bundle_archive-root/iOSAppObjCUnitTestSuite.xctest",
+            "p": "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTestSuite.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         },
         "r": [
@@ -9910,7 +9910,7 @@
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.example.tests",
             "PRODUCT_MODULE_NAME": "iOSAppSwiftUnitTestSuite",
             "SWIFT_COMPILATION_MODE": "wholemodule",
-            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-10/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-10/bin/UI/UIFramework.iOS.zip/Modules $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Source $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/TestingUtils",
+            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-10/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-10/bin/UI/UIFramework.iOS.framework/Modules $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Source $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/TestingUtils",
             "TARGETED_DEVICE_FAMILY": "1,2"
         },
         "c": "CONFIGURATION-STABLE-10",
@@ -9947,7 +9947,7 @@
             "e": "iOSAppSwiftUnitTestSuite",
             "m": "iOSAppSwiftUnitTestSuite",
             "n": "iOSAppSwiftUnitTestSuite",
-            "p": "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTestSuite.__internal__.__test_bundle_archive-root/iOSAppSwiftUnitTestSuite.xctest",
+            "p": "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTestSuite.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         },
         "x": [
@@ -13235,7 +13235,7 @@
             "e": "CommandLineToolTests",
             "m": "CommandLineToolTests",
             "n": "CommandLineToolTests",
-            "p": "bazel-out/CONFIGURATION-STABLE-26/bin/CommandLine/Tests/CommandLineToolTests.__internal__.__test_bundle_archive-root/CommandLineToolTests.xctest",
+            "p": "bazel-out/CONFIGURATION-STABLE-26/bin/CommandLine/Tests/CommandLineToolTests.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         },
         "x": [
@@ -13349,7 +13349,7 @@
             "e": "AppClip",
             "m": "AppClip",
             "n": "AppClip",
-            "p": "bazel-out/CONFIGURATION-STABLE-14/bin/AppClip/AppClip_archive-root/Payload/AppClip.app",
+            "p": "bazel-out/CONFIGURATION-STABLE-14/bin/AppClip/AppClip.app",
             "t": "com.apple.product-type.application.on-demand-install-capable"
         },
         "x": [
@@ -13495,7 +13495,7 @@
             "e": "WidgetExtension",
             "m": "WidgetExtension",
             "n": "WidgetExtension",
-            "p": "bazel-out/CONFIGURATION-STABLE-14/bin/WidgetExtension/WidgetExtension_archive-root/WidgetExtension.appex",
+            "p": "bazel-out/CONFIGURATION-STABLE-14/bin/WidgetExtension/WidgetExtension.appex",
             "t": "com.apple.product-type.app-extension"
         },
         "x": [
@@ -13549,7 +13549,7 @@
             "e": "CoreUtilsObjC",
             "m": "CoreUtilsObjC",
             "n": "CoreUtilsObjC",
-            "p": "bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Source/CoreUtilsObjC/FrameworkCoreUtilsObjC_archive-root/CoreUtilsObjC.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Source/CoreUtilsObjC/CoreUtilsObjC.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -13596,7 +13596,7 @@
             "e": "LibFramework.iOS",
             "m": "LibFramework.iOS",
             "n": "LibFramework.iOS",
-            "p": "bazel-out/CONFIGURATION-STABLE-14/bin/Lib/LibFramework.iOS_archive-root/LibFramework.iOS.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-14/bin/Lib/LibFramework.iOS.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -13633,7 +13633,7 @@
             "OTHER_SWIFT_FLAGS": "-F$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7 -Xcc -F -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7 -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(BAZEL_OUT)/CONFIGURATION-STABLE-14/bin/external/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(PROJECT_DIR) -Xcc -iquote -Xcc $(BAZEL_OUT)/CONFIGURATION-STABLE-14/bin -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework/Modules/module.modulemap -Xcc -Os -Xcc -DNDEBUG=1 -Xcc -Wno-unused-variable -Xcc -Winit-self -Xcc -Wno-extra",
             "PREVIEWS_SWIFT_INCLUDE__": "",
             "PREVIEWS_SWIFT_INCLUDE__NO": "",
-            "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-14/bin/UI/UIFramework.iOS.zip/Modules",
+            "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-14/bin/UI/UIFramework.iOS.framework/Modules",
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.UIFramework",
             "PRODUCT_MODULE_NAME": "UI",
             "SWIFT_COMPILATION_MODE": "wholemodule",
@@ -13669,7 +13669,7 @@
             "e": "UIFramework.iOS",
             "m": "UIFramework.iOS",
             "n": "UIFramework.iOS",
-            "p": "bazel-out/CONFIGURATION-STABLE-14/bin/UI/UIFramework.iOS_archive-root/UIFramework.iOS.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-14/bin/UI/UIFramework.iOS.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -13756,7 +13756,7 @@
             "e": "LibFramework.watchOS",
             "m": "LibFramework.watchOS",
             "n": "LibFramework.watchOS",
-            "p": "bazel-out/CONFIGURATION-STABLE-15/bin/Lib/LibFramework.watchOS_archive-root/LibFramework.watchOS.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-15/bin/Lib/LibFramework.watchOS.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -13793,7 +13793,7 @@
             "OTHER_SWIFT_FLAGS": "-F$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k -Xcc -F -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(BAZEL_OUT)/CONFIGURATION-STABLE-15/bin/external/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(PROJECT_DIR) -Xcc -iquote -Xcc $(BAZEL_OUT)/CONFIGURATION-STABLE-15/bin -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k/CryptoSwift.framework/Modules/module.modulemap -Xcc -Os -Xcc -DNDEBUG=1 -Xcc -Wno-unused-variable -Xcc -Winit-self -Xcc -Wno-extra",
             "PREVIEWS_SWIFT_INCLUDE__": "",
             "PREVIEWS_SWIFT_INCLUDE__NO": "",
-            "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-15/bin/UI/UIFramework.watchOS.zip/Modules",
+            "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-15/bin/UI/UIFramework.watchOS.framework/Modules",
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.UIFramework",
             "PRODUCT_MODULE_NAME": "UI",
             "SWIFT_COMPILATION_MODE": "wholemodule",
@@ -13826,7 +13826,7 @@
             "e": "UIFramework.watchOS",
             "m": "UIFramework.watchOS",
             "n": "UIFramework.watchOS",
-            "p": "bazel-out/CONFIGURATION-STABLE-15/bin/UI/UIFramework.watchOS_archive-root/UIFramework.watchOS.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-15/bin/UI/UIFramework.watchOS.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -13869,7 +13869,7 @@
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.example.watch.extension",
             "PRODUCT_MODULE_NAME": "watchOSAppExtension",
             "SWIFT_COMPILATION_MODE": "wholemodule",
-            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-15/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-15/bin/UI/UIFramework.watchOS.zip/Modules",
+            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-15/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-15/bin/UI/UIFramework.watchOS.framework/Modules",
             "TARGETED_DEVICE_FAMILY": "4"
         },
         "c": "CONFIGURATION-STABLE-15",
@@ -13900,7 +13900,7 @@
             "e": "watchOSAppExtension",
             "m": "watchOSAppExtension",
             "n": "watchOSAppExtension",
-            "p": "bazel-out/CONFIGURATION-STABLE-15/bin/watchOSAppExtension/watchOSAppExtension_archive-root/watchOSAppExtension.appex",
+            "p": "bazel-out/CONFIGURATION-STABLE-15/bin/watchOSAppExtension/watchOSAppExtension.appex",
             "t": "com.apple.product-type.watchkit2-extension"
         },
         "x": [
@@ -13942,7 +13942,7 @@
             "e": "watchOSApp",
             "m": "watchOSApp",
             "n": "watchOSApp",
-            "p": "bazel-out/CONFIGURATION-STABLE-20/bin/watchOSApp/watchOSApp_archive-root/Payload/watchOSApp.app",
+            "p": "bazel-out/CONFIGURATION-STABLE-20/bin/watchOSApp/watchOSApp.app",
             "t": "com.apple.product-type.application.watchapp2"
         },
         "x": [
@@ -13990,7 +13990,7 @@
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.example",
             "PRODUCT_MODULE_NAME": "iOSApp",
             "SWIFT_COMPILATION_MODE": "wholemodule",
-            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-14/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-14/bin/UI/UIFramework.iOS.zip/Modules $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer",
+            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-14/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-14/bin/UI/UIFramework.iOS.framework/Modules $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer",
             "TARGETED_DEVICE_FAMILY": "1"
         },
         "c": "CONFIGURATION-STABLE-14",
@@ -14043,7 +14043,7 @@
             "e": "iOSApp",
             "m": "iOSApp",
             "n": "iOSApp",
-            "p": "bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Source/iOSApp_archive-root/Payload/iOSApp.app",
+            "p": "bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Source/iOSApp.app",
             "t": "com.apple.product-type.application"
         },
         "r": [
@@ -14095,7 +14095,7 @@
             "e": "Lib",
             "m": "Lib",
             "n": "Lib",
-            "p": "bazel-out/CONFIGURATION-STABLE-14/bin/Lib/dist/dynamic/iOS_archive-root/Lib.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-14/bin/Lib/dist/dynamic/Lib.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -14182,7 +14182,7 @@
             "e": "Lib",
             "m": "Lib",
             "n": "Lib",
-            "p": "bazel-out/CONFIGURATION-STABLE-16/bin/Lib/dist/dynamic/tvOS_archive-root/Lib.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-16/bin/Lib/dist/dynamic/Lib.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -14229,7 +14229,7 @@
             "e": "Lib",
             "m": "Lib",
             "n": "Lib",
-            "p": "bazel-out/CONFIGURATION-STABLE-15/bin/Lib/dist/dynamic/watchOS_archive-root/Lib.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-15/bin/Lib/dist/dynamic/Lib.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -14276,7 +14276,7 @@
             "e": "LibFramework.tvOS",
             "m": "LibFramework.tvOS",
             "n": "LibFramework.tvOS",
-            "p": "bazel-out/CONFIGURATION-STABLE-16/bin/Lib/LibFramework.tvOS_archive-root/LibFramework.tvOS.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-16/bin/Lib/LibFramework.tvOS.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -14313,7 +14313,7 @@
             "OTHER_SWIFT_FLAGS": "-F$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64 -Xcc -F -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64 -Xcc -iquote -Xcc $(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(BAZEL_OUT)/CONFIGURATION-STABLE-16/bin/external/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift -Xcc -iquote -Xcc $(PROJECT_DIR) -Xcc -iquote -Xcc $(BAZEL_OUT)/CONFIGURATION-STABLE-16/bin -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/_main~non_module_deps~com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64/CryptoSwift.framework/Modules/module.modulemap -Xcc -Os -Xcc -DNDEBUG=1 -Xcc -Wno-unused-variable -Xcc -Winit-self -Xcc -Wno-extra",
             "PREVIEWS_SWIFT_INCLUDE__": "",
             "PREVIEWS_SWIFT_INCLUDE__NO": "",
-            "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-16/bin/UI/UIFramework.tvOS.zip/Modules",
+            "PREVIEWS_SWIFT_INCLUDE__YES": "-I $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-16/bin/UI/UIFramework.tvOS.framework/Modules",
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.UIFramework",
             "PRODUCT_MODULE_NAME": "UI",
             "SWIFT_COMPILATION_MODE": "wholemodule",
@@ -14346,7 +14346,7 @@
             "e": "UIFramework.tvOS",
             "m": "UIFramework.tvOS",
             "n": "UIFramework.tvOS",
-            "p": "bazel-out/CONFIGURATION-STABLE-16/bin/UI/UIFramework.tvOS_archive-root/UIFramework.tvOS.framework",
+            "p": "bazel-out/CONFIGURATION-STABLE-16/bin/UI/UIFramework.tvOS.framework",
             "t": "com.apple.product-type.framework"
         },
         "x": [
@@ -14388,7 +14388,7 @@
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.example",
             "PRODUCT_MODULE_NAME": "tvOSApp",
             "SWIFT_COMPILATION_MODE": "wholemodule",
-            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-16/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-16/bin/UI/UIFramework.tvOS.zip/Modules",
+            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-16/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-16/bin/UI/UIFramework.tvOS.framework/Modules",
             "TARGETED_DEVICE_FAMILY": "3"
         },
         "c": "CONFIGURATION-STABLE-16",
@@ -14419,7 +14419,7 @@
             "e": "tvOSApp",
             "m": "tvOSApp",
             "n": "tvOSApp",
-            "p": "bazel-out/CONFIGURATION-STABLE-16/bin/tvOSApp/Source/tvOSApp_archive-root/Payload/tvOSApp.app",
+            "p": "bazel-out/CONFIGURATION-STABLE-16/bin/tvOSApp/Source/tvOSApp.app",
             "t": "com.apple.product-type.application"
         },
         "x": [
@@ -14592,7 +14592,7 @@
             "e": "iOSAppObjCUnitTests",
             "m": "iOSAppObjCUnitTests",
             "n": "iOSAppObjCUnitTests",
-            "p": "bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.__internal__.__test_bundle_archive-root/iOSAppObjCUnitTests.xctest",
+            "p": "bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         },
         "r": [
@@ -14653,7 +14653,7 @@
             "e": "iOSAppUITests",
             "m": "iOSAppUITests",
             "n": "iOSAppUITests",
-            "p": "bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Test/UITests/iOSAppUITests.__internal__.__test_bundle_archive-root/iOSAppUITests.xctest",
+            "p": "bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Test/UITests/iOSAppUITests.xctest",
             "t": "com.apple.product-type.bundle.ui-testing"
         },
         "r": [
@@ -14698,7 +14698,7 @@
             "PRODUCT_BUNDLE_IDENTIFIER": "rules-xcodeproj.example.tests",
             "PRODUCT_MODULE_NAME": "iOSAppSwiftUnitTests",
             "SWIFT_COMPILATION_MODE": "wholemodule",
-            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-14/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-14/bin/UI/UIFramework.iOS.zip/Modules $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Source $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Test/TestingUtils",
+            "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-14/bin/Lib $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-14/bin/UI/UIFramework.iOS.framework/Modules $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Source $(BUILD_DIR)/bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Test/TestingUtils",
             "TARGETED_DEVICE_FAMILY": "1,2"
         },
         "c": "CONFIGURATION-STABLE-14",
@@ -14735,7 +14735,7 @@
             "e": "iOSAppSwiftUnitTests",
             "m": "iOSAppSwiftUnitTests",
             "n": "iOSAppSwiftUnitTests",
-            "p": "bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.__internal__.__test_bundle_archive-root/iOSAppSwiftUnitTests.xctest",
+            "p": "bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.xctest",
             "t": "com.apple.product-type.bundle.unit-test"
         },
         "x": [

--- a/test/internal/target/process_top_level_properties_tests.bzl
+++ b/test/internal/target/process_top_level_properties_tests.bzl
@@ -27,12 +27,6 @@ def _process_top_level_properties_test_impl(ctx):
 
     asserts.equals(
         env,
-        ctx.attr.expected_bundle_path if ctx.attr.expected_bundle_path else None,
-        properties.bundle_file_path,
-        "bundle_file_path",
-    )
-    asserts.equals(
-        env,
         ctx.attr.expected_product_name,
         properties.product_name,
         "product_name",

--- a/test/internal/target/process_top_level_properties_tests.bzl
+++ b/test/internal/target/process_top_level_properties_tests.bzl
@@ -20,7 +20,6 @@ def _process_top_level_properties_test_impl(ctx):
             for p in ctx.attr.target_files
         ],
         bundle_info = _bundle_info_stub(ctx.attr.bundle_info),
-        tree_artifact_enabled = ctx.attr.tree_artifact_enabled,
         build_settings = build_settings,
     )
     string_build_settings = stringify_dict(build_settings)
@@ -64,7 +63,6 @@ process_top_level_properties_test = unittest.make(
         "expected_product_type": attr.string(mandatory = True),
         "target_files": attr.string_list(mandatory = True),
         "target_name": attr.string(mandatory = True),
-        "tree_artifact_enabled": attr.bool(mandatory = True),
     },
 )
 
@@ -118,7 +116,6 @@ def process_top_level_properties_test_suite(name):
             target_name,
             target_files,
             bundle_info,
-            tree_artifact_enabled,
             expected_bundle_path,
             expected_executable_name,
             expected_product_name,
@@ -130,7 +127,6 @@ def process_top_level_properties_test_suite(name):
             target_name = target_name,
             target_files = target_files,
             bundle_info = bundle_info,
-            tree_artifact_enabled = tree_artifact_enabled,
             expected_bundle_path = expected_bundle_path,
             expected_executable_name = expected_executable_name,
             expected_product_name = expected_product_name,
@@ -146,7 +142,6 @@ def process_top_level_properties_test_suite(name):
         target_name = "binary",
         target_files = ["bazel-out/some/binary"],
         bundle_info = None,
-        tree_artifact_enabled = True,
         expected_bundle_path = None,
         expected_executable_name = "binary",
         expected_product_name = "binary",
@@ -159,7 +154,6 @@ def process_top_level_properties_test_suite(name):
         target_name = "test",
         target_files = ["bazel-out/some/test.xctest/test"],
         bundle_info = None,
-        tree_artifact_enabled = True,
         expected_bundle_path = "bazel-out/some/test.xctest",
         expected_executable_name = "test",
         expected_product_name = "test",
@@ -182,7 +176,6 @@ def process_top_level_properties_test_suite(name):
             product_type = "com.apple.product-type.application",
             executable_name = "executable_name",
         ),
-        tree_artifact_enabled = True,
         expected_bundle_path = "bazel-out/some/flagship.app",
         expected_executable_name = "executable_name",
         expected_product_name = "flagship",
@@ -205,7 +198,6 @@ def process_top_level_properties_test_suite(name):
             product_type = "com.apple.product-type.application",
             executable_name = "executable_name",
         ),
-        tree_artifact_enabled = False,
         expected_bundle_path = (
             "bazel-out/some/intermediate/Payload/flagship.app"
         ),
@@ -230,7 +222,6 @@ def process_top_level_properties_test_suite(name):
             product_type = "com.apple.product-type.bundle.unit-test",
             executable_name = "executable_name",
         ),
-        tree_artifact_enabled = False,
         expected_bundle_path = "bazel-out/some/intermediate/flagship.xctest",
         expected_executable_name = "executable_name",
         expected_product_name = "flagship",

--- a/xcodeproj/internal/bazel_integration_files/copy_outputs.sh
+++ b/xcodeproj/internal/bazel_integration_files/copy_outputs.sh
@@ -23,36 +23,7 @@ readonly test_frameworks=(
 if [[ "$ACTION" != indexbuild ]]; then
   # Copy product
   if [[ -n ${BAZEL_OUTPUTS_PRODUCT:-} ]]; then
-    if [[ "$BAZEL_OUTPUTS_PRODUCT" = *.ipa ]]; then
-      suffix=/Payload
-    fi
-
-    if [[ "$BAZEL_OUTPUTS_PRODUCT" = *.ipa ]] || [[ "$BAZEL_OUTPUTS_PRODUCT" = *.zip ]]; then
-      # Extract archive first
-      readonly archive="$BAZEL_OUTPUTS_PRODUCT"
-      readonly expanded_dest="$DERIVED_FILE_DIR/expanded_archive"
-      readonly product_parent_dir="$expanded_dest${suffix:-}"
-      readonly sha_output="$DERIVED_FILE_DIR/archive.sha256"
-
-      existing_sha=$(cat "$sha_output" 2>/dev/null || true)
-      sha=$(shasum -a 256 "$archive")
-
-      if [[ \
-        "$existing_sha" != "$sha" || \
-        ! -d "$product_parent_dir/$BAZEL_OUTPUTS_PRODUCT_BASENAME" \
-      ]]; then
-        mkdir -p "$expanded_dest"
-        rm -rf "${expanded_dest:?}/"
-        echo "Extracting $archive to $expanded_dest"
-        # Set timestamps (-DD) to allow rsync to work properly, since Bazel
-        # zeroes out timestamps in the archive
-        unzip -q -DD "$archive" -d "$expanded_dest"
-        echo "$sha" > "$sha_output"
-      fi
-      cd "$product_parent_dir"
-    else
-      cd "${BAZEL_OUTPUTS_PRODUCT%/*}"
-    fi
+    cd "${BAZEL_OUTPUTS_PRODUCT%/*}"
 
     if [[ -f "$BAZEL_OUTPUTS_PRODUCT_BASENAME" ]]; then
       # Product is a binary, so symlink instead of rsync, to allow for Bazel-set

--- a/xcodeproj/internal/product.bzl
+++ b/xcodeproj/internal/product.bzl
@@ -37,6 +37,11 @@ PRODUCT_TYPE_ENCODED = {
     "com.apple.product-type.xpc-service": "X",
 }
 
+_ARCHIVE_EXTENSIONS = {
+    "ipa": None,
+    "zip": None,
+}
+
 def _codesign_executable(*, actions, executable):
     executable_path = "{}_codesigned".format(
         executable.basename,
@@ -98,14 +103,51 @@ exit ${PIPESTATUS[0]}
 
     return output
 
+def _extract_archive(*, actions, archive, bundle_name, bundle_extension):
+    output = actions.declare_directory(
+        bundle_name + bundle_extension,
+        sibling = archive,
+    )
+
+    args = actions.args()
+    args.add(archive)
+    args.add(output.path)
+
+    actions.run_shell(
+        inputs = [archive],
+        outputs = [output],
+        command = """\
+set -eu
+
+readonly archive="$1"
+readonly output="$2"
+
+if [[ "$archive" = *.ipa ]]; then
+    suffix=/Payload
+else
+    suffix=
+fi
+
+expanded_dir=$(mktemp -d)
+trap 'rm -rf "$expanded_dir"' EXIT
+
+unzip -q -DD "$archive" -d "$expanded_dir"
+mv "$expanded_dir$suffix/${output##*/}" "${output%/*}"
+""",
+        arguments = [args],
+        mnemonic = "XcodeProjExtractBundleArchive",
+    )
+
+    return output
+
 def process_product(
         *,
         actions,
-        archive_file_path = None,
         bin_dir_path,
+        bundle_extension = None,
         bundle_file = None,
+        bundle_name = None,
         bundle_path = None,
-        bundle_file_path = None,
         executable_name = None,
         is_resource_bundle = False,
         linker_inputs,
@@ -117,14 +159,14 @@ def process_product(
 
     Args:
         actions: `ctx.actions`.
-        archive_file_path: If the product is a bundle, this is
-            `file_path` to the bundle, possibly in an archive, otherwise `None`.
         bin_dir_path: `ctx.bin_dir.path`.
+        bundle_extension: If the product is a bundle, the extension of the
+            unarchived bundle, otherwise `None`.
         bundle_file: If the product is a bundle, this is `File` for the bundle,
             otherwise `None`.
+        bundle_name: If the product is a bundle, this is the name of the
+            unarchived bundle, without the extension, otherwise `None`.
         bundle_path: If the product is a bundle, this is the path to
-            the bundle, when not in an archive, otherwise `None`.
-        bundle_file_path: If the product is a bundle, this is the `file_path` to
             the bundle, when not in an archive, otherwise `None`.
         executable_name: If the product is a bundle, this is the executable
             name, otherwise `None`.
@@ -141,33 +183,42 @@ def process_product(
     Returns:
         A `struct` with various fields describing the product.
     """
-    if bundle_file_path:
+    if bundle_file and bundle_file.extension in _ARCHIVE_EXTENSIONS:
+        file = _extract_archive(
+            actions = actions,
+            archive = bundle_file,
+            bundle_name = bundle_name,
+            bundle_extension = bundle_extension,
+        )
+        basename = file.basename
+        path = file.path
+        fp = path
+        actual_fp = path
+    elif bundle_path:
+        # Tree artifacts, resource bundles, and `swift_test`
         file = bundle_file
-        basename = paths.basename(bundle_file_path)
-        fp = bundle_file_path
-        actual_fp = archive_file_path
+        basename = paths.basename(bundle_path)
+        path = bundle_path
+        fp = path
+        actual_fp = path
     elif target[DefaultInfo].files_to_run.executable:
         executable = target[DefaultInfo].files_to_run.executable
         file = _codesign_executable(actions = actions, executable = executable)
         basename = file.basename
         fp = executable.path
         actual_fp = fp
+        path = file.path
     elif CcInfo in target and linker_inputs and target.files != depset():
         file = linker_input_files.get_primary_static_library(linker_inputs)
         basename = file.basename if file else None
         fp = file.path if file else None
         actual_fp = fp
+        path = fp
     else:
         file = None
         basename = None
         fp = None
         actual_fp = None
-
-    if bundle_path:
-        path = bundle_path
-    elif file:
-        path = file.path
-    else:
         path = None
 
     if target and apple_common.AppleDynamicFramework in target:

--- a/xcodeproj/internal/product.bzl
+++ b/xcodeproj/internal/product.bzl
@@ -136,6 +136,15 @@ mv "$expanded_dir$suffix/${output##*/}" "${output%/*}"
 """,
         arguments = [args],
         mnemonic = "XcodeProjExtractBundleArchive",
+        execution_requirements = {
+            # Similar to our recommendations on `BundleApp`, by default it
+            # doesn't make sense to cache the output of this action
+            "no-cache": "1",
+            # Similar to our recommendations on `BundleApp`, by default it
+            # doesn't make sense to cache transfer the input or output of this
+            # action over the network
+            "no-remote": "1",
+        },
     )
 
     return output

--- a/xcodeproj/internal/resource_target.bzl
+++ b/xcodeproj/internal/resource_target.bzl
@@ -38,7 +38,6 @@ def _process_resource_bundle(bundle, *, bundle_id):
         bin_dir_path = None,
         bundle_file = None,
         bundle_path = bundle_path,
-        bundle_file_path = bundle_path,
         is_resource_bundle = True,
         linker_inputs = None,
         # For resource bundles, we want to use the bundle name instead of


### PR DESCRIPTION
Part of #2641.

This gets us most of the way to fixing Xcode Previews when not using tree artifacts. The last thing needed is adding these products to an output group for Xcode previews, otherwise unfocused frameworks aren’t extracted.