### PR TITLE
Remove `default` cases for `PBXProductType` handling

### DIFF
--- a/tools/generators/xcschemes/src/Generator/CreateAutomaticSchemeInfo.swift
+++ b/tools/generators/xcschemes/src/Generator/CreateAutomaticSchemeInfo.swift
@@ -162,22 +162,35 @@ private extension PBXProductType {
     var isLaunchable: Bool {
         switch self {
         case .application,
-                .messagesApplication,
-                .onDemandInstallCapableApplication,
-                .watch2App,
-                .watch2AppContainer,
-                .appExtension,
-                .intentsServiceExtension,
-                .messagesExtension,
-                .tvExtension,
-                .extensionKitExtension,
-                .xcodeExtension,
-                .driverExtension,
-                .systemExtension,
-                .commandLineTool,
-                .xpcService:
+             .messagesApplication,
+             .onDemandInstallCapableApplication,
+             .watch2App,
+             .watch2AppContainer,
+             .appExtension,
+             .intentsServiceExtension,
+             .messagesExtension,
+             .tvExtension,
+             .extensionKitExtension,
+             .xcodeExtension,
+             .driverExtension,
+             .systemExtension,
+             .commandLineTool,
+             .xpcService:
             return true
-        default:
+        case .stickerPack,
+             .watch2Extension,
+             .resourceBundle,
+             .bundle,
+             .ocUnitTestBundle,
+             .unitTestBundle,
+             .uiTestBundle,
+             .framework,
+             .staticFramework,
+             .xcFramework,
+             .dynamicLibrary,
+             .staticLibrary,
+             .instrumentsPackage,
+             .metalLibrary:
             return false
         }
     }

--- a/tools/generators/xcschemes/src/Generator/CreateAutomaticSchemeInfos.swift
+++ b/tools/generators/xcschemes/src/Generator/CreateAutomaticSchemeInfos.swift
@@ -144,32 +144,40 @@ private extension PBXProductType {
         switch self {
         // Applications
         case .application,
-            .commandLineTool,
-            .messagesApplication,
-            .onDemandInstallCapableApplication,
-            .watch2App,
-            .watch2AppContainer,
-            .xpcService:
+             .commandLineTool,
+             .messagesApplication,
+             .onDemandInstallCapableApplication,
+             .watch2App,
+             .watch2AppContainer,
+             .xpcService:
             return 0
         // App extensions
         case .appExtension,
-            .driverExtension,
-            .extensionKitExtension,
-            .intentsServiceExtension,
-            .messagesExtension,
-            .stickerPack,
-            .systemExtension,
-            .tvExtension,
-            .watch2Extension,
-            .xcodeExtension:
+             .driverExtension,
+             .extensionKitExtension,
+             .intentsServiceExtension,
+             .messagesExtension,
+             .stickerPack,
+             .systemExtension,
+             .tvExtension,
+             .watch2Extension,
+             .xcodeExtension:
             return 1
         // Tests
         case .ocUnitTestBundle,
-            .uiTestBundle,
-            .unitTestBundle:
+             .uiTestBundle,
+             .unitTestBundle:
             return 2
         // Others
-        default:
+        case .resourceBundle,
+             .bundle,
+             .framework,
+             .staticFramework,
+             .xcFramework,
+             .dynamicLibrary,
+             .staticLibrary,
+             .instrumentsPackage,
+             .metalLibrary:
             return 3
         }
     }

--- a/tools/generators/xcschemes/src/Generator/CreateCustomSchemeInfos.swift
+++ b/tools/generators/xcschemes/src/Generator/CreateCustomSchemeInfos.swift
@@ -720,10 +720,10 @@ private extension PBXProductType {
     var needsExtensionHost: Bool {
         switch self {
         case .appExtension,
-                .intentsServiceExtension,
-                .messagesExtension,
-                .tvExtension,
-                .extensionKitExtension:
+             .intentsServiceExtension,
+             .messagesExtension,
+             .tvExtension,
+             .extensionKitExtension:
             return true
         default:
             return false


### PR DESCRIPTION
Better future proofing.