### PR TITLE
Add `--incompatible_python_disallow_native_rules` when using Bazel 8

### DIFF
--- a/bazel_8.bazelrc
+++ b/bazel_8.bazelrc
@@ -1,0 +1,1 @@
+common --incompatible_python_disallow_native_rules


### PR DESCRIPTION
We will add it for Bazel 7 when it’s cherry-picked into 7.1.0.