### PR TITLE
Codesign UI tests in incremental generation mode

### DIFF
--- a/tools/generators/pbxnativetargets/src/Generator/CalculateSharedBuildSettings.swift
+++ b/tools/generators/pbxnativetargets/src/Generator/CalculateSharedBuildSettings.swift
@@ -100,9 +100,17 @@ extension Generator.CalculateSharedBuildSettings {
                 )
             )
         } else {
-            // Used to work around CODE_SIGNING_ENABLED = YES in Xcode 14
+            // Used to work around CODE_SIGNING_ENABLED = YES for resource
+            // bundles in Xcode 14+
             buildSettings.append(
                 .init(key: "CODE_SIGNING_ALLOWED", value: "NO")
+            )
+        }
+
+        if productType == .uiTestBundle {
+            // UI tests require code signing to enable debugging
+            buildSettings.append(
+                .init(key: "CODE_SIGNING_ALLOWED", value: "YES")
             )
         }
 

--- a/tools/generators/pbxnativetargets/test/Generator/CalculateSharedBuildSettingsTests.swift
+++ b/tools/generators/pbxnativetargets/test/Generator/CalculateSharedBuildSettingsTests.swift
@@ -73,13 +73,14 @@ class CalculateSharedBuildSettingsTests: XCTestCase {
         )
     }
 
-    func test_uiTest_withTestHost() {
+    func test_uiTest() {
         // Arrange
 
         let productType = PBXProductType.uiTestBundle
         let uiTestHostName = "Host (tvOS)"
 
         let expectedBuildSettings = baseBuildSettings.updating([
+            "CODE_SIGNING_ALLOWED": "YES",
             "TEST_TARGET_NAME": #""Host (tvOS)""#,
         ])
 


### PR DESCRIPTION
Fixes #2848.

UI test require codesigning to enable debugging.