### PR TITLE
Define _rules_xcodeproj_build config for all commands

### DIFF
--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -111,7 +111,7 @@ build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable
 # `rules_xcodeproj` instead. This config exists solely to allow project-level
 # configs to work correctly.
 
-build:_rules_xcodeproj_build --config=rules_xcodeproj
+common:_rules_xcodeproj_build --config=rules_xcodeproj
 
 ### Project specific configs
 

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -111,7 +111,7 @@ build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable
 # `rules_xcodeproj` instead. This config exists solely to allow project-level
 # configs to work correctly.
 
-build:_rules_xcodeproj_build --config=rules_xcodeproj
+common:_rules_xcodeproj_build --config=rules_xcodeproj
 
 ### Project specific configs
 

--- a/examples/rules_ios/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/rules_ios/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -111,7 +111,7 @@ build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable
 # `rules_xcodeproj` instead. This config exists solely to allow project-level
 # configs to work correctly.
 
-build:_rules_xcodeproj_build --config=rules_xcodeproj
+common:_rules_xcodeproj_build --config=rules_xcodeproj
 
 ### Project specific configs
 

--- a/xcodeproj/internal/templates/xcodeproj.bazelrc
+++ b/xcodeproj/internal/templates/xcodeproj.bazelrc
@@ -111,7 +111,7 @@ build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable
 # `rules_xcodeproj` instead. This config exists solely to allow project-level
 # configs to work correctly.
 
-build:_rules_xcodeproj_build --config=rules_xcodeproj
+common:_rules_xcodeproj_build --config=rules_xcodeproj
 
 ### Project specific configs
 %project_configs%


### PR DESCRIPTION
Define _rules_xcodeproj_build for all commands, not only build

### Problem

Prior to this change, other commands (e.g. `fetch`) fail with an error, like:
```
$ bazel run //:bazel-project --   "--generator_output_groups=all_targets" "fetch //..."
...
ERROR: Config value '_rules_xcodeproj_build' is not defined in any .rc file
```