### PR TITLE
Implement support for new swift_proto_library rule

### DIFF
--- a/xcodeproj/internal/build_settings.bzl
+++ b/xcodeproj/internal/build_settings.bzl
@@ -40,6 +40,12 @@ def get_product_module_name(*, rule_attr, target):
         return (module_name, module_name)
 
     if SwiftProtoInfo in target:
+        # The new swift_proto_library implementation exposes 
+        # the derived module name via the provider.
+        swift_proto_info = target[SwiftProtoInfo]
+        if hasattr(swift_proto_info, "module_name"):
+            return (None, module_name)
+
         # A `swift_proto_library` target must only have exactly one target in
         # the deps attribute. This is already validated in
         # `swift_proto_library`'s implementation.

--- a/xcodeproj/internal/build_settings.bzl
+++ b/xcodeproj/internal/build_settings.bzl
@@ -40,7 +40,7 @@ def get_product_module_name(*, rule_attr, target):
         return (module_name, module_name)
 
     if SwiftProtoInfo in target:
-        # The new swift_proto_library implementation exposes 
+        # The new swift_proto_library implementation exposes
         # the derived module name via the provider.
         swift_proto_info = target[SwiftProtoInfo]
         if hasattr(swift_proto_info, "module_name"):


### PR DESCRIPTION
The rules_swift PR with the new swift_proto_library rule just merged:
[https://github.com/bazelbuild/rules_swift/pull/1140](https://github.com/bazelbuild/rules_swift/pull/1140)

The provider for the new rules is backwards compatible, but now users of the rule can define their own module names,
or if they don't, the name is derived from the swift proto library target, not the proto library target, because multiple proto libraries can now be compiled into a single swift proto library.

rules_xcodeproj has logic to attempt to derive this module name which will be wrong for the new rules. This PR adds a couple of lines to read the module name from the SwiftProtoInfo if it was set. The new rules would actually have worked without this if the module_name attribute was set because of the earlier code intended for swift_library targets, but this ensures that rules_xcodeproj will still get the correct module name even if the user doesn't customize this.