### PR TITLE
Fix tree artifact `File` handling in incremental generation

### DIFF
--- a/examples/integration/iOSApp/Source/BUILD
+++ b/examples/integration/iOSApp/Source/BUILD
@@ -8,6 +8,10 @@ load(
     "IOS_BUNDLE_ID",
     "TEAMID",
 )
+load(
+    ":localizable.bzl",
+    "localizable_resources",
+)
 
 config_setting(
     name = "release_build",
@@ -68,7 +72,10 @@ ios_application(
         ":device_build": ":xcode_profile",
         "//conditions:default": None,
     }),
-    resources = [":ExampleResourceGroup"] + glob(
+    resources = [
+        ":ExampleResourceGroup",
+        ":FrenchLocalizableResources",
+    ] + glob(
         [
             "Assets.xcassets/**",
             "Model.xcdatamodeld/**",
@@ -140,6 +147,11 @@ swift_library(
         "//iOSApp/Source/CoreUtilsObjC",
         "@com_google_google_maps//:GoogleMaps",
     ],
+)
+
+localizable_resources(
+    name = "FrenchLocalizableResources",
+    localizable_directory_name = "fr.lproj",
 )
 
 apple_resource_group(

--- a/examples/integration/iOSApp/Source/localizable.bzl
+++ b/examples/integration/iOSApp/Source/localizable.bzl
@@ -1,0 +1,39 @@
+"""
+Example rule that creates a directory containing localizable resources intended to be bundled with other app resources 
+"""
+
+def _localizable_resources_impl(ctx):
+    localizable_directory = ctx.actions.declare_directory(ctx.attr.localizable_directory_name)
+
+    ctx.actions.run_shell(
+        progress_message = "Generating localizable resources...",
+        command = """
+localizable_directory=$1
+localizable_strings_path="${localizable_directory}/Localizable.strings"
+additional_localizable_strings_path="${localizable_directory}/AdditionalLocalizable.strings"
+
+echo "\"rules_xcodeproj_key\" = \"rules_xcodeproj\";\n" > "${localizable_strings_path}"
+echo "\"additional_rules_xcodeproj_key\" = \"additional_rules_xcodeproj_key\";\n" > "${additional_localizable_strings_path}"
+""",
+        arguments = [localizable_directory.path],
+        inputs = [],
+        outputs = [localizable_directory],
+    )
+
+    output_directory = ctx.actions.declare_directory("{}Output".format(ctx.attr.name))
+    ctx.actions.run_shell(
+        progress_message = "Staging output container: '{}'".format(ctx.attr.localizable_directory_name),
+        outputs = [output_directory],
+        inputs = [localizable_directory],
+        arguments = [localizable_directory.path, output_directory.path],
+        command = "cp -r $1 $2",
+    )
+
+    return DefaultInfo(files = depset([output_directory]))
+
+localizable_resources = rule(
+    implementation = _localizable_resources_impl,
+    attrs = {
+        "localizable_directory_name": attr.string(doc = "Name of localizable directory intended to ultimately land in the app bundle, typically this will be something like fr.lproj"),
+    },
+)

--- a/examples/integration/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -1972,6 +1972,7 @@
 		0B30255F0839E986EC479AB3 /* UIFramework.watchOS.237.link.params */ = {isa = PBXFileReference; lastKnownFileType = file; path = UIFramework.watchOS.237.link.params; sourceTree = "<group>"; };
 		0B317312D9FC9A2854838E2E /* proto.47.link.params */ = {isa = PBXFileReference; lastKnownFileType = file; path = proto.47.link.params; sourceTree = "<group>"; };
 		0B46C19AD5A145E2F87A6232 /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
+		0B9BE978336E348BC271C79C /* FrenchLocalizableResourcesOutput */ = {isa = PBXFileReference; lastKnownFileType = file; path = FrenchLocalizableResourcesOutput; sourceTree = "<group>"; };
 		0BB7EC0BA4D58E56C9041FB3 /* internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = internal.h; sourceTree = "<group>"; };
 		0BBB6189AC53D332FF369668 /* EventLoopFuture+WithEventLoop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EventLoopFuture+WithEventLoop.swift"; sourceTree = "<group>"; };
 		0BDA43852EBDE7D7A252F3EC /* handshake_client.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = handshake_client.cc; sourceTree = "<group>"; };
@@ -2175,6 +2176,7 @@
 		24E378A36779AB6010656E75 /* a_time.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = a_time.c; sourceTree = "<group>"; };
 		24E516B5C128315ADF68A066 /* libNIOEmbedded.a */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = libNIOEmbedded.a; path = "bazel-out/CONFIGURATION-STABLE-22/bin/external/rules_swift~~non_module_deps~com_github_apple_swift_nio/libNIOEmbedded.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		24FB1FB10A9BFFB99A4162F2 /* bio_mem.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = bio_mem.c; sourceTree = "<group>"; };
+		24FE17F74B9D49419A6CC231 /* FrenchLocalizableResourcesOutput */ = {isa = PBXFileReference; lastKnownFileType = file; path = FrenchLocalizableResourcesOutput; sourceTree = "<group>"; };
 		251E5C358F818B607BE8D9D4 /* ssl_file.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ssl_file.cc; sourceTree = "<group>"; };
 		25671ECB9A0B5D8E52CA2DB4 /* CNIOBoringSSL_pkcs7.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CNIOBoringSSL_pkcs7.h; sourceTree = "<group>"; };
 		256F722A8C97943AA5BE79E6 /* CNIOBoringSSLShims.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CNIOBoringSSLShims.h; sourceTree = "<group>"; };
@@ -2863,6 +2865,7 @@
 		7E06BAA217B95FA396E162BE /* rsaz_exp.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = rsaz_exp.c; sourceTree = "<group>"; };
 		7E089FD26631E97FC6764943 /* Message+JSONAdditions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Message+JSONAdditions.swift"; sourceTree = "<group>"; };
 		7E22EB62206448A7F6F1F84A /* private_swift_lib.rules_xcodeproj.swift.compile.params */ = {isa = PBXFileReference; lastKnownFileType = file; path = private_swift_lib.rules_xcodeproj.swift.compile.params; sourceTree = "<group>"; };
+		7E5135B7C7C38F4EB742035D /* FrenchLocalizableResourcesOutput */ = {isa = PBXFileReference; lastKnownFileType = file; path = FrenchLocalizableResourcesOutput; sourceTree = "<group>"; };
 		7E6BDE332FB9345185D79052 /* UnaryServerHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnaryServerHandler.swift; sourceTree = "<group>"; };
 		7E83114EE7AEAAF2F1725C23 /* SafeCompare.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafeCompare.swift; sourceTree = "<group>"; };
 		7EA6184D4A5E4D4455CB6C87 /* params.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = params.c; sourceTree = "<group>"; };
@@ -3506,6 +3509,7 @@
 		D38A4F63C320025B26C1406F /* x_crl.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = x_crl.c; sourceTree = "<group>"; };
 		D3923DC86E8C4441EFB79930 /* tvOS.147.link.params */ = {isa = PBXFileReference; lastKnownFileType = file; path = tvOS.147.link.params; sourceTree = "<group>"; };
 		D3CF1D23BB5D27B1470E6442 /* sha512-armv8.ios.aarch64.S */ = {isa = PBXFileReference; lastKnownFileType = file; path = "sha512-armv8.ios.aarch64.S"; sourceTree = "<group>"; };
+		D3ED8E11361F635D525276E0 /* FrenchLocalizableResourcesOutput */ = {isa = PBXFileReference; lastKnownFileType = file; path = FrenchLocalizableResourcesOutput; sourceTree = "<group>"; };
 		D400B31456EA397D8AD99359 /* CoreUtilsObjC.rules_xcodeproj.cxx.compile.params */ = {isa = PBXFileReference; lastKnownFileType = file; path = CoreUtilsObjC.rules_xcodeproj.cxx.compile.params; sourceTree = "<group>"; };
 		D43313794DC4D47361B3DB08 /* export_symbol_list.exp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.exports; path = export_symbol_list.exp; sourceTree = "<group>"; };
 		D4371DF7E2C93C38A6B59B37 /* liburing_nio.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = liburing_nio.h; sourceTree = "<group>"; };
@@ -5557,6 +5561,7 @@
 				21D735CF6F24E82FD2C3F115 /* CoreUtilsObjC */,
 				38FC20E2AB3E05F061202593 /* rules_xcodeproj */,
 				9B4D89B3D9223562F9D0A926 /* Utils */,
+				7E5135B7C7C38F4EB742035D /* FrenchLocalizableResourcesOutput */,
 				432E458B0F07DDA2FA726044 /* iOSApp.library.rules_xcodeproj.swift.compile.params */,
 			);
 			path = Source;
@@ -9612,6 +9617,7 @@
 				BFEEF12EB7D75E9983E765F4 /* CoreUtilsObjC */,
 				8F67320A0D35A02DD1678E3E /* rules_xcodeproj */,
 				07F869C9D3D1B4845D6D0DBA /* Utils */,
+				0B9BE978336E348BC271C79C /* FrenchLocalizableResourcesOutput */,
 				A3DA6AC884CAA370E94334F9 /* iOSApp.library.rules_xcodeproj.swift.compile.params */,
 			);
 			path = Source;
@@ -11728,6 +11734,7 @@
 				82B2C6AEB151BFF3723A336E /* CoreUtilsObjC */,
 				4F061B6F273240E6EECD808B /* rules_xcodeproj */,
 				990C36FBFED298B0C47BE75A /* Utils */,
+				24FE17F74B9D49419A6CC231 /* FrenchLocalizableResourcesOutput */,
 				1206B4AD8B5B4005E681312A /* iOSApp.library.rules_xcodeproj.swift.compile.params */,
 			);
 			path = Source;
