### PR TITLE
Depend on `--experimental_remote_download_regex` for Index Build input collection in incremental generation mode

### DIFF
--- a/xcodeproj/internal/bazel_integration_files/generate_bazel_dependencies.sh
+++ b/xcodeproj/internal/bazel_integration_files/generate_bazel_dependencies.sh
@@ -22,12 +22,14 @@ else
     # Inputs for compiling, inputs for linking, and index store data
     readonly output_group_prefixes="xc,xl,xi"
   elif [[ "${ENABLE_PREVIEWS:-}" == "YES" ]]; then
-    # Compiled outputs (i.e. swiftmodules) and generated inputs, products (i.e.
-    # bundles), index store data, and link params
+    # Compile params, products (i.e. bundles) and index store data, and link
+    # params
+    # TODO: Remove `bi` once we remove support for legacy generation mode
     readonly output_group_prefixes="bc,bp,bi,bl"
   else
-    # Compiled outputs (i.e. swiftmodules) and generated
-    # inputs, products (i.e. bundles), and index store data
+    # Products (i.e. bundles) and index store data
+    # TODO: Remove `bc` and `bi` once we remove support for legacy generation
+    # mode
     readonly output_group_prefixes="bc,bp,bi"
   fi
 
@@ -108,7 +110,18 @@ fi
 # Build
 
 build_pre_config_flags=(
-  "--experimental_remote_download_regex=.*\.indexstore/.*|.*\.a$|.*\.swiftdoc$|.*\.swiftmodule$|.*\.swiftsourceinfo$|.*\.swift$"
+  # Include the following:
+  #
+  # - .indexstore directories to allow importing indexes
+  # - .swift{doc,sourceinfo} files for indexing
+  # - .a and .swiftmodule files for lldb
+  # - primary compilation input files (.c, .C, .cc, .cl, .cpp, .cu, .cxx, .c++,
+  #   .m, .mm, .swift) for Xcode build input checking
+  #
+  # This is brittle. If different file extensions are used for compilation
+  # inputs, they will need to be added to this list. Ideally we can stop doing
+  # this once Bazel adds support for a Remote Output Service.
+  "--experimental_remote_download_regex=.*\.indexstore/.*|.*\.(a|c|C|cc|cl|cpp|cu|cxx|c++|m|mm|swift|swiftdoc|swiftmodule|swiftsourceinfo)$"
 )
 
 apply_sanitizers=1

--- a/xcodeproj/internal/files/incremental_resources.bzl
+++ b/xcodeproj/internal/files/incremental_resources.bzl
@@ -38,7 +38,6 @@ def _process_resource(
         bundle_path,
         file,
         bundle_metadata,
-        generated,
         xccurrentversions):
     if (file.basename == ".xccurrentversion" and
         file.dirname.endswith(".xcdatamodeld")):
@@ -46,7 +45,6 @@ def _process_resource(
         return None
 
     if not file.is_source:
-        generated.append(file)
         if bundle_path and file.basename == "Info.plist":
             path_components = file.path.split("/")
             label = file.owner
@@ -77,7 +75,6 @@ def _add_resources_to_bundle(
         bundle_path,
         files,
         bundle_metadata,
-        generated,
         xccurrentversions):
     for file in files.to_list():
         file = _process_resource(
@@ -85,7 +82,6 @@ def _add_resources_to_bundle(
             bundle_path = bundle_path,
             file = file,
             bundle_metadata = bundle_metadata,
-            generated = generated,
             xccurrentversions = xccurrentversions,
         )
         if file:
@@ -103,17 +99,13 @@ def _add_structured_resources_to_bundle(
         bundle,
         *,
         nested_path,
-        files,
-        generated):
+        files):
     if nested_path:
         inner_dir = nested_path.split("/")[0]
     else:
         inner_dir = None
 
     for file in files.to_list():
-        if not file.is_source:
-            generated.append(file)
-
         if not inner_dir:
             bundle.resources.append(file)
             continue
@@ -141,8 +133,7 @@ def _add_structured_resources(
         resource_bundle_targets,
         bundle_path,
         nested_path,
-        files,
-        generated):
+        files):
     bundle = resource_bundle_targets.get(bundle_path)
 
     if bundle:
