### PR TITLE
Support pre/post actions with `launch_path`

### DIFF
--- a/docs/bazel.md
+++ b/docs/bazel.md
@@ -278,7 +278,7 @@ Defines an environment variable value.
 ## xcschemes.launch_path
 
 <pre>
-xcschemes.launch_path(<a href="#xcschemes.launch_path-path">path</a>, <a href="#xcschemes.launch_path-working_directory">working_directory</a>)
+xcschemes.launch_path(<a href="#xcschemes.launch_path-path">path</a>, <a href="#xcschemes.launch_path-post_actions">post_actions</a>, <a href="#xcschemes.launch_path-pre_actions">pre_actions</a>, <a href="#xcschemes.launch_path-working_directory">working_directory</a>)
 </pre>
 
 Defines the launch path for a pre-built executable.
@@ -289,6 +289,8 @@ Defines the launch path for a pre-built executable.
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="xcschemes.launch_path-path"></a>path |  Positional. The launch path for a launch target.<br><br>The path must be an absolute path to an executable file. It will be set as the runnable within a launch action.   |  none |
+| <a id="xcschemes.launch_path-post_actions"></a>post_actions |  Post-actions to run when running the launch path.<br><br>Elements of the `list` must be values returned by functions in [`xcschemes.pre_post_actions`](#xcschemes.pre_post_actions).   |  `[]` |
+| <a id="xcschemes.launch_path-pre_actions"></a>pre_actions |  Pre-actions to run when running the launch path.<br><br>Elements of the `list` must be values returned by functions in [`xcschemes.pre_post_actions`](#xcschemes.pre_post_actions).   |  `[]` |
 | <a id="xcschemes.launch_path-working_directory"></a>working_directory |  The working directory to use when running the launch target.<br><br>If not set, the Xcode default working directory will be used (i.e. some directory in `DerivedData`).   |  `None` |
 
 

--- a/test/internal/xcschemes/info_constructors_tests.bzl
+++ b/test/internal/xcschemes/info_constructors_tests.bzl
@@ -314,11 +314,57 @@ def info_constructors_test_suite(name):
     )
 
     _add_test(
-        name = "{}_make_launch_target_is_path".format(name),
+        name = "{}_make_launch_target_is_path_minimal".format(name),
 
         # Inputs
         info = xcscheme_infos_testable.make_launch_target(
             path = "/Foo/Bar.app",
+        ),
+
+        # Expected
+        expected_info = struct(
+            is_path = "1",
+            path = "/Foo/Bar.app",
+            post_actions = [],
+            pre_actions = [],
+            working_directory = "",
+        ),
+    )
+
+    _add_test(
+        name = "{}_make_launch_target_is_path_full".format(name),
+
+        # Inputs
+        info = xcscheme_infos_testable.make_launch_target(
+            path = "/Foo/Bar.app",
+            post_actions = [
+                xcscheme_infos_testable.make_pre_post_action(
+                    for_build = False,
+                    order = "",
+                    script_text = "script",
+                    title = "title",
+                ),
+                xcscheme_infos_testable.make_pre_post_action(
+                    for_build = True,
+                    order = "1",
+                    script_text = "s",
+                    title = "t",
+                ),
+            ],
+            pre_actions = [
+                xcscheme_infos_testable.make_pre_post_action(
+                    for_build = True,
+                    order = "2",
+                    script_text = "ss",
+                    title = "tt",
+                ),
+                xcscheme_infos_testable.make_pre_post_action(
+                    for_build = False,
+                    order = "11",
+                    script_text = "sss",
+                    title = "ttt",
+                ),
+            ],
             working_directory = "/Foo",
         ),
 
@@ -326,6 +372,34 @@ def info_constructors_test_suite(name):
         expected_info = struct(
             is_path = "1",
             path = "/Foo/Bar.app",
+            post_actions = [
+                xcscheme_infos_testable.make_pre_post_action(
+                    for_build = False,
+                    order = "",
+                    script_text = "script",
+                    title = "title",
+                ),
+                xcscheme_infos_testable.make_pre_post_action(
+                    for_build = True,
+                    order = "1",
+                    script_text = "s",
+                    title = "t",
+                ),
+            ],
+            pre_actions = [
+                xcscheme_infos_testable.make_pre_post_action(
+                    for_build = True,
+                    order = "2",
+                    script_text = "ss",
+                    title = "tt",
+                ),
+                xcscheme_infos_testable.make_pre_post_action(
+                    for_build = False,
+                    order = "11",
+                    script_text = "sss",
+                    title = "ttt",
+                ),
+            ],
             working_directory = "/Foo",
         ),
     )

--- a/test/internal/xcschemes/infos_from_json_tests.bzl
+++ b/test/internal/xcschemes/infos_from_json_tests.bzl
@@ -698,6 +698,93 @@ def infos_from_json_test_suite(name):
     )
 
     _add_test(
+        name = "{}_run_launch_path".format(name),
+
+        # Inputs
+        default_xcode_configuration = "AppStore",
+        json_str = json.encode([
+            {
+                "name": "A scheme",
+                "profile": None,
+                "run": struct(
+                    args = full_args,
+                    build_targets = full_build_targets,
+                    diagnostics = struct(
+                        address_sanitizer = "1",
+                        thread_sanitizer = "1",
+                        undefined_behavior_sanitizer = "1",
+                    ),
+                    env = full_env,
+                    env_include_defaults = "0",
+                    launch_target = struct(
+                        is_path = "1",
+                        path = "/path/to/App.app",
+                        post_actions = [
+                            xcscheme_infos_testable.make_pre_post_action(
+                                for_build = True,
+                                order = "",
+                                script_text = "ssss",
+                                title = "ttt",
+                            ),
+                        ],
+                        pre_actions = [
+                            xcscheme_infos_testable.make_pre_post_action(
+                                for_build = True,
+                                order = "7",
+                                script_text = "s",
+                                title = "tttt",
+                            ),
+                        ],
+                        working_directory = "wd",
+                    ),
+                    xcode_configuration = "custom",
+                ),
+                "test": None,
+            },
+        ]),
+        top_level_deps = top_level_deps,
+
+        # Expected
+        expected_infos = [
+            xcscheme_infos_testable.make_scheme(
+                name = "A scheme",
+                run = xcscheme_infos_testable.make_run(
+                    args = expected_full_args,
+                    build_targets = expected_full_build_targets,
+                    diagnostics = xcscheme_infos_testable.make_diagnostics(
+                        address_sanitizer = "1",
+                        thread_sanitizer = "1",
+                        undefined_behavior_sanitizer = "1",
+                    ),
+                    env = expected_full_env,
+                    env_include_defaults = "0",
+                    launch_target = xcscheme_infos_testable.make_launch_target(
+                        path = "/path/to/App.app",
+                        post_actions = [
+                            xcscheme_infos_testable.make_pre_post_action(
+                                for_build = True,
+                                order = "",
+                                script_text = "ssss",
+                                title = "ttt",
+                            ),
+                        ],
+                        pre_actions = [
+                            xcscheme_infos_testable.make_pre_post_action(
+                                for_build = True,
+                                order = "7",
+                                script_text = "s",
+                                title = "tttt",
+                            ),
+                        ],
+                        working_directory = "wd",
+                    ),
+                    xcode_configuration = "custom",
+                ),
+            ),
+        ],
+    )
+
+    _add_test(
         name = "{}_run_full".format(name),
 
         # Inputs

--- a/test/internal/xcschemes/utils.bzl
+++ b/test/internal/xcschemes/utils.bzl
@@ -23,6 +23,8 @@ def _dict_to_launch_target_info(d):
         return struct(
             is_path = "1",
             path = d["path"],
+            post_actions = _dicts_to_pre_post_action_infos(d["post_actions"]),
+            pre_actions = _dicts_to_pre_post_action_infos(d["pre_actions"]),
             working_directory = d["working_directory"],
         )
     else:

--- a/tools/generators/lib/XCScheme/test/CreateLaunchActionTests.swift
+++ b/tools/generators/lib/XCScheme/test/CreateLaunchActionTests.swift
@@ -444,6 +444,76 @@ final class CreateLaunchActionTests: XCTestCase {
 
         XCTAssertNoDifference(action, expectedAction)
     }
+
+    func test_runnable_path_with_pre_and_postActions() {
+         // Arrange
+
+         let buildConfiguration = "Debug"
+         let runnable = Runnable.path(path: "/Foo/Bar.app")
+         let preActions: [ExecutionAction] = [
+               .init(
+                  title: "PRE_ACTION_TITLE",
+                  escapedScriptText: "PRE_ACTION_SCRIPT_TEXT",
+                  expandVariablesBasedOn: nil
+               ),
+         ]
+         let postActions: [ExecutionAction] = [
+               .init(
+                  title: "POST_ACTION_TITLE",
+                  escapedScriptText: "POST_ACTION_SCRIPT_TEXT",
+                  expandVariablesBasedOn: nil
+               ),
+         ]
+
+         let expectedAction = #"""
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "PRE_ACTION_TITLE"
+               scriptText = "PRE_ACTION_SCRIPT_TEXT">
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
+      <PostActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "POST_ACTION_TITLE"
+               scriptText = "POST_ACTION_SCRIPT_TEXT">
+            </ActionContent>
+         </ExecutionAction>
+      </PostActions>
+      <PathRunnable
+         runnableDebuggingMode = "0"
+         FilePath = "/Foo/Bar.app">
+      </PathRunnable>
+   </LaunchAction>
+"""#
+
+         // Act
+
+         let action = createLaunchActionWithDefaults(
+            buildConfiguration: buildConfiguration,
+            postActions: postActions,
+            preActions: preActions,
+            runnable: runnable
+         )
+
+         // Assert
+
+         XCTAssertNoDifference(action, expectedAction)
+    }
 }
 
 private func createLaunchActionWithDefaults(

--- a/tools/generators/lib/XCScheme/test/CreateProfileActionTests.swift
+++ b/tools/generators/lib/XCScheme/test/CreateProfileActionTests.swift
@@ -308,6 +308,72 @@ final class CreateProfileActionTests: XCTestCase {
 
         XCTAssertNoDifference(prefix, expectedPrefix)
     }
+
+    func test_runnable_path_with_pre_and_postActions() {
+        // Arrange
+
+        let buildConfiguration = "Debug"
+        let runnable = Runnable.path(path: "/Foo/Bar")
+          let preActions: [ExecutionAction] = [
+               .init(
+                  title: "PRE_ACTION_TITLE",
+                  escapedScriptText: "PRE_ACTION_SCRIPT_TEXT",
+                  expandVariablesBasedOn: nil
+               ),
+         ]
+         let postActions: [ExecutionAction] = [
+               .init(
+                  title: "POST_ACTION_TITLE",
+                  escapedScriptText: "POST_ACTION_SCRIPT_TEXT",
+                  expandVariablesBasedOn: nil
+               ),
+         ]
+
+        let expectedPrefix = #"""
+   <ProfileAction
+      buildConfiguration = "Debug"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "PRE_ACTION_TITLE"
+               scriptText = "PRE_ACTION_SCRIPT_TEXT">
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
+      <PostActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "POST_ACTION_TITLE"
+               scriptText = "POST_ACTION_SCRIPT_TEXT">
+            </ActionContent>
+         </ExecutionAction>
+      </PostActions>
+      <PathRunnable
+         runnableDebuggingMode = "0"
+         FilePath = "/Foo/Bar">
+      </PathRunnable>
+   </ProfileAction>
+"""#
+
+        // Act
+
+        let prefix = createProfileActionWithDefaults(
+            buildConfiguration: buildConfiguration,
+            postActions: postActions,
+            preActions: preActions,
+            runnable: runnable
+        )
+
+        // Assert
+
+        XCTAssertNoDifference(prefix, expectedPrefix)
+    }
 }
 
 private func createProfileActionWithDefaults(

--- a/tools/generators/xcschemes/src/Generator/CreateCustomSchemeInfos.swift
+++ b/tools/generators/xcschemes/src/Generator/CreateCustomSchemeInfos.swift
@@ -720,16 +720,19 @@ private extension Dictionary where
                 try rawArgs.consumeArg("target-id", as: TargetID.self, in: url)
             let order = try rawArgs.consumeArg("order", as: Int?.self, in: url)
 
+            // if target id is empty then there is no target associated with this pre/post action.
+            let target = try id.rawValue.isEmpty ? nil : targetsByID.value(
+                for: id,
+                context: "Execution action associated target ID"
+            )
+
             ret[schemeName, default: []].append(
                 .init(
                     title: title,
                     scriptText: scriptText,
                     action: action,
                     isPreAction: isPreAction,
-                    target: try targetsByID.value(
-                        for: id,
-                        context: "Execution action associated target ID"
-                    ),
+                    target: target,
                     order: order
                 )
             )

--- a/tools/generators/xcschemes/src/Generator/CreateScheme.swift
+++ b/tools/generators/xcschemes/src/Generator/CreateScheme.swift
@@ -120,7 +120,7 @@ extension Generator.CreateScheme {
                 escapedScriptText:
                     executionAction.scriptText.schemeXmlEscaped,
                 expandVariablesBasedOn:
-                    executionAction.target.buildableReference
+                    executionAction.target?.buildableReference
             )
 
             switch (executionAction.action, executionAction.isPreAction) {

--- a/tools/generators/xcschemes/src/Generator/SchemeInfo.swift
+++ b/tools/generators/xcschemes/src/Generator/SchemeInfo.swift
@@ -15,7 +15,7 @@ struct SchemeInfo: Equatable {
         let scriptText: String
         let action: Action
         let isPreAction: Bool
-        let target: Target
+        let target: Target?
         let order: Int?
     }
 

--- a/xcodeproj/internal/xcschemes/xcscheme_infos.bzl
+++ b/xcodeproj/internal/xcschemes/xcscheme_infos.bzl
@@ -50,6 +50,8 @@ def _make_launch_target(
         return struct(
             is_path = TRUE_ARG,
             path = path,
+            post_actions = post_actions,
+            pre_actions = pre_actions,
             working_directory = working_directory,
         )
 
@@ -355,6 +357,12 @@ def _launch_target_info_from_dict(
         return (
             _make_launch_target(
                 path = launch_target["path"],
+                post_actions = _pre_post_action_info_from_dicts(
+                    launch_target["post_actions"],
+                ),
+                pre_actions = _pre_post_action_info_from_dicts(
+                    launch_target["pre_actions"],
+                ),
                 working_directory = launch_target["working_directory"],
             ),
             EMPTY_LIST,

--- a/xcodeproj/internal/xcschemes/xcscheme_labels.bzl
+++ b/xcodeproj/internal/xcschemes/xcscheme_labels.bzl
@@ -43,6 +43,8 @@ def _resolve_launch_target_labels(launch_target):
         return struct(
             is_path = TRUE_ARG,
             path = launch_target.path,
+            post_actions = launch_target.post_actions,
+            pre_actions = launch_target.pre_actions,
             working_directory = launch_target.working_directory,
         )
 

--- a/xcodeproj/internal/xcschemes/xcschemes.bzl
+++ b/xcodeproj/internal/xcschemes/xcschemes.bzl
@@ -539,6 +539,8 @@ def _test(
 def _launch_path(
         path,
         *,
+        post_actions = [],
+        pre_actions = [],
         working_directory = None):
     """Defines the launch path for a pre-built executable.
 
@@ -552,6 +554,14 @@ def _launch_path(
 
             If not set, the Xcode default working directory will be used (i.e.
             some directory in `DerivedData`).
+        post_actions: Post-actions to run when running the launch path.
+
+            Elements of the `list` must be values returned by functions in
+            [`xcschemes.pre_post_actions`](#xcschemes.pre_post_actions).
+        pre_actions: Pre-actions to run when running the launch path.
+
+            Elements of the `list` must be values returned by functions in
+            [`xcschemes.pre_post_actions`](#xcschemes.pre_post_actions).
     """
 
     if not path:
@@ -562,6 +572,8 @@ def _launch_path(
     return struct(
         is_path = TRUE_ARG,
         path = path,
+        post_actions = post_actions,
+        pre_actions = pre_actions,
         working_directory = working_directory or "",
     )
 

--- a/xcodeproj/internal/xcschemes/xcschemes_execution.bzl
+++ b/xcodeproj/internal/xcschemes/xcschemes_execution.bzl
@@ -256,6 +256,7 @@ def _write_schemes(
             custom_scheme_args.add(build_target.id)
             _add_execution_actions(
                 build_target,
+                target_id = build_target.id,
                 action_name = action_name,
                 scheme_name = scheme_name,
             )
@@ -297,17 +298,17 @@ def _write_schemes(
             [action.title, action.script_text],
             map_each = _null_newlines,
         )
-        execution_actions_args.add(id)
+        execution_actions_args.add(id or "")
         execution_actions_args.add(action.order or "")
 
     # buildifier: disable=uninitialized
-    def _add_execution_actions(target, *, action_name, scheme_name):
+    def _add_execution_actions(target, *, target_id, action_name, scheme_name):
         # buildifier: disable=uninitialized
         for action in target.pre_actions:
             _add_execution_action(
                 action,
                 action_name = action_name,
-                id = target.id,
+                id = target_id,
                 is_pre_action = TRUE_ARG,
                 scheme_name = scheme_name,
             )
@@ -317,7 +318,7 @@ def _write_schemes(
             _add_execution_action(
                 action,
                 action_name = action_name,
-                id = target.id,
+                id = target_id,
                 is_pre_action = FALSE_ARG,
                 scheme_name = scheme_name,
             )
@@ -327,17 +328,21 @@ def _write_schemes(
         custom_scheme_args.add(launch_target.is_path)
 
         if launch_target.is_path == TRUE_ARG:
+            target_id = None
             custom_scheme_args.add(launch_target.path)
             custom_scheme_args.add(launch_target.working_directory)
         else:
-            custom_scheme_args.add(launch_target.id)
+            target_id = launch_target.id
+            custom_scheme_args.add(target_id)
             custom_scheme_args.add(launch_target.extension_host)
             custom_scheme_args.add(launch_target.working_directory)
-            _add_execution_actions(
-                launch_target,
-                action_name = action_name,
-                scheme_name = scheme_name,
-            )
+
+        _add_execution_actions(
+            launch_target,
+            target_id = target_id,
+            action_name = action_name,
+            scheme_name = scheme_name,
+        )
 
     custom_scheme_args.add(len(xcscheme_infos))
     for info in xcscheme_infos:
@@ -352,6 +357,7 @@ def _write_schemes(
             custom_scheme_args.add(test_target.enabled)
             _add_execution_actions(
                 test_target,
+                target_id = test_target.id,
                 action_name = _EXECUTION_ACTION_NAME.test,
                 scheme_name = scheme_name,
             )


### PR DESCRIPTION
Follow up to #2785 which added `launch_path`. After using this more I realized we can also support `pre`/`post` actions for this attribute.