### PR TITLE
Set `--noincompatible_objc_provider_remove_linking_info` for now

### DIFF
--- a/bazel_8.bazelrc
+++ b/bazel_8.bazelrc
@@ -1,0 +1,2 @@
+# TODO: Remove once https://github.com/bazelbuild/rules_apple/issues/2353 and https://github.com/bazelbuild/rules_swift/issues/1142 are fixed
+build --noincompatible_objc_provider_remove_linking_info


### PR DESCRIPTION
Works around the flag flipping at HEAD, until rules_apple and rules_swift are updated.