### PR TITLE
Fix hang in `import_indexstores`

### DIFF
--- a/tools/import_indexstores/ImportIndexstores.swift
+++ b/tools/import_indexstores/ImportIndexstores.swift
@@ -28,9 +28,13 @@ Not enough arguments, expected path to execution root
             if FileManager.default.fileExists(atPath: pidFile) {
                 let pid = try String(contentsOfFile: pidFile)
 
-                try runSubProcess("/bin/kill", [pid])
+                try runSubProcess("/bin/kill", [pid], ignoreStdErr: true)
                 while true {
-                    if try runSubProcess("/bin/kill", ["-0", pid]) != 0 {
+                    if try runSubProcess(
+                        "/bin/kill",
+                        ["-0", pid],
+                        ignoreStdErr: true
+                    ) != 0 {
                         break
                     }
                     sleep(1)
@@ -53,6 +57,13 @@ Not enough arguments, expected path to execution root
             var indexstores: [String: Set<String>] = [:]
             for filePath in args.dropFirst(2) {
                 let url = URL(fileURLWithPath: filePath)
+
+                if !FileManager.default.fileExists(atPath: url.path) {
+                        throw PreconditionError(message: """
+\(url.path) does not exist
+"""
+                        )
+                }
 
                 var iterator = url.allLines.makeAsyncIterator()
                 while let indexstore = try await iterator.next() {

--- a/tools/import_indexstores/SubProcess.swift
+++ b/tools/import_indexstores/SubProcess.swift
@@ -2,12 +2,19 @@ import Foundation
 
 @discardableResult func runSubProcess(
     _ executable: String,
-    _ args: [String]
+    _ args: [String],
+    ignoreStdErr: Bool = false
 ) throws -> Int32 {
     let task = Process()
     task.launchPath = executable
     task.arguments = args
+
+    if ignoreStdErr {
+        task.standardError = Pipe()
+    }
+
     try task.run()
     task.waitUntilExit()
+
     return task.terminationStatus
 }


### PR DESCRIPTION
Because of a known issue with `url.allLines`, if the file doesn’t exist the stream hangs. We now correctly report an error instead of hanging when that happens.

This change also includes a silence to the `kill: 69492: No such process` outputs in the logs.
