### PR TITLE
Log when the Bazel build is starting

### DIFF
--- a/xcodeproj/internal/templates/bazel_build.sh
+++ b/xcodeproj/internal/templates/bazel_build.sh
@@ -115,6 +115,8 @@ fi
 
 # Build
 
+echo "Starting Bazel build"
+
 "$BAZEL_INTEGRATION_DIR/process_bazel_build_log.py" \
   "${bazel_cmd[@]}" \
   build \


### PR DESCRIPTION
This can be useful to know where stuck builds get stuck at, since it could be in `calculate_output_groups.py`, a `tools/bazel` wrapper, or in `bazel` itself.