### PR TITLE
Example of 'ERROR: Internal precondition failure' raised when generating a project containing a target with more than one dynamically generated localizable resources

### DIFF
--- a/examples/integration/iOSApp/Source/BUILD
+++ b/examples/integration/iOSApp/Source/BUILD
@@ -8,6 +8,10 @@ load(
     "IOS_BUNDLE_ID",
     "TEAMID",
 )
+load(
+    ":localizable.bzl",
+    "localizable_resources",
+)
 
 config_setting(
     name = "release_build",
@@ -68,7 +72,7 @@ ios_application(
         ":device_build": ":xcode_profile",
         "//conditions:default": None,
     }),
-    resources = [":ExampleResourceGroup"] + glob(
+    resources = [":ExampleResourceGroup", ":FrenchLocalizableResources"] + glob(
         [
             "Assets.xcassets/**",
             "Model.xcdatamodeld/**",
@@ -140,6 +144,11 @@ swift_library(
         "//iOSApp/Source/CoreUtilsObjC",
         "@com_google_google_maps//:GoogleMaps",
     ],
+)
+
+localizable_resources(
+    name = "FrenchLocalizableResources",
+    localizable_directory_name = "fr.lproj",
 )
 
 apple_resource_group(

--- a/examples/integration/iOSApp/Source/localizable.bzl
+++ b/examples/integration/iOSApp/Source/localizable.bzl
@@ -1,0 +1,39 @@
+"""
+Example rule that creates a directory containing localizable resources intended to be bundled with other app resources 
+"""
+
+def _localizable_resources_impl(ctx):
+    localizable_directory = ctx.actions.declare_directory(ctx.attr.localizable_directory_name)
+
+    ctx.actions.run_shell(
+        progress_message = "Generating localizable resources...",
+        command = """
+localizable_directory=$1
+localizable_strings_path="${localizable_directory}/Localizable.strings"
+additional_localizable_strings_path="${localizable_directory}/AdditionalLocalizable.strings"
+
+echo "\"rules_xcodeproj_key\" = \"rules_xcodeproj\";\n" > "${localizable_strings_path}"
+echo "\"additional_rules_xcodeproj_key\" = \"additional_rules_xcodeproj_key\";\n" > "${additional_localizable_strings_path}"
+""",
+        arguments = [localizable_directory.path],
+        inputs = [],
+        outputs = [localizable_directory],
+    )
+
+    output_directory = ctx.actions.declare_directory("{}Output".format(ctx.attr.name))    
+    ctx.actions.run_shell(
+        progress_message = "Staging output container: '{}'".format(ctx.attr.localizable_directory_name),
+        outputs = [output_directory],
+        inputs = [localizable_directory],
+        arguments = [localizable_directory.path, output_directory.path],
+        command = "cp -r $1 $2",
+    )
+
+    return DefaultInfo(files = depset([output_directory]))
+    
+localizable_resources = rule(
+    implementation = _localizable_resources_impl,
+    attrs = {
+        "localizable_directory_name": attr.string(doc = "Name of localizable directory intended to ultimately land in the app bundle, typically this will be something like fr.lproj"),
+    },
+)


### PR DESCRIPTION
You can consistently reproduce the `Internal precondition failure` on this PR branch by running:

  `cd examples/integration/iOSApp && bazel run //:xcodeproj-incremental-bazel-sim_arm64`

Example error output:
```
ERROR: Internal precondition failure:
tools/generators/lib/PBXProj/src/ConsumeArgs.swift:168: "/Users/<username>/Developer/rules_xcodeproj/examples/integration/iOSApp/bazel-output-base/rules_xcodeproj.noindex/build_output_base/execroot/_main/bazel-out/darwin_arm64-dbg/bin/external/rules_xcodeproj~override~internal~rules_xcodeproj_generated/generator/xcodeproj-incremental-bazel-sim_arm64/xcodeproj-incremental-bazel-sim_arm64_pbxproj_partials/target_arguments_files/3": Failed to parse "iOSApp/Source/es.lproj/unprocessed.json" as Int.Type for <folder-resources-count>
Please file a bug report at https://github.com/MobileNativeFoundation/rules_xcodeproj/issues/new?template=bug.md
```
Hypothesis: 

- This error is apparently caused by generating more than one localizable resource file within a containing folder
- When only a single localizable resource is generated in the example rule implementation, project generation succeeds as expected