### PR TITLE
Use Bazel 6.4.0 with `examples/rules_ios`

### DIFF
--- a/examples/rules_ios/.bazelversion
+++ b/examples/rules_ios/.bazelversion
@@ -1,1 +1,1 @@
-../../.bazelversion
+6.4.0


### PR DESCRIPTION
Until rules_ios supports Bazel 7+.