@@ -12103,6 +12110,7 @@
 				9A96B67A59067F8BDC5938EE /* CoreUtilsObjC */,
 				5474714FE871BC9E22C1F2F1 /* rules_xcodeproj */,
 				999627317B66DD38EBDF7BEB /* Utils */,
+				D3ED8E11361F635D525276E0 /* FrenchLocalizableResourcesOutput */,
 				2643F17F03B08B74FB81EBE3 /* iOSApp.library.rules_xcodeproj.swift.compile.params */,
 			);
 			path = Source;

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/generated.xcfilelist
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/generated.xcfilelist
@@ -144,6 +144,7 @@ $(BAZEL_OUT)/CONFIGURATION-STABLE-10/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswe
 $(BAZEL_OUT)/CONFIGURATION-STABLE-10/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer_swift_modulemap-module.modulemap
 $(BAZEL_OUT)/CONFIGURATION-STABLE-10/bin/iOSApp/Source/CoreUtilsObjC/CoreUtilsObjC.rules_xcodeproj.cxx.compile.params
 $(BAZEL_OUT)/CONFIGURATION-STABLE-10/bin/iOSApp/Source/CoreUtilsObjC/rules_xcodeproj/FrameworkCoreUtilsObjC/Info.plist
+$(BAZEL_OUT)/CONFIGURATION-STABLE-10/bin/iOSApp/Source/FrenchLocalizableResourcesOutput
 $(BAZEL_OUT)/CONFIGURATION-STABLE-10/bin/iOSApp/Source/Utils/Utils.rules_xcodeproj.c.compile.params
 $(BAZEL_OUT)/CONFIGURATION-STABLE-10/bin/iOSApp/Source/iOSApp.library.rules_xcodeproj.swift.compile.params
 $(BAZEL_OUT)/CONFIGURATION-STABLE-10/bin/iOSApp/Source/rules_xcodeproj/iOSApp/Info.plist
