### PR TITLE
Stop setting a comment with `TestTargetID`

### DIFF
--- a/tools/generators/pbxtargetdependencies/src/Generator/CreateTargetAttributesContent.swift
+++ b/tools/generators/pbxtargetdependencies/src/Generator/CreateTargetAttributesContent.swift
@@ -14,11 +14,12 @@ extension Generator {
         /// Calculates a `PBXProject.targets` object content.
         func callAsFunction(
             createdOnToolsVersion: String,
-            testHostIdentifier: String?
+            testHostIdentifierWithoutComment: String?
         ) -> String {
             return callable(
                 /*createdOnToolsVersion:*/ createdOnToolsVersion,
-                /*testHostIdentifier:*/ testHostIdentifier
+                /*testHostIdentifierWithoutComment:*/
+                    testHostIdentifierWithoutComment
             )
         }
     }
@@ -29,17 +30,17 @@ extension Generator {
 extension Generator.CreateTargetAttributesContent {
     typealias Callable = (
         _ createdOnToolsVersion: String,
-        _ testHostIdentifier: String?
+        _ testHostIdentifierWithoutComment: String?
     ) -> String
 
     static func defaultCallable(
         createdOnToolsVersion: String,
-        testHostIdentifier: String?
+        testHostIdentifierWithoutComment: String?
     ) -> String {
         let testTargetID: String
-        if let testHostIdentifier = testHostIdentifier {
+        if let testHostIdentifierWithoutComment {
             testTargetID = #"""
-						TestTargetID = \#(testHostIdentifier);
+						TestTargetID = \#(testHostIdentifierWithoutComment);
 
 """#
         } else {

--- a/tools/generators/pbxtargetdependencies/src/Generator/CreateTargetAttributesObjects.swift
+++ b/tools/generators/pbxtargetdependencies/src/Generator/CreateTargetAttributesObjects.swift
@@ -60,7 +60,7 @@ extension Generator.CreateTargetAttributesObjects {
                 identifier: Identifiers.BazelDependencies.id,
                 content: createTargetAttributesContent(
                     createdOnToolsVersion: createdOnToolsVersion,
-                    testHostIdentifier: nil
+                    testHostIdentifierWithoutComment: nil
                 )
             ),
         ]
@@ -73,12 +73,13 @@ extension Generator.CreateTargetAttributesObjects {
                     identifier: target.identifier.full,
                     content: createTargetAttributesContent(
                         createdOnToolsVersion: createdOnToolsVersion,
-                        testHostIdentifier: try testHosts[anId].flatMap { id in
-                            return try identifiedTargetsMap
-                                .value(for: id, context: "Test host")
-                                .identifier
-                                .full
-                        }
+                        testHostIdentifierWithoutComment:
+                        try testHosts[anId].flatMap { id in
+                                return try identifiedTargetsMap
+                                    .value(for: id, context: "Test host")
+                                    .identifier
+                                    .withoutComment
+                            }
                     )
                 )
             )

--- a/tools/generators/pbxtargetdependencies/test/Generator/CreateTargetAttributesContentTests.swift
+++ b/tools/generators/pbxtargetdependencies/test/Generator/CreateTargetAttributesContentTests.swift
@@ -8,7 +8,7 @@ class CreateTargetAttributesContentTests: XCTestCase {
         // Arrange
 
         let createdOnToolsVersion = "13.0.0"
-        let testHostIdentifier: String? = nil
+        let testHostIdentifierWithoutComment: String? = nil
 
         // Shows that it's not responsible for sorting (this order is wrong)
         // The tabs for indenting are intentional
@@ -24,7 +24,8 @@ class CreateTargetAttributesContentTests: XCTestCase {
         let targetAttributes = Generator.CreateTargetAttributesContent
             .defaultCallable(
                 createdOnToolsVersion: createdOnToolsVersion,
-                testHostIdentifier: testHostIdentifier
+                testHostIdentifierWithoutComment:
+                    testHostIdentifierWithoutComment
             )
 
         // Assert
@@ -35,11 +36,11 @@ class CreateTargetAttributesContentTests: XCTestCase {
         )
     }
 
-    func test_testHostIdentifier() {
+    func test_testHostIdentifierWithoutComment() {
         // Arrange
 
         let createdOnToolsVersion = "13.0.0"
-        let testHostIdentifier = "testHost_id /* testHost */"
+        let testHostIdentifierWithoutComment = "testHost_id /* testHost */"
 
         // The tabs for indenting are intentional
         let expectedTargetAttributes = #"""
@@ -55,7 +56,8 @@ class CreateTargetAttributesContentTests: XCTestCase {
         let targetAttributes = Generator.CreateTargetAttributesContent
             .defaultCallable(
                 createdOnToolsVersion: createdOnToolsVersion,
-                testHostIdentifier: testHostIdentifier
+                testHostIdentifierWithoutComment:
+                    testHostIdentifierWithoutComment
             )
 
         // Assert

--- a/tools/generators/pbxtargetdependencies/test/Generator/CreateTargetAttributesObject+Testing.swift
+++ b/tools/generators/pbxtargetdependencies/test/Generator/CreateTargetAttributesObject+Testing.swift
@@ -8,7 +8,7 @@ extension Generator.CreateTargetAttributesContent {
     final class MockTracker {
         struct Called: Equatable {
             let createdOnToolsVersion: String
-            let testHostIdentifier: String?
+            let testHostIdentifierWithoutComment: String?
         }
 
         fileprivate(set) var called: [Called] = []
@@ -31,10 +31,12 @@ extension Generator.CreateTargetAttributesContent {
         let mockTracker = MockTracker(results: contents)
 
         let mocked = Self(
-            callable: { createdOnToolsVersion, testHostIdentifier in
+            callable: {
+                    createdOnToolsVersion, testHostIdentifierWithoutComment in
                 mockTracker.called.append(.init(
                     createdOnToolsVersion: createdOnToolsVersion,
-                    testHostIdentifier: testHostIdentifier
+                    testHostIdentifierWithoutComment:
+                        testHostIdentifierWithoutComment
                 ))
                 return mockTracker.nextResult()
             }

--- a/tools/generators/pbxtargetdependencies/test/Generator/CreateTargetAttributesObjectsTests.swift
+++ b/tools/generators/pbxtargetdependencies/test/Generator/CreateTargetAttributesObjectsTests.swift
@@ -61,15 +61,16 @@ final class CreateTargetAttributesObjectsTests: XCTestCase {
         ] = [
             .init(
                 createdOnToolsVersion: createdOnToolsVersion,
-                testHostIdentifier: nil
+                testHostIdentifierWithoutComment: nil
             ),
             .init(
                 createdOnToolsVersion: createdOnToolsVersion,
-                testHostIdentifier: identifiedTargetsMap["C"]!.identifier.full
+                testHostIdentifierWithoutComment:
+                    identifiedTargetsMap["C"]!.identifier.withoutComment
             ),
             .init(
                 createdOnToolsVersion: createdOnToolsVersion,
-                testHostIdentifier: nil
+                testHostIdentifierWithoutComment: nil
             ),
         ]
 


### PR DESCRIPTION
Xcode only sets the ID.