### PR TITLE
Remove `external.xcfilelist` from incremental generation

### DIFF
--- a/tools/generators/pbxproj_prefix/src/Generator/BazelDependenciesPartial.swift
+++ b/tools/generators/pbxproj_prefix/src/Generator/BazelDependenciesPartial.swift
@@ -36,7 +36,6 @@ extension Generator {
 			);
 			name = "Generate Bazel Dependendencies";
 			outputFileListPaths = (
-				"$(INTERNAL_DIR)/external.xcfilelist",
 				"$(INTERNAL_DIR)/generated.xcfilelist",
 			);
 			outputPaths = (

--- a/tools/generators/pbxproj_prefix/test/BazelDependenciesPartialTests.swift
+++ b/tools/generators/pbxproj_prefix/test/BazelDependenciesPartialTests.swift
@@ -33,7 +33,6 @@ class BazelDependenciesPartialTests: XCTestCase {
 			);
 			name = "Generate Bazel Dependendencies";
 			outputFileListPaths = (
-				"$(INTERNAL_DIR)/external.xcfilelist",
 				"$(INTERNAL_DIR)/generated.xcfilelist",
 			);
 			outputPaths = (
@@ -142,7 +141,6 @@ class BazelDependenciesPartialTests: XCTestCase {
 			);
 			name = "Generate Bazel Dependendencies";
 			outputFileListPaths = (
-				"$(INTERNAL_DIR)/external.xcfilelist",
 				"$(INTERNAL_DIR)/generated.xcfilelist",
 			);
 			outputPaths = (
@@ -251,7 +249,6 @@ class BazelDependenciesPartialTests: XCTestCase {
 			);
 			name = "Generate Bazel Dependendencies";
 			outputFileListPaths = (
-				"$(INTERNAL_DIR)/external.xcfilelist",
 				"$(INTERNAL_DIR)/generated.xcfilelist",
 			);
 			outputPaths = (
@@ -363,7 +360,6 @@ class BazelDependenciesPartialTests: XCTestCase {
 			);
 			name = "Generate Bazel Dependendencies";
 			outputFileListPaths = (
-				"$(INTERNAL_DIR)/external.xcfilelist",
 				"$(INTERNAL_DIR)/generated.xcfilelist",
 			);
 			outputPaths = (


### PR DESCRIPTION
Non-generated source file tracking is only needed for BwX mode, which incremental generation mode doesn’t support.