### PR TITLE
Use Bazel 6.4.0 when updating fixtures

### DIFF
--- a/test/update_all_fixtures.sh
+++ b/test/update_all_fixtures.sh
@@ -13,5 +13,5 @@ for dir in examples/*/ ; do
     echo
     echo "Updating \"${dir%/}\" fixtures"
     echo
-    bazel run --config=cache //test/fixtures:update
+    USE_BAZEL_VERSION="6.4.0" bazel run --config=cache //test/fixtures:update
 done


### PR DESCRIPTION
This ensures that we continue to update the BwX version of `examples/integration`.