### PR TITLE
Keep scheme sorting info in rsync

### DIFF
--- a/xcodeproj/internal/templates/legacy_installer.sh
+++ b/xcodeproj/internal/templates/legacy_installer.sh
@@ -134,7 +134,7 @@ rsync \
   --chmod=u+w,F-x \
   --exclude=project.xcworkspace \
   --exclude=rules_xcodeproj/bazel \
-  --exclude=xcuserdata \
+  --exclude="*.xcbkptlist" \
   --delete \
   "$src/" "$dest/"
 


### PR DESCRIPTION
Issue : 
Xcode schemes were not sorted as expected 

Cause :
Scheme sorting hint file was included under xcuserdata dir and was not being rsycn due to existing --exaclude pattern. 

Change : 
Make the existing exclude a little bit more specific.