### PR TITLE
Add support for PathRunnable in schemes

### DIFF
--- a/test/internal/xcschemes/info_constructors_tests.bzl
+++ b/test/internal/xcschemes/info_constructors_tests.bzl
@@ -231,6 +231,7 @@ def info_constructors_test_suite(name):
         expected_info = struct(
             extension_host = "",
             id = "",
+            is_path = "0",
             post_actions = [],
             pre_actions = [],
             working_directory = "",
@@ -279,6 +280,7 @@ def info_constructors_test_suite(name):
         expected_info = struct(
             extension_host = "host id",
             id = "an id",
+            is_path = "0",
             post_actions = [
                 xcscheme_infos_testable.make_pre_post_action(
                     for_build = False,
@@ -308,6 +310,23 @@ def info_constructors_test_suite(name):
                 ),
             ],
             working_directory = "a working directory",
+        ),
+    )
+
+    _add_test(
+        name = "{}_make_launch_target_is_path".format(name),
+
+        # Inputs
+        info = xcscheme_infos_testable.make_launch_target(
+            path = "/Foo/Bar.app",
+            working_directory = "/Foo",
+        ),
+
+        # Expected
+        expected_info = struct(
+            is_path = "1",
+            path = "/Foo/Bar.app",
+            working_directory = "/Foo",
         ),
     )
 

