### PR TITLE
Include `CcCompilationContext.headers` in collected generated files in incremental generation mode

### DIFF
--- a/xcodeproj/internal/files/incremental_input_files.bzl
+++ b/xcodeproj/internal/files/incremental_input_files.bzl
@@ -251,8 +251,17 @@ def _process_files_and_deps(
             ),
         )
 
+        # We need to collect `headers` in `generated` in addition to the above
+        # collection of `direct_{public,private}_headers` to get all files
+        # needed for indexing, even if they are from unsupported transitive
+        # dependencies
+        transitive_generated = [compilation_context.headers]
+    else:
+        transitive_generated = EMPTY_LIST
+
     return (
         transitive_extra_files,
+        transitive_generated,
         uncategorized,
         xccurrentversions,
     )
@@ -462,6 +471,7 @@ def _collect_incremental_input_files(
 
     (
         transitive_extra_files,
+        transitive_generated,
         uncategorized,
         xccurrentversions,
     ) = _process_files_and_deps(
@@ -575,7 +585,7 @@ def _collect_incremental_input_files(
 
     generated_depset = memory_efficient_depset(
         generated,
-        transitive = [
+        transitive = transitive_generated + [
             info.inputs.generated
             for info in transitive_infos
         ],
@@ -706,6 +716,7 @@ def _collect_unsupported_input_files(
 
     (
         transitive_extra_files,
+        transitive_generated,
         uncategorized,
         xccurrentversions,
     ) = _process_files_and_deps(
@@ -767,7 +778,7 @@ def _collect_unsupported_input_files(
         ),
         generated = memory_efficient_depset(
             generated,
-            transitive = [
+            transitive = transitive_generated + [
                 info.inputs.generated
                 for info in transitive_infos
             ],

--- a/xcodeproj/internal/files/incremental_input_files.bzl
+++ b/xcodeproj/internal/files/incremental_input_files.bzl
@@ -112,11 +112,9 @@ def _should_ignore_input_attr(attr):
         attr in _IGNORE_ATTR
     )
 
-def _process_cc_info_headers(headers, *, exclude_headers, generated):
+def _process_cc_info_headers(headers, *, exclude_headers):
     def _process_header(header_file):
         exclude_headers[header_file] = None
-        if not header_file.is_source:
-            generated.append(header_file)
         return header_file
 
     files = []
@@ -233,21 +231,18 @@ def _process_files_and_deps(
             _process_cc_info_headers(
                 compilation_context.direct_private_headers,
                 exclude_headers = categorized_files,
-                generated = generated,
             ),
         )
         extra_files.extend(
             _process_cc_info_headers(
                 compilation_context.direct_public_headers,
                 exclude_headers = categorized_files,
-                generated = generated,
             ),
         )
         extra_files.extend(
             _process_cc_info_headers(
                 compilation_context.direct_textual_headers,
                 exclude_headers = categorized_files,
-                generated = generated,
             ),
         )
 

--- a/xcodeproj/internal/files/legacy_input_files.bzl
+++ b/xcodeproj/internal/files/legacy_input_files.bzl
@@ -48,11 +48,9 @@ def _should_ignore_input_attr(attr):
         attr in _IGNORE_ATTR
     )
 
-def _process_cc_info_headers(headers, *, exclude_headers, generated):
+def _process_cc_info_headers(headers, *, exclude_headers):
     def _process_header(header):
         exclude_headers[header] = None
-        if not header.is_source:
-            generated.append(header)
         return normalized_file_path(
             header,
             folder_type_extensions = FRAMEWORK_EXTENSIONS,
@@ -496,21 +494,18 @@ def _collect_legacy_input_files(
             _process_cc_info_headers(
                 compilation_context.direct_private_headers,
                 exclude_headers = categorized_files,
-                generated = generated,
             ),
         )
         extra_files.extend(
             _process_cc_info_headers(
                 compilation_context.direct_public_headers,
                 exclude_headers = categorized_files,
-                generated = generated,
             ),
         )
         extra_files.extend(
             _process_cc_info_headers(
                 compilation_context.direct_textual_headers,
                 exclude_headers = categorized_files,
-                generated = generated,
             ),
         )
 


### PR DESCRIPTION
Related to #2852.

This ensures that things like hmaps, vfs overlays, etc. are properly created during Index Build for C/C++/Objective-C targets. Swift targets will need a similar change.