### PR TITLE
Move `--crosstool_top` setting to `bazel_6.bazelrc`

### DIFF
--- a/bazel_6.bazelrc
+++ b/bazel_6.bazelrc
@@ -3,5 +3,10 @@ build:cache --experimental_remote_build_event_upload=minimal
 # Use Bzlmod
 build --enable_bzlmod
 
+# Use apple_support Xcode toolchain
+build --apple_crosstool_top=@local_config_apple_cc//:toolchain
+build --crosstool_top=@local_config_apple_cc//:toolchain
+build --host_crosstool_top=@local_config_apple_cc//:toolchain
+
 # Disabled until bugs are fixed
 common --lockfile_mode=off

--- a/shared.bazelrc
+++ b/shared.bazelrc
@@ -7,11 +7,6 @@ build --experimental_convenience_symlinks=ignore
 # Faster digest hashing with BLAKE3
 startup --digest_function=blake3
 
-# Use apple_support Xcode toolchain
-build --apple_crosstool_top=@local_config_apple_cc//:toolchain
-build --crosstool_top=@local_config_apple_cc//:toolchain
-build --host_crosstool_top=@local_config_apple_cc//:toolchain
-
 # Work around https://github.com/bazelbuild/bazel/issues/13912
 build --experimental_action_cache_store_output_metadata
 


### PR DESCRIPTION
We don’t need it anymore with Bazel 7+.