### PR TITLE
Stop setting a comment for `TargetAttributes` keys

### DIFF
--- a/tools/generators/lib/PBXProj/src/Identifiers.swift
+++ b/tools/generators/lib/PBXProj/src/Identifiers.swift
@@ -48,7 +48,7 @@ import ToolCommon
 public enum Identifiers {
     public enum BazelDependencies {
         fileprivate static let name = "BazelDependencies"
-        fileprivate static let idWithoutComment = "FF0100000000000000000001"
+        public static let idWithoutComment = "FF0100000000000000000001"
         public static let id = #"\#(idWithoutComment) /* \#(name) */"#
 
         public static let buildConfigurationList = #"""

--- a/tools/generators/pbxtargetdependencies/src/Generator/CreateTargetAttributesObjects.swift
+++ b/tools/generators/pbxtargetdependencies/src/Generator/CreateTargetAttributesObjects.swift
@@ -57,7 +57,7 @@ extension Generator.CreateTargetAttributesObjects {
     ) throws -> [Object] {
         var targetAttributes: [Object] = [
             .init(
-                identifier: Identifiers.BazelDependencies.id,
+                identifier: Identifiers.BazelDependencies.idWithoutComment,
                 content: createTargetAttributesContent(
                     createdOnToolsVersion: createdOnToolsVersion,
                     testHostIdentifierWithoutComment: nil
@@ -70,7 +70,7 @@ extension Generator.CreateTargetAttributesObjects {
 
             targetAttributes.append(
                 Object(
-                    identifier: target.identifier.full,
+                    identifier: target.identifier.withoutComment,
                     content: createTargetAttributesContent(
                         createdOnToolsVersion: createdOnToolsVersion,
                         testHostIdentifierWithoutComment:

--- a/tools/generators/pbxtargetdependencies/test/Generator/CreateTargetAttributesObjectsTests.swift
+++ b/tools/generators/pbxtargetdependencies/test/Generator/CreateTargetAttributesObjectsTests.swift
@@ -76,15 +76,17 @@ final class CreateTargetAttributesObjectsTests: XCTestCase {
 
         let expectedObjects: [Object] = [
             .init(
-                identifier: Identifiers.BazelDependencies.id,
+                identifier: Identifiers.BazelDependencies.idWithoutComment,
                 content: "{TA_BazelDependnencies}"
             ),
             .init(
-                identifier: identifiedTargetsMap["A"]!.identifier.full,
+                identifier:
+                    identifiedTargetsMap["A"]!.identifier.withoutComment,
                 content: "{TA_AB}"
             ),
             .init(
-                identifier: identifiedTargetsMap["C"]!.identifier.full,
+                identifier:
+                    identifiedTargetsMap["C"]!.identifier.withoutComment,
                 content: "{TA_C}"
             ),
         ]


### PR DESCRIPTION
Xcode only sets the ID.