### PR TITLE
Generate file elements without `.joined()`

### DIFF
--- a/tools/generators/files_and_groups/src/ElementCreator/CreateFileElement.swift
+++ b/tools/generators/files_and_groups/src/ElementCreator/CreateFileElement.swift
@@ -88,27 +88,17 @@ extension ElementCreator.CreateFileElement {
             sortOrder = .fileLike
         }
 
-        let explicitFileType: String?
+        let fileType: String
+        let fileTypeType: String
         if name == "BUILD" {
-            explicitFileType = Xcode.pbxProjEscapedFileType(extension: "bazel")
+            fileTypeType = "explicitFileType"
+            fileType = Xcode.pbxProjEscapedFileType(extension: "bazel")!
         } else if name == "Podfile" {
-            explicitFileType = Xcode.pbxProjEscapedFileType(extension: "rb")
+            fileTypeType = "explicitFileType"
+            fileType = Xcode.pbxProjEscapedFileType(extension: "rb")!
         } else {
-            explicitFileType = nil
-        }
-
-        var contentComponents = [
-            "{isa = PBXFileReference;",
-        ]
-
-        if let explicitFileType {
-            contentComponents.append(
-                "explicitFileType = \(explicitFileType);"
-            )
-        } else {
-            contentComponents.append(
-                "lastKnownFileType = \(lastKnownFileType);"
-            )
+            fileTypeType = "lastKnownFileType"
+            fileType = lastKnownFileType
         }
 
         let attributes = createAttributes(
@@ -117,17 +107,20 @@ extension ElementCreator.CreateFileElement {
             isGroup: false,
             specialRootGroupType: specialRootGroupType
         )
+
+        let nameAttribute: String
         if let name = attributes.elementAttributes.name {
-            contentComponents.append("name = \(name.pbxProjEscaped);")
+            nameAttribute = "name = \(name.pbxProjEscaped); "
+        } else {
+            nameAttribute = ""
         }
-        contentComponents.append(
-            "path = \(attributes.elementAttributes.path.pbxProjEscaped);"
-        )
-        contentComponents.append(
-            """
+        let content = """
+{isa = PBXFileReference; \
+\(fileTypeType) = \(fileType); \
+\(nameAttribute)\
+path = \(attributes.elementAttributes.path.pbxProjEscaped); \
 sourceTree = \(attributes.elementAttributes.sourceTree.rawValue); }
 """
-        )
 
         return (
             element: .init(
@@ -139,7 +132,7 @@ sourceTree = \(attributes.elementAttributes.sourceTree.rawValue); }
                             attributes.elementAttributes.path,
                         type: .fileReference
                     ),
-                    content: contentComponents.joined(separator: " ")
+                    content: content
                 ),
                 sortOrder: sortOrder
             ),

--- a/tools/generators/files_and_groups/src/ElementCreator/CreateLocalizedFileElement.swift
+++ b/tools/generators/files_and_groups/src/ElementCreator/CreateLocalizedFileElement.swift
@@ -54,37 +54,28 @@ extension ElementCreator.CreateLocalizedFileElement {
         bazelPath: BazelPath,
         createIdentifier: ElementCreator.CreateIdentifier
     ) -> Element {
-        let lastKnownFileType = ext
-            .flatMap { Xcode.pbxProjEscapedFileType(extension: $0) } ?? "file"
-
-        let explicitFileType: String?
+        let fileType: String
+        let fileTypeType: String
         if name == "BUILD" {
-            explicitFileType = Xcode.pbxProjEscapedFileType(extension: "bazel")
+            fileTypeType = "explicitFileType"
+            fileType = Xcode.pbxProjEscapedFileType(extension: "bazel")!
         } else if name == "Podfile" {
-            explicitFileType = Xcode.pbxProjEscapedFileType(extension: "rb")
+            fileTypeType = "explicitFileType"
+            fileType = Xcode.pbxProjEscapedFileType(extension: "rb")!
         } else {
-            explicitFileType = nil
+            fileTypeType = "lastKnownFileType"
+            fileType = ext
+                .flatMap { Xcode.pbxProjEscapedFileType(extension: $0) } ??
+                "file"
         }
 
-        var contentComponents = [
-            "{isa = PBXFileReference;",
-        ]
-
-        if let explicitFileType {
-            contentComponents.append(
-                "explicitFileType = \(explicitFileType);"
-            )
-        } else {
-            contentComponents.append(
-                "lastKnownFileType = \(lastKnownFileType);"
-            )
-        }
-
-        contentComponents.append("""
+        let content = """
+{isa = PBXFileReference; \
+\(fileTypeType) = \(fileType); \
 name = \(name.pbxProjEscaped); \
 path = \(path.pbxProjEscaped); \
 sourceTree = "<group>"; }
-""")
+"""
 
         return .init(
             name: name,
@@ -94,7 +85,7 @@ sourceTree = "<group>"; }
                     name: name,
                     type: .localized
                 ),
-                content: contentComponents.joined(separator: " ")
+                content: content
             ),
             sortOrder: .fileLike
         )


### PR DESCRIPTION
This was a noticeable hotspot in a real world large project.