### PR TITLE
Remove `--experimental_strict_conflict_checks`

### DIFF
--- a/shared.bazelrc
+++ b/shared.bazelrc
@@ -1,5 +1,4 @@
 # Opt into future migrations
-build --experimental_strict_conflict_checks
 build --incompatible_disallow_empty_glob
 
 # Don't create convenience symlinks


### PR DESCRIPTION
No longer available in Bazel 8.