### PR TITLE
Track generated source files in incremental generation mode

### DIFF
--- a/xcodeproj/internal/xcodeproj_incremental_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_incremental_rule.bzl
@@ -127,6 +127,7 @@ def _collect_files(
     transitive_file_paths = []
     transitive_files = [unsupported_extra_files]
     transitive_folders = []
+    transitive_srcs = []
     for xcode_target in all_targets:
         transitive_file_paths.append(xcode_target.inputs.extra_file_paths)
         transitive_files.append(xcode_target.inputs.extra_files)
@@ -134,6 +135,8 @@ def _collect_files(
         transitive_files.append(xcode_target.inputs.resources)
         transitive_files.append(xcode_target.inputs.srcs)
         transitive_folders.append(xcode_target.inputs.folder_resources)
+        transitive_srcs.append(xcode_target.inputs.non_arc_srcs)
+        transitive_srcs.append(xcode_target.inputs.srcs)
 
         infoplist_path = xcode_target.inputs.infoplist_path
         if infoplist_path:
@@ -147,8 +150,16 @@ def _collect_files(
         transitive = transitive_files,
     )
     folders = depset(transitive = transitive_folders)
+    srcs = depset(transitive = transitive_srcs)
 
-    return (compile_stub_needed, file_paths, files, folders, infoplist_paths)
+    return (
+        compile_stub_needed,
+        file_paths,
+        files,
+        folders,
+        infoplist_paths,
+        srcs,
+    )
 
 def _get_minimum_xcode_version(*, xcode_config):
     version = str(xcode_config.xcode_version())
@@ -318,6 +329,7 @@ def _write_project_contents(
         files,
         folders,
         infoplist_paths,
+        srcs,
     ) = _collect_files(
         resource_bundle_xcode_targets = resource_bundle_xcode_targets,
         unowned_extra_files = unowned_extra_files,
@@ -423,6 +435,7 @@ def _write_project_contents(
         actions = actions,
         generator_name = name,
         infoplist_paths = infoplist_paths,
+        srcs = srcs,
     )
 
     return (

--- a/xcodeproj/internal/xcodeproj_incremental_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_incremental_rule.bzl
@@ -131,9 +131,7 @@ def _collect_files(
     for xcode_target in all_targets:
         transitive_file_paths.append(xcode_target.inputs.extra_file_paths)
         transitive_files.append(xcode_target.inputs.extra_files)
-        transitive_files.append(xcode_target.inputs.non_arc_srcs)
         transitive_files.append(xcode_target.inputs.resources)
-        transitive_files.append(xcode_target.inputs.srcs)
         transitive_folders.append(xcode_target.inputs.folder_resources)
         transitive_srcs.append(xcode_target.inputs.non_arc_srcs)
         transitive_srcs.append(xcode_target.inputs.srcs)
@@ -144,13 +142,16 @@ def _collect_files(
 
         if xcode_target.compile_stub_needed:
             compile_stub_needed = True
+
+    srcs = depset(transitive = transitive_srcs)
+    transitive_files.append(srcs)
+
     file_paths = depset(transitive = transitive_file_paths)
     files = depset(
         unowned_extra_files,
         transitive = transitive_files,
     )
     folders = depset(transitive = transitive_folders)
-    srcs = depset(transitive = transitive_srcs)
 
     return (
         compile_stub_needed,


### PR DESCRIPTION
Source files are tracked as build files by Xcode, so building targets that directly use generated source files will fail the first time they are built if we don't track them.