### PR TITLE
Rename `xcode_targets` to `legacy_xcode_targets`

### DIFF
--- a/xcodeproj/internal/legacy_xcode_targets.bzl
+++ b/xcodeproj/internal/legacy_xcode_targets.bzl
@@ -21,7 +21,7 @@ load(
 )
 load(":platforms.bzl", "platforms")
 
-def _make_xcode_target(
+def _make_legacy_xcode_target(
         *,
         id,
         label,
@@ -336,7 +336,7 @@ def _merge_xcode_target(*, src_swift, src_non_swift, dest):
         cxx_has_fortify_source = src_non_swift._cxx_has_fortify_source or cxx_has_fortify_source
         platform = src_non_swift.platform
 
-    return _make_xcode_target(
+    return _make_legacy_xcode_target(
         id = dest.id,
         label = dest.label,
         configuration = dest.configuration,
@@ -1019,7 +1019,7 @@ def _swift_to_dto(outputs):
 
     return dto
 
-def _get_top_level_static_libraries(xcode_target):
+def _get_legacy_top_level_static_libraries(xcode_target):
     """Returns the static libraries needed to link the target.
 
     Args:
@@ -1035,9 +1035,9 @@ Target '{}' requires `ObjcProvider` or `CcInfo`\
 """.format(xcode_target.label))
     return linker_inputs.static_libraries
 
-xcode_targets = struct(
-    get_top_level_static_libraries = _get_top_level_static_libraries,
-    make = _make_xcode_target,
+legacy_xcode_targets = struct(
+    get_top_level_static_libraries = _get_legacy_top_level_static_libraries,
+    make = _make_legacy_xcode_target,
     merge = _merge_xcode_target,
     to_dto = _xcode_target_to_dto,
 )

--- a/xcodeproj/internal/processed_targets/legacy_library_targets.bzl
+++ b/xcodeproj/internal/processed_targets/legacy_library_targets.bzl
@@ -11,12 +11,15 @@ load(
     "process_modulemaps",
     "process_swiftmodules",
 )
+load(
+    "//xcodeproj/internal:legacy_xcode_targets.bzl",
+    xcode_targets = "legacy_xcode_targets",
+)
 load("//xcodeproj/internal:lldb_contexts.bzl", "lldb_contexts")
 load("//xcodeproj/internal:opts.bzl", "process_opts")
 load("//xcodeproj/internal:platforms.bzl", "platforms")
 load("//xcodeproj/internal:product.bzl", "process_product")
 load("//xcodeproj/internal:target_id.bzl", "get_id")
-load("//xcodeproj/internal:xcode_targets.bzl", "xcode_targets")
 load("//xcodeproj/internal:xcodeprojinfo.bzl", "XcodeProjInfo")
 load("//xcodeproj/internal/files:files.bzl", "build_setting_path", "join_paths_ignoring_empty")
 load(

--- a/xcodeproj/internal/processed_targets/legacy_top_level_targets.bzl
+++ b/xcodeproj/internal/processed_targets/legacy_top_level_targets.bzl
@@ -15,6 +15,10 @@ load(
     "process_modulemaps",
     "process_swiftmodules",
 )
+load(
+    "//xcodeproj/internal:legacy_xcode_targets.bzl",
+    xcode_targets = "legacy_xcode_targets",
+)
 load("//xcodeproj/internal:lldb_contexts.bzl", "lldb_contexts")
 load(
     "//xcodeproj/internal:memory_efficiency.bzl",
@@ -26,7 +30,6 @@ load("//xcodeproj/internal:platforms.bzl", "platforms")
 load("//xcodeproj/internal:product.bzl", "process_product")
 load("//xcodeproj/internal:provisioning_profiles.bzl", "provisioning_profiles")
 load("//xcodeproj/internal:target_id.bzl", "get_id")
-load("//xcodeproj/internal:xcode_targets.bzl", "xcode_targets")
 load("//xcodeproj/internal:xcodeprojinfo.bzl", "XcodeProjInfo")
 load("//xcodeproj/internal/files:app_icons.bzl", "app_icons")
 load("//xcodeproj/internal/files:files.bzl", "build_setting_path", "join_paths_ignoring_empty")

--- a/xcodeproj/internal/product.bzl
+++ b/xcodeproj/internal/product.bzl
@@ -1,4 +1,5 @@
-"""Functions for calculating a target's product."""
+"""Functions for calculating a target's product, when using \
+`generation_mode = "legacy"`."""
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("//xcodeproj/internal/files:linker_input_files.bzl", "linker_input_files")

--- a/xcodeproj/internal/resource_target.bzl
+++ b/xcodeproj/internal/resource_target.bzl
@@ -15,9 +15,9 @@ load(
     ":legacy_target_properties.bzl",
     "process_modulemaps",
 )
+load(":legacy_xcode_targets.bzl", xcode_targets = "legacy_xcode_targets")
 load(":memory_efficiency.bzl", "EMPTY_LIST")
 load(":product.bzl", "process_product")
-load(":xcode_targets.bzl", "xcode_targets")
 
 def _process_resource_bundle(bundle, *, bundle_id):
     name = bundle.name

--- a/xcodeproj/internal/xcodeproj_legacy_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_legacy_rule.bzl
@@ -27,6 +27,7 @@ load(
     "write_extension_point_identifiers_file",
 )
 load(":flattened_key_values.bzl", "flattened_key_values")
+load(":legacy_xcode_targets.bzl", xcode_targets = "legacy_xcode_targets")
 load(":lldb_contexts.bzl", "lldb_contexts")
 load(":logging.bzl", "warn")
 load(":memory_efficiency.bzl", "FALSE_ARG", "TRUE_ARG")
@@ -34,7 +35,6 @@ load(":platforms.bzl", "platforms")
 load(":project_options.bzl", "project_options_to_dto")
 load(":resource_target.bzl", "process_resource_bundles")
 load(":target_id.bzl", "write_target_ids_list")
-load(":xcode_targets.bzl", "xcode_targets")
 load(":xcodeprojinfo.bzl", "XcodeProjInfo")
 
 # Utility


### PR DESCRIPTION
In preparation of incremental generation mode.