### PR TITLE
Update `.bcr/presubmit.yaml`

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,4 +1,7 @@
 tasks:
   verify_targets_macos:
     name: Verify build targets
+    bazel: 7.x
     platform: macos
+    build_targets:
+    - '@rules_xcodeproj//tools/generators/pbxproj_prefix:universal_pbxproj_prefix'


### PR DESCRIPTION
The BCR now needs a Bazel version(s). Decided to also add one of the precompiled tools as a build test.