### PR TITLE
Remove `xcdatamodel` from incremental generation `folderTypeFileExtensions`

### DIFF
--- a/tools/generators/files_and_groups/src/ElementCreator/CreateFileElement.swift
+++ b/tools/generators/files_and_groups/src/ElementCreator/CreateFileElement.swift
@@ -52,7 +52,6 @@ extension ElementCreator.CreateFileElement {
        "framework",
        "scnassets",
        "xcassets",
-       "xcdatamodel",
     ]
 
     typealias Callable = (


### PR DESCRIPTION
We handle core data stuff in a different path.