@@ -156,14 +147,12 @@ def _add_structured_resources(
             bundle,
             nested_path = nested_path,
             files = files,
-            generated = generated,
         )
     else:
         _add_structured_resources_to_bundle(
             root_bundle,
             nested_path = join_paths_ignoring_empty(bundle_path, nested_path),
             files = files,
-            generated = generated,
         )
 
 def _add_processed_resources(
@@ -172,7 +161,6 @@ def _add_processed_resources(
         root_bundle,
         resource_bundle_targets,
         bundle_metadata,
-        generated,
         xccurrentversions):
     for parent_dir, _, files in resources:
         if not parent_dir:
@@ -181,7 +169,6 @@ def _add_processed_resources(
                 bundle_path = None,
                 files = files,
                 bundle_metadata = bundle_metadata,
-                generated = generated,
                 xccurrentversions = xccurrentversions,
             )
             continue
@@ -193,7 +180,6 @@ def _add_processed_resources(
                 bundle_path = None,
                 files = files,
                 bundle_metadata = bundle_metadata,
-                generated = generated,
                 xccurrentversions = xccurrentversions,
             )
             continue
@@ -205,7 +191,6 @@ def _add_processed_resources(
             bundle_path = bundle_path,
             files = files,
             bundle_metadata = bundle_metadata,
-            generated = generated,
             xccurrentversions = xccurrentversions,
         )
 
@@ -216,7 +201,6 @@ def _add_unprocessed_resources(
         resource_bundle_targets,
         parent_bundle_paths,
         bundle_metadata,
-        generated,
         xccurrentversions):
     for parent_dir, _, files in resources:
         if not parent_dir:
@@ -225,7 +209,6 @@ def _add_unprocessed_resources(
                 bundle_path = None,
                 files = files,
                 bundle_metadata = bundle_metadata,
-                generated = generated,
                 xccurrentversions = xccurrentversions,
             )
             continue
@@ -244,7 +227,6 @@ def _add_unprocessed_resources(
             bundle_path = bundle_path,
             nested_path = nested_path,
             files = files,
-            generated = generated,
         )
 
 # API
@@ -269,12 +251,10 @@ def _collect_incremental_resources(
             `process_resource_bundles`.
         *   `resources`: A `list` of `file_path`s of resources that should be
             added to the target's bundle.
-        *   `generated`: A `list` of `file_path`s of generated resources.
         *   `xccurrentversions`: A `list` of `.xccurrentversion` `File`s.
     """
     root_bundle = _create_bundle()
     resource_bundle_targets = {}
-    generated = []
     xccurrentversions = []
     bundle_metadata = {}
 
@@ -310,7 +290,6 @@ def _collect_incremental_resources(
                 resource_bundle_targets = resource_bundle_targets,
                 parent_bundle_paths = parent_bundle_paths,
                 bundle_metadata = bundle_metadata,
-                generated = generated,
                 xccurrentversions = xccurrentversions,
             )
         else:
@@ -319,7 +298,6 @@ def _collect_incremental_resources(
                 root_bundle = root_bundle,
                 resource_bundle_targets = resource_bundle_targets,
                 bundle_metadata = bundle_metadata,
-                generated = generated,
                 xccurrentversions = xccurrentversions,
             )
 
@@ -370,7 +348,6 @@ def _collect_incremental_resources(
         bundles = frozen_bundles,
         resources = root_bundle.resources,
         folder_resources = root_bundle.folder_resources,
-        generated = generated,
         xccurrentversions = xccurrentversions,
     )
 

--- a/xcodeproj/internal/processed_targets/incremental_library_targets.bzl
+++ b/xcodeproj/internal/processed_targets/incremental_library_targets.bzl
@@ -15,7 +15,6 @@ load(
     "//xcodeproj/internal:memory_efficiency.bzl",
     "EMPTY_DEPSET",
     "EMPTY_TUPLE",
-    "memory_efficient_depset",
 )
 load("//xcodeproj/internal:pbxproj_partials.bzl", "pbxproj_partials")
 load("//xcodeproj/internal:platforms.bzl", "platforms")
@@ -122,25 +121,6 @@ def _process_incremental_library_target(
         transitive_infos = transitive_infos,
     )
 
-    debug_outputs = target[apple_common.AppleDebugOutputs] if apple_common.AppleDebugOutputs in target else None
-    output_group_info = (
-        target[OutputGroupInfo] if OutputGroupInfo in target else None
-    )
-    (
-        target_outputs,
-        provider_outputs,
-        target_output_groups_metadata,
-    ) = output_files.collect(
-        actions = actions,
-        debug_outputs = debug_outputs,
-        id = id,
-        name = label.name,
-        output_group_info = output_group_info,
-        product = product,
-        swift_info = swift_info,
-        transitive_infos = transitive_infos,
-    )
-
     package_bin_dir = products.calculate_packge_bin_dir(
         bin_dir_path = bin_dir_path,
         label = label,
@@ -178,16 +158,26 @@ def _process_incremental_library_target(
         order = "topological",
     )
 
-    if params_files:
-        compiling_files = memory_efficient_depset(
-            params_files,
-            transitive = [provider_inputs.generated],
-        )
-    else:
-        compiling_files = provider_inputs.generated
-
+    (
+        target_outputs,
+        provider_outputs,
+        target_output_groups_metadata,
+    ) = output_files.collect(
+        actions = actions,
+        compile_params_files = params_files,
+        debug_outputs = (
+            target[apple_common.AppleDebugOutputs] if apple_common.AppleDebugOutputs in target else None
+        ),
+        id = id,
+        name = label.name,
+        output_group_info = (
+            target[OutputGroupInfo] if OutputGroupInfo in target else None
+        ),
+        product = product,
+        swift_info = swift_info,
+        transitive_infos = transitive_infos,
+    )
     target_output_groups = output_groups.collect(
-        compiling_files = compiling_files,
         metadata = target_output_groups_metadata,
         transitive_infos = transitive_infos,
     )

--- a/xcodeproj/internal/processed_targets/incremental_top_level_targets.bzl
+++ b/xcodeproj/internal/processed_targets/incremental_top_level_targets.bzl
@@ -703,14 +703,6 @@ def _process_focused_top_level_target(
 
     swift_info = target[SwiftInfo] if SwiftInfo in target else None
 
-    if params_files:
-        compiling_files = memory_efficient_depset(
-            params_files,
-            transitive = [provider_inputs.generated],
-        )
-    else:
-        compiling_files = provider_inputs.generated
-
     if apple_common.AppleDebugOutputs in target:
         debug_outputs = target[apple_common.AppleDebugOutputs]
     else:
@@ -734,6 +726,7 @@ def _process_focused_top_level_target(
         target_output_groups_metadata,
     ) = output_files.collect(
         actions = actions,
+        compile_params_files = params_files,
         copy_product_transitively = True,
         debug_outputs = debug_outputs,
         id = id,
@@ -748,9 +741,7 @@ def _process_focused_top_level_target(
         swift_info = swift_info,
         transitive_infos = transitive_infos,
     )
-
     target_output_groups = output_groups.collect(
-        compiling_files = compiling_files,
         metadata = target_output_groups_metadata,
         transitive_infos = transitive_infos,
     )


### PR DESCRIPTION
Fixes #2852.

This is a pretty big shift away from how we used to do it.

With the baggage of BwX mode gone we don’t have to track generated files in the same way. After removing that tracking we can depend on building the product for each target (i.e. the `bp` output group) to transitive generate all files needed to compile that target.

In a BwtB world though we need to make sure we still download all of those inputs, which is where `--experimental_remote_download_regex` comes in. I’ve added all of the file types that I currently know of to the regex, but it’s brittle and may require more from the user. The flag supports multiple uses, so a user can fix this on their own as well.

There are four main benefits with this new way (which is good, because the above is a pretty big downside):

1. We now generate/download previously tricky to track files like vfs overlays and hmaps
2. Less Starlark CPU usage collecting all of the generated files
3. Less Starlark memory usage retaining these generated files
4. Much smaller BEP, since the output groups are smaller, resulting in less memory usage and faster builds