--- a/test/internal/xcschemes/infos_from_json_tests.bzl
+++ b/test/internal/xcschemes/infos_from_json_tests.bzl
@@ -285,6 +285,7 @@ def infos_from_json_test_suite(name):
 
     full_launch_target = struct(
         extension_host = "eh label",
+        is_path = "0",
         label = "lt label",
         library_targets = [
             struct(
@@ -462,6 +463,7 @@ def infos_from_json_test_suite(name):
                         pre_actions = [],
                         target_environment = "",
                         working_directory = "",
+                        is_path = "0",
                     ),
                     use_run_args_and_env = "1",
                     xcode_configuration = "",
@@ -652,6 +654,7 @@ def infos_from_json_test_suite(name):
                     env_include_defaults = "1",
                     launch_target = struct(
                         extension_host = "eh label",
+                        is_path = "0",
                         label = "lt label",
                         library_targets = [
                             struct(

--- a/test/internal/xcschemes/utils.bzl
+++ b/test/internal/xcschemes/utils.bzl
@@ -19,13 +19,21 @@ def _dict_to_diagnostics_info(d):
     )
 
 def _dict_to_launch_target_info(d):
-    return struct(
-        extension_host = d["extension_host"],
-        id = d["id"],
-        post_actions = _dicts_to_pre_post_action_infos(d["post_actions"]),
-        pre_actions = _dicts_to_pre_post_action_infos(d["pre_actions"]),
-        working_directory = d["working_directory"],
-    )
+    if d["is_path"] == "1":
+        return struct(
+            is_path = "1",
+            path = d["path"],
+            working_directory = d["working_directory"],
+        )
+    else:
+        return struct(
+            extension_host = d["extension_host"],
+            id = d["id"],
+            is_path = "0",
+            post_actions = _dicts_to_pre_post_action_infos(d["post_actions"]),
+            pre_actions = _dicts_to_pre_post_action_infos(d["pre_actions"]),
+            working_directory = d["working_directory"],
+        )
 
 def _dict_to_profile_info(d):
     return struct(

--- a/test/internal/xcschemes/write_schemes_tests.bzl
+++ b/test/internal/xcschemes/write_schemes_tests.bzl
@@ -768,6 +768,14 @@ def write_schemes_test_suite(name):
                     xcode_configuration = "Test",
                 ),
             ),
+            xcscheme_infos_testable.make_scheme(
+                name = "Scheme 3",
+                run = xcscheme_infos_testable.make_run(
+                    launch_target = xcscheme_infos_testable.make_launch_target(
+                        path = "/Foo/Bar.app",
+                    ),
+                ),
+            ),
         ],
 
         # Expected
@@ -802,7 +810,7 @@ def write_schemes_test_suite(name):
         expected_writes = {
             _CUSTOM_SCHEMES_DECLARED_FILE: "\n".join([
                 # schemeCount
-                "2",
+                "3",
                 # - name
                 "Scheme 2",
                 # - test - testTargetCount
@@ -841,6 +849,8 @@ def write_schemes_test_suite(name):
                 "0",
                 # - run - xcodeConfiguration
                 "",
+                # - run - launchTarget - isPath
+                "0",
                 # - run - launchTarget - id
                 "",
                 # - run - launchTarget - extensionHostID
@@ -859,6 +869,8 @@ def write_schemes_test_suite(name):
                 "1",
                 # - profile - xcodeConfiguration
                 "",
+                # - profile - launchTarget - isPath
+                "0",
                 # - profile - launchTarget - id
                 "",
                 # - profile - launchTarget - extensionHostID
@@ -948,6 +960,8 @@ def write_schemes_test_suite(name):
                 "1",
                 # - run - xcodeConfiguration
                 "Run",
+                # - run - launchTarget - isPath
+                "0",
                 # - run - launchTarget - id
                 "run launch id",
                 # - run - launchTarget - extensionHostID
@@ -982,12 +996,79 @@ def write_schemes_test_suite(name):
                 "0",
                 # - profile - xcodeConfiguration
                 "Profile",
+                # - profile - launchTarget - isPath
+                "0",
                 # - profile - launchTarget - id
                 "profile launch id",
                 # - profile - launchTarget - extensionHostID
                 "profile extension host id",
                 # - profile - customWorkingDirectory
                 "profile working dir",
+
+                # - name
+                "Scheme 3",
+                # - test - testTargetCount
+                "0",
+                # - test - buildTargets count
+                "0",
+                # - test - commandLineArguments count
+                "-1",
+                # - test - environmentVariables count
+                "-1",
+                # - test - environmentVariablesIncludeDefaults
+                "0",
+                # - test - useRunArgsAndEnv
+                "1",
+                # - test - enableAddressSanitizer
+                "0",
+                # - test - enableThreadSanitizer
+                "0",
+                # - test - enableUBSanitizer
+                "0",
+                # - test - xcodeConfiguration
+                "",
+                # - run - buildTargets count
+                "0",
+                # - run - commandLineArguments count
+                "-1",
+                # - run - environmentVariables count
+                "-1",
+                # - run - environmentVariablesIncludeDefaults
+                "1",
+                # - run - enableAddressSanitizer
+                "0",
+                # - run - enableThreadSanitizer
+                "0",
+                # - run - enableUBSanitizer
+                "0",
+                # - run - xcodeConfiguration
+                "",
+                # - run - launchTarget - isPath
+                "1",
+                # - run - launchTarget - path
+                "/Foo/Bar.app",
+                # - run - customWorkingDirectory
+                "",
+                # - profile - buildTargets count
+                "0",
+                # - profile - commandLineArguments count
+                "-1",
+                # - profile - environmentVariables count
+                "-1",
+                # - profile - environmentVariablesIncludeDefaults
+                "0",
+                # - profile - useRunArgsAndEnv
+                "1",
+                # - profile - xcodeConfiguration
+                "",
+                # - profile - launchTarget - isPath
+                "0",
+                # - profile - launchTarget - id
+                "",
+                # - profile - launchTarget - extensionHostID
+                "",
+                # - profile - customWorkingDirectory
+                "",
             ]) + "\n",
             _EXECUTION_ACTIONS_DECLARED_FILE: "\n".join([
                 # schemeName

--- a/tools/generators/lib/XCScheme/src/CreateLaunchAction.swift
+++ b/tools/generators/lib/XCScheme/src/CreateLaunchAction.swift
@@ -131,6 +131,14 @@ ignoresPersistentStateOnLaunch = "NO"
         let runnableString: String
         if let runnable = runnable {
             switch runnable {
+            case let .path(path):
+                runnableString = #"""
+      <PathRunnable
+         runnableDebuggingMode = "0"
+         FilePath = "\#(path)">
+      </PathRunnable>
+
+"""#
             case let .plain(reference):
                 runnableString = #"""
       <BuildableProductRunnable
@@ -195,7 +203,7 @@ ignoresPersistentStateOnLaunch = "NO"
 private extension Runnable {
     var isHosted: Bool {
         switch self {
-        case .plain: return false
+        case .path, .plain: return false
         case .hosted: return true
         }
     }

--- a/tools/generators/lib/XCScheme/src/CreateProfileAction.swift
+++ b/tools/generators/lib/XCScheme/src/CreateProfileAction.swift
@@ -84,6 +84,14 @@ useCustomWorkingDirectory = "YES"
         let runnableString: String
         if let runnable = runnable {
             switch runnable {
+            case let .path(path):
+                runnableString = #"""
+      <PathRunnable
+         runnableDebuggingMode = "0"
+         FilePath = "\#(path)">
+      </PathRunnable>
+
+"""#
             case let .plain(reference), let .hosted(reference, _, _, _):
                 runnableString = #"""
       <BuildableProductRunnable

--- a/tools/generators/lib/XCScheme/src/Runnable.swift
+++ b/tools/generators/lib/XCScheme/src/Runnable.swift
@@ -6,4 +6,5 @@ public enum Runnable {
         debuggingMode: Int,
         remoteBundleIdentifier: String
     )
+    case path(path: String)
 }

--- a/tools/generators/lib/XCScheme/test/CreateLaunchActionTests.swift
+++ b/tools/generators/lib/XCScheme/test/CreateLaunchActionTests.swift
@@ -409,6 +409,41 @@ final class CreateLaunchActionTests: XCTestCase {
 
         XCTAssertNoDifference(action, expectedAction)
     }
+
+    func test_runnable_path() {
+         // Arrange
+        let buildConfiguration = "Debug"
+        let runnable = Runnable.path(path: "/Foo/Bar.app")
+
+        let expectedAction = #"""
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <PathRunnable
+         runnableDebuggingMode = "0"
+         FilePath = "/Foo/Bar.app">
+      </PathRunnable>
+   </LaunchAction>
+"""#
+
+         // Act
+
+        let action = createLaunchActionWithDefaults(
+            buildConfiguration: buildConfiguration,
+            runnable: runnable
+         )
+
+        // Assert
+
+        XCTAssertNoDifference(action, expectedAction)
+    }
 }
 
 private func createLaunchActionWithDefaults(

--- a/tools/generators/lib/XCScheme/test/CreateProfileActionTests.swift
+++ b/tools/generators/lib/XCScheme/test/CreateProfileActionTests.swift
@@ -276,6 +276,38 @@ final class CreateProfileActionTests: XCTestCase {
 
         XCTAssertNoDifference(prefix, expectedPrefix)
     }
+
+    func test_runnable_path() {
+        // Arrange
+
+        let buildConfiguration = "Debug"
+        let runnable = Runnable.path(path: "/Foo/Bar")
+
+        let expectedPrefix = #"""
+   <ProfileAction
+      buildConfiguration = "Debug"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <PathRunnable
+         runnableDebuggingMode = "0"
+         FilePath = "/Foo/Bar">
+      </PathRunnable>
+   </ProfileAction>
+"""#
+
+        // Act
+
+        let prefix = createProfileActionWithDefaults(
+            buildConfiguration: buildConfiguration,
+            runnable: runnable
+        )
+
+        // Assert
+
+        XCTAssertNoDifference(prefix, expectedPrefix)
+    }
 }
 
 private func createProfileActionWithDefaults(

--- a/tools/generators/xcschemes/src/Generator/CreateAutomaticSchemeInfo.swift
+++ b/tools/generators/xcschemes/src/Generator/CreateAutomaticSchemeInfo.swift
@@ -74,13 +74,13 @@ extension Generator.CreateAutomaticSchemeInfo {
 """
 
             launchTarget =
-                .init(primary: target, extensionHost: extensionHost)
+                .target(primary: target, extensionHost: extensionHost)
             buildTargets = []
         } else {
             name = baseSchemeName
 
             if productType.isLaunchable {
-                launchTarget = .init(primary: target, extensionHost: nil)
+                launchTarget = .target(primary: target, extensionHost: nil)
                 buildTargets = []
             } else {
                 launchTarget = nil

--- a/tools/generators/xcschemes/src/Generator/CreateCustomSchemeInfos.swift
+++ b/tools/generators/xcschemes/src/Generator/CreateCustomSchemeInfos.swift
@@ -245,6 +245,29 @@ private extension ArraySlice where Element == String {
         [CommandLineArgument],
         [EnvironmentVariable]
     ) {
+        let isPath = try consumeArg(
+            "\(namePrefix)-launch-target-is-path",
+            as: Bool.self,
+            in: url,
+            file: file,
+            line: line
+        )
+
+        if isPath {
+            let path = try consumeArg(
+                "\(namePrefix)-launch-target-path",
+                as: String.self,
+                in: url,
+                file: file,
+                line: line
+            )
+            return (
+                SchemeInfo.LaunchTarget.path(path),
+                commandLineArguments ?? [],
+                environmentVariables ?? []
+            )
+        }
+
         let id = try consumeArg(
             "\(namePrefix)-launch-target-id",
             as: TargetID?.self,
@@ -313,7 +336,7 @@ set
         }
 
         return (
-            SchemeInfo.LaunchTarget(
+            SchemeInfo.LaunchTarget.target(
                 primary: target,
                 extensionHost: extensionHost
             ),

--- a/tools/generators/xcschemes/src/Generator/CreateScheme.swift
+++ b/tools/generators/xcschemes/src/Generator/CreateScheme.swift
@@ -158,18 +158,17 @@ extension Generator.CreateScheme {
 
         let launchRunnable: Runnable?
         let wasCreatedForAppExtension: Bool
-        if let launchTarget = schemeInfo.run.launchTarget {
-            let buildableReference =
-                launchTarget.primary.buildableReference
+        switch schemeInfo.run.launchTarget {
+        case let .target(primary, extensionHost):
+            let buildableReference = primary.buildableReference
 
             adjustBuildActionEntry(
                 for: buildableReference,
                 include: [.running, .analyzing]
             )
 
-            if let extensionHost = launchTarget.extensionHost {
+            if let extensionHost {
                 let hostBuildableReference = extensionHost.buildableReference
-
                 adjustBuildActionEntry(
                     for: hostBuildableReference,
                     include: [.running, .analyzing]
@@ -177,7 +176,7 @@ extension Generator.CreateScheme {
 
                 let extensionPointIdentifier = try extensionPointIdentifiers
                     .value(
-                        for: launchTarget.primary.key.sortedIds.first!,
+                        for: primary.key.sortedIds.first!,
                         context: "Extension Target ID"
                     )
 
@@ -196,7 +195,11 @@ extension Generator.CreateScheme {
 
             launchPreActions
                 .appendUpdateLldbInitAndCopyDSYMs(for: buildableReference)
-        } else {
+        case let .path(path):
+            launchRunnable = .path(path: path)
+            wasCreatedForAppExtension = false
+
+        case .none:
             launchRunnable = nil
             wasCreatedForAppExtension = false
         }
@@ -211,13 +214,12 @@ extension Generator.CreateScheme {
         // MARK: Profile
 
         let profileRunnable: Runnable?
-        if let launchTarget = schemeInfo.profile.launchTarget {
-            let buildableReference =
-                launchTarget.primary.buildableReference
-
+        switch schemeInfo.profile.launchTarget {
+        case let .target(primary, extensionHost):
+            let buildableReference = primary.buildableReference
             adjustBuildActionEntry(for: buildableReference, include: .profiling)
 
-            if let extensionHost = launchTarget.extensionHost {
+            if let extensionHost {
                 let hostBuildableReference = extensionHost.buildableReference
 
                 adjustBuildActionEntry(
@@ -227,7 +229,7 @@ extension Generator.CreateScheme {
 
                 let extensionPointIdentifier = try extensionPointIdentifiers
                     .value(
-                        for: launchTarget.primary.key.sortedIds.first!,
+                        for: primary.key.sortedIds.first!,
                         context: "Extension Target ID"
                     )
 
@@ -245,7 +247,11 @@ extension Generator.CreateScheme {
 
             profilePreActions
                 .appendUpdateLldbInitAndCopyDSYMs(for: buildableReference)
-        } else {
+
+        case let .path(path):
+            profileRunnable = .path(path: path)
+
+        case .none:
             profileRunnable = nil
         }
 

--- a/tools/generators/xcschemes/src/Generator/SchemeInfo.swift
+++ b/tools/generators/xcschemes/src/Generator/SchemeInfo.swift
@@ -19,9 +19,9 @@ struct SchemeInfo: Equatable {
         let order: Int?
     }
 
-    struct LaunchTarget: Equatable {
-        let primary: Target
-        let extensionHost: Target?
+    enum LaunchTarget: Equatable {
+        case target(primary: Target, extensionHost: Target?)
+        case path(String)
     }
 
     struct Profile: Equatable {

--- a/tools/generators/xcschemes/test/CreateAutomaticSchemeInfoTests.swift
+++ b/tools/generators/xcschemes/test/CreateAutomaticSchemeInfoTests.swift
@@ -146,7 +146,7 @@ final class CreateAutomaticSchemeInfoTests: XCTestCase {
                 enableThreadSanitizer: false,
                 enableUBSanitizer: false,
                 environmentVariables: baseEnvironmentVariables,
-                launchTarget: .init(
+                launchTarget: .target(
                     primary: launchable,
                     extensionHost: nil
                 ),
@@ -158,7 +158,7 @@ final class CreateAutomaticSchemeInfoTests: XCTestCase {
                 commandLineArguments: [],
                 customWorkingDirectory: nil,
                 environmentVariables: [],
-                launchTarget: .init(
+                launchTarget: .target(
                     primary: launchable,
                     extensionHost: nil
                 ),
@@ -224,7 +224,7 @@ final class CreateAutomaticSchemeInfoTests: XCTestCase {
                 enableThreadSanitizer: false,
                 enableUBSanitizer: false,
                 environmentVariables: baseEnvironmentVariables,
-                launchTarget: .init(
+                launchTarget: .target(
                     primary: launchable,
                     extensionHost: extensionHost
                 ),
@@ -236,7 +236,7 @@ final class CreateAutomaticSchemeInfoTests: XCTestCase {
                 commandLineArguments: [],
                 customWorkingDirectory: nil,
                 environmentVariables: [],
-                launchTarget: .init(
+                launchTarget: .target(
                     primary: launchable,
                     extensionHost: extensionHost
                 ),
@@ -297,7 +297,7 @@ final class CreateAutomaticSchemeInfoTests: XCTestCase {
                 enableThreadSanitizer: false,
                 enableUBSanitizer: false,
                 environmentVariables: baseEnvironmentVariables,
-                launchTarget: .init(
+                launchTarget: .target(
                     primary: launchable,
                     extensionHost: nil
                 ),
@@ -309,7 +309,7 @@ final class CreateAutomaticSchemeInfoTests: XCTestCase {
                 commandLineArguments: [],
                 customWorkingDirectory: nil,
                 environmentVariables: [],
-                launchTarget: .init(
+                launchTarget: .target(
                     primary: launchable,
                     extensionHost: nil
                 ),
@@ -371,7 +371,7 @@ final class CreateAutomaticSchemeInfoTests: XCTestCase {
                 enableUBSanitizer: false,
                 environmentVariables:
                     baseEnvironmentVariables + environmentVariables,
-                launchTarget: .init(
+                launchTarget: .target(
                     primary: launchable,
                     extensionHost: nil
                 ),
@@ -383,7 +383,7 @@ final class CreateAutomaticSchemeInfoTests: XCTestCase {
                 commandLineArguments: [],
                 customWorkingDirectory: nil,
                 environmentVariables: [],
-                launchTarget: .init(
+                launchTarget: .target(
                     primary: launchable,
                     extensionHost: nil
                 ),

--- a/xcodeproj/internal/xcschemes/xcscheme_labels.bzl
+++ b/xcodeproj/internal/xcschemes/xcscheme_labels.bzl
@@ -1,5 +1,11 @@
 """Module for dealing with custom Xcode schemes from the `xcodeproj` macro."""
 
+load(
+    "//xcodeproj/internal:memory_efficiency.bzl",
+    "FALSE_ARG",
+    "TRUE_ARG",
+)
+
 def _resolve_build_target_labels(build_target):
     return struct(
         extension_host = _resolve_label(build_target.extension_host),
@@ -29,8 +35,16 @@ def _resolve_launch_target_labels(launch_target):
     if not launch_target or type(launch_target) == "string":
         return _resolve_label(launch_target)
 
+    if launch_target.is_path == TRUE_ARG:
+        return struct(
+            is_path = TRUE_ARG,
+            path = launch_target.path,
+            working_directory = launch_target.working_directory,
+        )
+
     return struct(
         extension_host = _resolve_label(launch_target.extension_host),
+        is_path = FALSE_ARG,
         label = _resolve_label(launch_target.label),
         library_targets = [
             _resolve_library_target_labels(library_target)

--- a/xcodeproj/internal/xcschemes/xcschemes.bzl
+++ b/xcodeproj/internal/xcschemes/xcschemes.bzl
@@ -160,9 +160,10 @@ def _profile(
             addition to any set by [`env`](#xcschemes.profile-env).
         launch_target: The target to launch when profiling.
 
-            Can be `None`, a label string, or a value returned by
-            [`xcschemes.launch_target`](#xcschemes.launch_target). If a label
-            string, `xcschemes.launch_target(label_str)` will be used. If
+            Can be `None`, a label string, a value returned by
+            [`xcschemes.launch_target`](#xcschemes.launch_target),
+            or a value returned by [`xcschemes.launch_path`](#xcschemes.launch_path).
+            If a label string, `xcschemes.launch_target(label_str)` will be used. If
             `None`, `xcschemes.launch_target()` will be used, which means no
             launch target will be set (i.e. the `Executable` dropdown will be
             set to `None`).
@@ -321,9 +322,10 @@ def _run(
             addition to any set by [`env`](#xcschemes.run-env).
         launch_target: The target to launch when running.
 
-            Can be `None`, a label string, or a value returned by
-            [`xcschemes.launch_target`](#xcschemes.launch_target). If a label
-            string, `xcschemes.launch_target(label_str)` will be used. If
+            Can be `None`, a label string, a value returned by
+            [`xcschemes.launch_target`](#xcschemes.launch_target),
+            or a value returned by [`xcschemes.launch_path`](#xcschemes.launch_path).
+            If a label string, `xcschemes.launch_target(label_str)` will be used. If
             `None`, `xcschemes.launch_target()` will be used, which means no
             launch target will be set (i.e. the `Executable` dropdown will be
             set to `None`).
@@ -534,6 +536,35 @@ def _test(
 
 # Targets
 
+def _launch_path(
+        path,
+        *,
+        working_directory = None):
+    """Defines the launch path for a pre-built executable.
+
+    Args:
+        path: Positional. The launch path for a launch target.
+
+            The path must be an absolute path to an executable file.
+            It will be set as the runnable within a launch action.
+        working_directory: The working directory to use when running the launch
+            target.
+
+            If not set, the Xcode default working directory will be used (i.e.
+            some directory in `DerivedData`).
+    """
+
+    if not path:
+        fail("""
+`path` must be provided to `xcschemes.launch_path`.
+""")
+
+    return struct(
+        is_path = TRUE_ARG,
+        path = path,
+        working_directory = working_directory or "",
+    )
+
 def _launch_target(
         label,
         *,
@@ -619,6 +650,7 @@ def _launch_target(
 
     return struct(
         extension_host = extension_host or "",
+        is_path = FALSE_ARG,
         label = label,
         library_targets = library_targets,
         post_actions = post_actions,
@@ -1119,6 +1151,7 @@ xcschemes = struct(
     arg = _arg,
     diagnostics = _diagnostics,
     env_value = _env_value,
+    launch_path = _launch_path,
     launch_target = _launch_target,
     library_target = _library_target,
     pre_post_actions = _pre_post_actions,

--- a/xcodeproj/internal/xcschemes/xcschemes_execution.bzl
+++ b/xcodeproj/internal/xcschemes/xcschemes_execution.bzl
@@ -324,14 +324,20 @@ def _write_schemes(
 
     # buildifier: disable=uninitialized
     def _add_launch_target(launch_target, *, action_name, scheme_name):
-        custom_scheme_args.add(launch_target.id)
-        custom_scheme_args.add(launch_target.extension_host)
-        custom_scheme_args.add(launch_target.working_directory)
-        _add_execution_actions(
-            launch_target,
-            action_name = action_name,
-            scheme_name = scheme_name,
-        )
+        custom_scheme_args.add(launch_target.is_path)
+
+        if launch_target.is_path == TRUE_ARG:
+            custom_scheme_args.add(launch_target.path)
+            custom_scheme_args.add(launch_target.working_directory)
+        else:
+            custom_scheme_args.add(launch_target.id)
+            custom_scheme_args.add(launch_target.extension_host)
+            custom_scheme_args.add(launch_target.working_directory)
+            _add_execution_actions(
+                launch_target,
+                action_name = action_name,
+                scheme_name = scheme_name,
+            )
 
     custom_scheme_args.add(len(xcscheme_infos))
     for info in xcscheme_infos:


### PR DESCRIPTION
Adds a new `xcschemes.launch_path` API for creating an Xcode `PathRunnable`. A `launch_path` is different than a `launch_target` because it does not need to be a product within the Bazel workspace. It can be used to launch pre-built binaries, applications, etc. while debugging in Xcode.

Closes #2783