### PR TITLE
Remove `--noincompatible_objc_provider_remove_linking_info`

### DIFF
--- a/bazel_8.bazelrc
+++ b/bazel_8.bazelrc
@@ -1,2 +1,0 @@
-# TODO: Remove once https://github.com/bazelbuild/rules_apple/issues/2353 and https://github.com/bazelbuild/rules_swift/issues/1142 are fixed
-build --noincompatible_objc_provider_remove_linking_info


### PR DESCRIPTION
Not a valid option at HEAD, and no longer needed.