### PR TITLE
Use better version specification

### DIFF
--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -17,10 +17,10 @@ x_templates:
       env: {}
     - &bazel_previous_lts
       env:
-        USE_BAZEL_VERSION: latest-1
+        USE_BAZEL_VERSION: 6.x
     - &bazel_lts
       env:
-        USE_BAZEL_VERSION: latest
+        USE_BAZEL_VERSION: 7.x
     - &bazel_head
       env:
         USE_BAZEL_VERSION: last_green


### PR DESCRIPTION
`latest-1` resolves to 7.0.0 instead of 6.4.0 for some reason, so we now use the `MAJOR.x` flavor instead.