### PR TITLE
Sort build files objects

### DIFF
--- a/tools/generators/files_and_groups/src/Generator/CalculateTargetFilesPartial.swift
+++ b/tools/generators/files_and_groups/src/Generator/CalculateTargetFilesPartial.swift
@@ -44,7 +44,12 @@ extension Generator.CalculateTargetFilesPartial {
         }
 
         return #"""
-\#(buildFiles.map { "\t\t\($0.identifier) = \($0.content);\n" }.joined())\#
+\#(
+    buildFiles
+        .sorted { $0.identifier < $1.identifier }
+        .map { "\t\t\($0.identifier) = \($0.content);\n" }
+        .joined()
+)\#
 		\#(Identifiers.FilesAndGroups.productsGroup) = {
 			isa = PBXGroup;
 			children = (

--- a/tools/generators/files_and_groups/test/Generator/CalculateTargetFilesPartialTests.swift
+++ b/tools/generators/files_and_groups/test/Generator/CalculateTargetFilesPartialTests.swift
@@ -42,9 +42,11 @@ class CalculateTargetFilesPartialTests: XCTestCase {
         ]
 
         // The tabs for indenting are intentional
+        //
+        // Shows that it's responsible for sorting build files.
         let expectedFilesAndGroupsPartial = #"""
-		ID_2 = {BUILDFILE_2};
 		ID_1 = {BUILDFILE_1};
+		ID_2 = {BUILDFILE_2};
 		FF0000000000000000000004 /* Products */ = {
 			isa = PBXGroup;
 			children = (


### PR DESCRIPTION
The order can be non-deterministic because of concurrency. The sorting doesn't have a large cost here either.