### PR TITLE
Upgrade bazel_features to 1.3.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,7 +5,7 @@ module(
     repo_name = "rules_xcodeproj",
 )
 
-bazel_dep(name = "bazel_features", version = "1.1.1")
+bazel_dep(name = "bazel_features", version = "1.3.0")
 bazel_dep(name = "bazel_skylib", version = "1.3.0")
 bazel_dep(
     name = "rules_swift",


### PR DESCRIPTION
This version is needed by rules_swift, so we might as well upgrade as well.