@@ -225,6 +226,7 @@ $(BAZEL_OUT)/CONFIGURATION-STABLE-14/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswe
 $(BAZEL_OUT)/CONFIGURATION-STABLE-14/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer_swift_modulemap-module.modulemap
 $(BAZEL_OUT)/CONFIGURATION-STABLE-14/bin/iOSApp/Source/CoreUtilsObjC/CoreUtilsObjC.rules_xcodeproj.cxx.compile.params
 $(BAZEL_OUT)/CONFIGURATION-STABLE-14/bin/iOSApp/Source/CoreUtilsObjC/rules_xcodeproj/FrameworkCoreUtilsObjC/Info.plist
+$(BAZEL_OUT)/CONFIGURATION-STABLE-14/bin/iOSApp/Source/FrenchLocalizableResourcesOutput
 $(BAZEL_OUT)/CONFIGURATION-STABLE-14/bin/iOSApp/Source/Utils/Utils.rules_xcodeproj.c.compile.params
 $(BAZEL_OUT)/CONFIGURATION-STABLE-14/bin/iOSApp/Source/iOSApp.library.rules_xcodeproj.swift.compile.params
 $(BAZEL_OUT)/CONFIGURATION-STABLE-14/bin/iOSApp/Source/rules_xcodeproj/iOSApp/Info.plist
