### PR TITLE
Remove bitcode support

### DIFF
--- a/xcodeproj/internal/processed_targets/legacy_library_targets.bzl
+++ b/xcodeproj/internal/processed_targets/legacy_library_targets.bzl
@@ -109,11 +109,6 @@ def _process_legacy_library_target(
 
     cpp = ctx.fragments.cpp
 
-    # TODO: Get the value for device builds, even when active config is not for
-    # device, as Xcode only uses this value for device builds
-    if str(cpp.apple_bitcode_mode) != "none":
-        build_settings["ENABLE_BITCODE"] = True
-
     platform = platforms.collect(ctx = ctx)
     product = process_product(
         actions = ctx.actions,

--- a/xcodeproj/internal/processed_targets/legacy_library_targets.bzl
+++ b/xcodeproj/internal/processed_targets/legacy_library_targets.bzl
@@ -107,8 +107,6 @@ def _process_legacy_library_target(
         compilation_providers = target_compilation_providers,
     )
 
-    cpp = ctx.fragments.cpp
-
     platform = platforms.collect(ctx = ctx)
     product = process_product(
         actions = ctx.actions,

--- a/xcodeproj/internal/processed_targets/legacy_top_level_targets.bzl
+++ b/xcodeproj/internal/processed_targets/legacy_top_level_targets.bzl
@@ -471,11 +471,6 @@ def _process_legacy_top_level_target(
 
     cpp = ctx.fragments.cpp
 
-    # TODO: Get the value for device builds, even when active config is not for
-    # device, as Xcode only uses this value for device builds
-    if str(cpp.apple_bitcode_mode) != "none":
-        build_settings["ENABLE_BITCODE"] = True
-
     # We don't have access to `CcInfo`/`SwiftInfo` here, so we have to make
     # a best guess at `-g` being used
     # We don't set "DEBUG_INFORMATION_FORMAT" for "dwarf", as we set that at


### PR DESCRIPTION
Apple no longer accepts bitcode and the newest Bazel and rules_apple don’t either.