### PR TITLE
Remove `--collect_specs` support

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -317,24 +317,6 @@ For example, this will build all targets the same way that Xcode does:
 bazel run //:xcodeproj -- --generator_output_groups=all_targets build
 ```
 
-### `--collect_specs`
-
-To aid in debugging an issue, we may request that you provide us with the specs
-that were used to generate your project. The specs are intermediate JSON files
-used to communicate information from the analysis (Starlark) half of the
-generator to the execution (Swift) half of the generator. They contain file
-paths and build settings.
-
-Since the location and number of these files can be hard to determine, we’ve
-added a command to be able to easily collect them:
-
-```
-bazel run //:xcodeproj -- --collect_specs=/path/to/specs.tar.gz
-```
-
-The path passed to `--collect_specs` is where a `.tar.gz` archive containing the
-specs will be written.
-
 ## Substitutions
 
 In your command, any reference to these variables will be expanded:

--- a/xcodeproj/internal/templates/installer.sh
+++ b/xcodeproj/internal/templates/installer.sh
@@ -44,10 +44,6 @@ while (("$#")); do
       extra_flags_bazelrc="${2}"
       shift 2
       ;;
-    "--collect_specs")
-      specs_archive_path="${2}"
-      shift 2
-      ;;
     *)
       fail "Unrecognized argument: ${1}"
       ;;
@@ -127,18 +123,6 @@ if [[ $for_fixture -eq 1 ]]; then
   targets_spec_src="$PWD/${spec_paths[2]}"
   readonly targets_spec_dest="${mode_prefix}_targets_spec.json"
   python3 -m json.tool "$targets_spec_src" > "$targets_spec_dest"
-elif [[ -n "${specs_archive_path:-}" ]]; then
-  specs_archive_path_staging=$(mktemp -d)
-  cp "${spec_paths[@]}" "$specs_archive_path_staging"
-  cd "$specs_archive_path_staging"
-
-  rm -f "$specs_archive_path"
-  COPYFILE_DISABLE=1 tar czfh "$specs_archive_path" .
-
-  echo
-  echo "Collected specs into \"$specs_archive_path\""
-
-  exit 0
 fi
 
 # Sync over the project, changing the permissions to be writable

--- a/xcodeproj/internal/templates/runner.sh
+++ b/xcodeproj/internal/templates/runner.sh
@@ -47,10 +47,6 @@ while (("$#")); do
       config="${1#*=}"
       shift 1
       ;;
-    --collect_specs=*)
-      specs_archive_path="${1#*=}"
-      shift 1
-      ;;
     -v|--verbose)
       verbose=1
       shift 1
@@ -64,11 +60,6 @@ while (("$#")); do
       ;;
   esac
 done
-
-if [[ -n "${specs_archive_path:-}" ]]; then
-  installer_flags+=(--collect_specs "$specs_archive_path")
-  original_arg_count=0
-fi
 
 if [[ $original_arg_count -gt 0 ]]; then
   if [[ $# -eq 0 ]]; then


### PR DESCRIPTION
There aren’t specs to collect in incremental generation mode. Also, the usefulness of this feature has drastically declined; there’s usually better ways to debug issues.