### PR TITLE
Upgrade WORKSPACE macro and dev rules_apple & apple_support version

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -56,12 +56,17 @@ bazel_dep(
 # To support Bazel 8 tests
 single_version_override(
     module_name = "rules_apple",
-    version = "3.2.1",
+    version = "3.3.0",
 )
 
 single_version_override(
     module_name = "rules_swift",
     version = "1.15.1",
+)
+
+single_version_override(
+    module_name = "apple_support",
+    version = "1.13.0",
 )
 
 # For Stardoc

--- a/examples/integration/MODULE.bazel
+++ b/examples/integration/MODULE.bazel
@@ -5,12 +5,12 @@ bazel_dep(
 )
 bazel_dep(
     name = "apple_support",
-    version = "1.11.1",
+    version = "1.13.0",
     repo_name = "build_bazel_apple_support",
 )
 bazel_dep(
     name = "rules_apple",
-    version = "3.2.1",
+    version = "3.3.0",
     repo_name = "build_bazel_rules_apple",
 )
 bazel_dep(

--- a/xcodeproj/repositories.bzl
+++ b/xcodeproj/repositories.bzl
@@ -128,8 +128,8 @@ def xcodeproj_rules_dependencies(
         _maybe(
             http_archive,
             name = "build_bazel_rules_apple",
-            sha256 = "9c4f1e1ec4fdfeac5bddb07fa0e872c398e3d8eb0ac596af9c463f9123ace292",
-            url = "https://github.com/bazelbuild/rules_apple/releases/download/3.2.1/rules_apple.3.2.1.tar.gz",
+            sha256 = "65eafafe94b8573e74160b7f587d091a0fa34d69e6d2c41c4afb1eef140383ec",
+            url = "https://github.com/bazelbuild/rules_apple/releases/download/3.3.0/rules_apple.3.3.0.tar.gz",
             ignore_version_differences = ignore_version_differences,
         )
 


### PR DESCRIPTION
This fixes Bazel head compatibility as `apple_cc_toolchain` was removed.