@@ -435,6 +437,7 @@ $(BAZEL_OUT)/CONFIGURATION-STABLE-3/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer
 $(BAZEL_OUT)/CONFIGURATION-STABLE-3/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer_swift_modulemap-module.modulemap
 $(BAZEL_OUT)/CONFIGURATION-STABLE-3/bin/iOSApp/Source/CoreUtilsObjC/CoreUtilsObjC.rules_xcodeproj.cxx.compile.params
 $(BAZEL_OUT)/CONFIGURATION-STABLE-3/bin/iOSApp/Source/CoreUtilsObjC/rules_xcodeproj/FrameworkCoreUtilsObjC/Info.plist
+$(BAZEL_OUT)/CONFIGURATION-STABLE-3/bin/iOSApp/Source/FrenchLocalizableResourcesOutput
 $(BAZEL_OUT)/CONFIGURATION-STABLE-3/bin/iOSApp/Source/Utils/Utils.rules_xcodeproj.c.compile.params
 $(BAZEL_OUT)/CONFIGURATION-STABLE-3/bin/iOSApp/Source/iOSApp.library.rules_xcodeproj.swift.compile.params
 $(BAZEL_OUT)/CONFIGURATION-STABLE-3/bin/iOSApp/Source/rules_xcodeproj/iOSApp/Info.plist
@@ -516,6 +519,7 @@ $(BAZEL_OUT)/CONFIGURATION-STABLE-7/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer
 $(BAZEL_OUT)/CONFIGURATION-STABLE-7/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer_swift_modulemap-module.modulemap
 $(BAZEL_OUT)/CONFIGURATION-STABLE-7/bin/iOSApp/Source/CoreUtilsObjC/CoreUtilsObjC.rules_xcodeproj.cxx.compile.params
 $(BAZEL_OUT)/CONFIGURATION-STABLE-7/bin/iOSApp/Source/CoreUtilsObjC/rules_xcodeproj/FrameworkCoreUtilsObjC/Info.plist
+$(BAZEL_OUT)/CONFIGURATION-STABLE-7/bin/iOSApp/Source/FrenchLocalizableResourcesOutput
 $(BAZEL_OUT)/CONFIGURATION-STABLE-7/bin/iOSApp/Source/Utils/Utils.rules_xcodeproj.c.compile.params
 $(BAZEL_OUT)/CONFIGURATION-STABLE-7/bin/iOSApp/Source/iOSApp.library.rules_xcodeproj.swift.compile.params
 $(BAZEL_OUT)/CONFIGURATION-STABLE-7/bin/iOSApp/Source/rules_xcodeproj/iOSApp/Info.plist

--- a/examples/integration/test/fixtures/bwb_targets_spec.json
+++ b/examples/integration/test/fixtures/bwb_targets_spec.json
@@ -840,7 +840,8 @@
                 "iOSApp/Source/en.lproj/Localizable.strings",
                 "iOSApp/Source/es.lproj/Localizable.strings",
                 "iOSApp/Source/en.lproj/unprocessed.json",
