### PR TITLE
Add `CppArchive` to the list of no-cache actions

### DIFF
--- a/shared.bazelrc
+++ b/shared.bazelrc
@@ -45,7 +45,7 @@ build:cache --bes_upload_mode=nowait_for_upload_complete
 build:cache --experimental_remote_cache_async
 build:cache --experimental_remote_cache_compression
 build:cache --jobs=100
-build:cache --modify_execution_info=^(AppleLipo|BitcodeSymbolsCopy|BundleApp|BundleTreeApp|DsymDwarf|DsymLipo|GenerateAppleSymbolsFile|ObjcBinarySymbolStrip|CppLink|ObjcLink|ProcessAndSign|SignBinary|SwiftArchive|SwiftStdlibCopy)$=+no-remote,^(BundleResources|ImportedDynamicFrameworkProcessor)$=+no-remote-exec
+build:cache --modify_execution_info=^(AppleLipo|BitcodeSymbolsCopy|BundleApp|BundleTreeApp|DsymDwarf|DsymLipo|GenerateAppleSymbolsFile|ObjcBinarySymbolStrip|CppArchive|CppLink|ObjcLink|ProcessAndSign|SignBinary|SwiftArchive|SwiftStdlibCopy)$=+no-remote,^(BundleResources|ImportedDynamicFrameworkProcessor)$=+no-remote-exec
 build:cache --remote_cache=grpcs://remote.buildbuddy.io
 build:cache --@rules_xcodeproj//xcodeproj:extra_common_flags='--config=cache'
 build:cache --@rules_xcodeproj//xcodeproj:extra_generator_flags='--bes_backend= --bes_results_url='


### PR DESCRIPTION
`CppLink` has been split into `CppLink` and `CppArchive` from Bazel 6. `CppArchive` is the action that creates archives for `swift_library`.