### PR TITLE
Add precompiled_apple_resource_bundle in rules_ios example

### DIFF
--- a/examples/rules_ios/iOSApp/Source/AssetsPrecompiled.xcassets/Contents.json
+++ b/examples/rules_ios/iOSApp/Source/AssetsPrecompiled.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/rules_ios/iOSApp/Source/AssetsPrecompiled.xcassets/PrecompiledAccentColor.colorset/Contents.json
+++ b/examples/rules_ios/iOSApp/Source/AssetsPrecompiled.xcassets/PrecompiledAccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/rules_ios/iOSApp/Source/BUILD
+++ b/examples/rules_ios/iOSApp/Source/BUILD
@@ -102,6 +102,9 @@ precompiled_apple_resource_bundle(
 rules_ios_apple_framework(
     name = "iOSApp.library",
     srcs = glob(["**/*.swift"]),
+    data = [
+        ":PrecompiledResourceBundle",
+    ],
     module_name = "iOSApp",
     platforms = {
         "ios": "15.0",
@@ -113,9 +116,6 @@ rules_ios_apple_framework(
         "//iOSApp/Source/CoreUtilsMixed/MixedAnswer",
         "//iOSApp/Source/CoreUtilsObjC",
     ],
-    data = [
-        ":PrecompiledResourceBundle"
-    ]
 )
 
 rules_ios_apple_framework(

--- a/examples/rules_ios/iOSApp/Source/BUILD
+++ b/examples/rules_ios/iOSApp/Source/BUILD
@@ -8,6 +8,7 @@ load(
     "@build_bazel_rules_ios//rules:framework.bzl",
     rules_ios_apple_framework = "apple_framework",
 )
+load("@build_bazel_rules_ios//rules:precompiled_apple_resource_bundle.bzl", "precompiled_apple_resource_bundle")
 load("@rules_xcodeproj//xcodeproj:defs.bzl", "xcode_provisioning_profile")
 load(
     "//:xcodeproj_targets.bzl",
@@ -89,6 +90,15 @@ apple_resource_group(
     ),
 )
 
+precompiled_apple_resource_bundle(
+    name = "PrecompiledResourceBundle",
+    resources = glob(
+        [
+            "AssetsPrecompiled.xcassets/**",
+        ],
+    ),
+)
+
 rules_ios_apple_framework(
     name = "iOSApp.library",
     srcs = glob(["**/*.swift"]),
@@ -103,6 +113,9 @@ rules_ios_apple_framework(
         "//iOSApp/Source/CoreUtilsMixed/MixedAnswer",
         "//iOSApp/Source/CoreUtilsObjC",
     ],
+    data = [
+        ":PrecompiledResourceBundle"
+    ]
 )
 
 rules_ios_apple_framework(

--- a/examples/rules_ios/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/rules_ios/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -498,6 +498,7 @@
 		73A8FD89730E3058632D8754 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		76B68C3C744B654E8E40F640 /* iOSAppSwiftUnitTestSuite_vfs.yaml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = iOSAppSwiftUnitTestSuite_vfs.yaml; sourceTree = "<group>"; };
 		76B8432C1EB86DADA12E77E3 /* LibDynamic_vfs.yaml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = LibDynamic_vfs.yaml; sourceTree = "<group>"; };
+		774C5DA2DB905F0CCCC5F31F /* AssetsPrecompiled.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = AssetsPrecompiled.xcassets; sourceTree = "<group>"; };
 		77BF92755261B04F8662A0F7 /* UI_swift.rules_xcodeproj.swift.compile.params */ = {isa = PBXFileReference; lastKnownFileType = file; path = UI_swift.rules_xcodeproj.swift.compile.params; sourceTree = "<group>"; };
 		788FC887077E2ECEA09C1D7F /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		7903387B40A06F8CEF4C8FBD /* resource_bundle.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = resource_bundle.plist; sourceTree = "<group>"; };
@@ -1656,6 +1657,7 @@
 				57E23D2B5CB8913F710374CE /* Utils */,
 				680B9771F21E6593ADB11455 /* Vendored */,
 				788FC887077E2ECEA09C1D7F /* Assets.xcassets */,
+				774C5DA2DB905F0CCCC5F31F /* AssetsPrecompiled.xcassets */,
 				CD07B657B5ED92CC3963B7FD /* BUILD */,
 				817C3EE93221FD1ABC7E9E9A /* data.json */,
 				3423B69557C97C31CE6F81A4 /* Info.plist */,

--- a/examples/rules_ios/test/fixtures/bwb_project_spec.json
+++ b/examples/rules_ios/test/fixtures/bwb_project_spec.json
@@ -202,6 +202,7 @@
         "external/rules_ios~3.2.1/rules/library/resource_bundle.plist",
         "external/rules_ios~3.2.1/rules/test_host_app/Info.plist",
         "iOSApp/BUILD",
+        "iOSApp/Source/AssetsPrecompiled.xcassets",
         "iOSApp/Source/BUILD",
         "iOSApp/Source/CoreUtilsMixed/MixedAnswer/BUILD",
         "iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer.h",


### PR DESCRIPTION
Related to #2914.

This diff adds a `precompiled_apple_resource_bundle` to the rules_ios example.