-                "iOSApp/Source/es.lproj/unprocessed.json"
+                "iOSApp/Source/es.lproj/unprocessed.json",
+                "bazel-out/CONFIGURATION-STABLE-3/bin/iOSApp/Source/FrenchLocalizableResourcesOutput"
             ],
             "s": [
                 "iOSApp/Source/iOSApp.swift"
@@ -6037,7 +6038,8 @@
                 "iOSApp/Source/en.lproj/Localizable.strings",
                 "iOSApp/Source/es.lproj/Localizable.strings",
                 "iOSApp/Source/en.lproj/unprocessed.json",
-                "iOSApp/Source/es.lproj/unprocessed.json"
+                "iOSApp/Source/es.lproj/unprocessed.json",
+                "bazel-out/CONFIGURATION-STABLE-7/bin/iOSApp/Source/FrenchLocalizableResourcesOutput"
             ],
             "s": [
                 "iOSApp/Source/iOSApp.swift"
@@ -7652,7 +7654,8 @@
                 "iOSApp/Source/en.lproj/Localizable.strings",
                 "iOSApp/Source/es.lproj/Localizable.strings",
                 "iOSApp/Source/en.lproj/unprocessed.json",
-                "iOSApp/Source/es.lproj/unprocessed.json"
+                "iOSApp/Source/es.lproj/unprocessed.json",
+                "bazel-out/CONFIGURATION-STABLE-10/bin/iOSApp/Source/FrenchLocalizableResourcesOutput"
             ],
             "s": [
                 "iOSApp/Source/iOSApp.swift"
@@ -13187,7 +13190,8 @@
                 "iOSApp/Source/en.lproj/Localizable.strings",
                 "iOSApp/Source/es.lproj/Localizable.strings",
                 "iOSApp/Source/en.lproj/unprocessed.json",
-                "iOSApp/Source/es.lproj/unprocessed.json"
+                "iOSApp/Source/es.lproj/unprocessed.json",
+                "bazel-out/CONFIGURATION-STABLE-14/bin/iOSApp/Source/FrenchLocalizableResourcesOutput"
             ],
             "s": [
                 "iOSApp/Source/iOSApp.swift"

--- a/tools/generators/pbxnativetargets/src/Generator/TargetArguments.swift
+++ b/tools/generators/pbxnativetargets/src/Generator/TargetArguments.swift
@@ -80,19 +80,22 @@ extension Dictionary<TargetID, TargetArguments> {
                 try rawArgs.consumeArg("has-c-params", as: Bool.self, in: url)
             let hasCxxParams =
                 try rawArgs.consumeArg("has-cxx-params", as: Bool.self, in: url)
-            let srcs =
-                try rawArgs.consumeArgs("srcs", as: BazelPath.self, in: url)
-            let nonArcSrcs = try rawArgs.consumeArgs(
+            let srcs = try rawArgs.consumeArgsUntilNull(
+                "srcs",
+                as: BazelPath.self,
+                in: url
+            )
+            let nonArcSrcs = try rawArgs.consumeArgsUntilNull(
                 "non-arc-srcs",
                 as: BazelPath.self,
                 in: url
             )
-            let resources = try rawArgs.consumeArgs(
+            let resources = try rawArgs.consumeArgsUntilNull(
                 "resources",
                 as: BazelPath.self,
                 in: url
             )
-            let folderResources = try rawArgs.consumeArgs(
+            let folderResources = try rawArgs.consumeArgsUntilNull(
                 "folder-resources",
                 as: BazelPath.self,
                 in: url

--- a/xcodeproj/internal/pbxproj_partials.bzl
+++ b/xcodeproj/internal/pbxproj_partials.bzl
@@ -245,25 +245,25 @@ def _write_consolidation_map_targets(
             )
 
             targets_args.add_all(
-                [xcode_target.inputs.srcs],
-                map_each = _depset_len,
+                xcode_target.inputs.srcs,
+                omit_if_empty = False,
+                terminate_with = "\0",
             )
-            targets_args.add_all(xcode_target.inputs.srcs)
             targets_args.add_all(
-                [xcode_target.inputs.non_arc_srcs],
-                map_each = _depset_len,
+                xcode_target.inputs.non_arc_srcs,
+                omit_if_empty = False,
+                terminate_with = "\0",
             )
-            targets_args.add_all(xcode_target.inputs.non_arc_srcs)
             targets_args.add_all(
-                [xcode_target.inputs.resources],
-                map_each = _depset_len,
+                xcode_target.inputs.resources,
+                omit_if_empty = False,
+                terminate_with = "\0",
             )
-            targets_args.add_all(xcode_target.inputs.resources)
             targets_args.add_all(
-                [xcode_target.inputs.folder_resources],
-                map_each = _depset_len,
+                xcode_target.inputs.folder_resources,
+                omit_if_empty = False,
+                terminate_with = "\0",
             )
-            targets_args.add_all(xcode_target.inputs.folder_resources)
 
             target_xcode_configurations = (
                 xcode_target_configurations[xcode_target.id]


### PR DESCRIPTION
Fixes #2904.

We fix our handling by using a null-character terminator instead of encoding the number of paths. This is because at analysis time we can’t rely on the number of elements in a `depset`, as they might expand to more elements at execution if any of the elements are tree artifacts.

Added an example by Wiley that exercises the previous failure case.