### PR TITLE
Roll incremental generation mode `resources` into `extra_files`

### DIFF
--- a/tools/generators/pbxnativetargets/src/Generator/TargetArguments.swift
+++ b/tools/generators/pbxnativetargets/src/Generator/TargetArguments.swift
@@ -27,7 +27,6 @@ struct TargetArguments: Equatable {
     // FIXME: Extract to `Inputs` type
     let srcs: [BazelPath]
     let nonArcSrcs: [BazelPath]
-    let resources: [BazelPath]
     let folderResources: [BazelPath]
 
     let dSYMPathsBuildSetting: String
@@ -90,11 +89,6 @@ extension Dictionary<TargetID, TargetArguments> {
                 as: BazelPath.self,
                 in: url
             )
-            let resources = try rawArgs.consumeArgs(
-                "resources",
-                as: BazelPath.self,
-                in: url
-            )
             let folderResources = try rawArgs.consumeArgs(
                 "folder-resources",
                 as: BazelPath.self,
@@ -142,7 +136,6 @@ extension Dictionary<TargetID, TargetArguments> {
                         hasCxxParams: hasCxxParams,
                         srcs: srcs,
                         nonArcSrcs: nonArcSrcs,
-                        resources: resources,
                         folderResources: folderResources,
                         dSYMPathsBuildSetting: dSYMPathsBuildSetting
                     )

--- a/xcodeproj/internal/files/incremental_input_files.bzl
+++ b/xcodeproj/internal/files/incremental_input_files.bzl
@@ -331,9 +331,6 @@ def _collect_incremental_input_files(
                     attributes.
                 *   `non_arc_srcs`: A `list` of `File`s that are inputs to
                     `target`'s `non_arc_srcs`-like attributes.
-                *   `resources`: A `depset` of `File`s that are inputs to
-                    `target`'s `resources`-like and `structured_resources`-like
-                    attributes.
                 *   `srcs`: A `list` of `File`s that are inputs to `target`'s
                     `srcs`-like attributes.
 
@@ -493,7 +490,7 @@ def _collect_incremental_input_files(
         folder_resources = memory_efficient_depset(
             resources_result.folder_resources,
         )
-        resources = memory_efficient_depset(resources_result.resources)
+        extra_files.extend(resources_result.resources)
         resource_bundles = resources_result.bundles
 
         xccurrentversions.extend(resources_result.xccurrentversions)
@@ -526,7 +523,6 @@ def _collect_incremental_input_files(
         ])
     else:
         folder_resources = EMPTY_DEPSET
-        resources = EMPTY_DEPSET
         resource_bundle_labels = memory_efficient_depset(
             transitive = [
                 info.inputs._resource_bundle_labels
@@ -570,7 +566,6 @@ def _collect_incremental_input_files(
                     "$(BAZEL_OUT){}".format(infoplist.path[9:]) if infoplist else None
                 ),
                 non_arc_srcs = memory_efficient_depset(non_arc_srcs),
-                resources = resources,
                 srcs = memory_efficient_depset(srcs),
             ),
         ),

--- a/xcodeproj/internal/incremental_xcode_targets.bzl
+++ b/xcodeproj/internal/incremental_xcode_targets.bzl
@@ -24,12 +24,11 @@ def _from_resource_bundle(bundle):
         compile_stub_needed = False,
         inputs = struct(
             entitlements = EMPTY_DEPSET,
-            extra_files = EMPTY_DEPSET,
+            extra_files = bundle.resources,
             extra_file_paths = EMPTY_DEPSET,
             folder_resources = bundle.folder_resources,
             infoplist_path = None,
             non_arc_srcs = EMPTY_DEPSET,
-            resources = bundle.resources,
             srcs = EMPTY_DEPSET,
         ),
     )
@@ -183,7 +182,6 @@ def _merge_xcode_inputs(*, dest_inputs, mergeable_info):
         folder_resources = dest_inputs.folder_resources,
         infoplist_path = dest_inputs.infoplist_path,
         non_arc_srcs = mergeable_info.non_arc_srcs,
-        resources = dest_inputs.resources,
         srcs = mergeable_info.srcs,
     )
 

--- a/xcodeproj/internal/pbxproj_partials.bzl
+++ b/xcodeproj/internal/pbxproj_partials.bzl
@@ -252,11 +252,6 @@ def _write_consolidation_map_targets(
                 terminate_with = "",
             )
             targets_args.add_all(
-                xcode_target.inputs.resources,
-                omit_if_empty = False,
-                terminate_with = "",
-            )
-            targets_args.add_all(
                 xcode_target.inputs.folder_resources,
                 omit_if_empty = False,
                 terminate_with = "",

--- a/xcodeproj/internal/xcodeproj_incremental_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_incremental_rule.bzl
@@ -131,7 +131,6 @@ def _collect_files(
     for xcode_target in all_targets:
         transitive_file_paths.append(xcode_target.inputs.extra_file_paths)
         transitive_files.append(xcode_target.inputs.extra_files)
-        transitive_files.append(xcode_target.inputs.resources)
         transitive_folders.append(xcode_target.inputs.folder_resources)
         transitive_srcs.append(xcode_target.inputs.non_arc_srcs)
         transitive_srcs.append(xcode_target.inputs.srcs)


### PR DESCRIPTION
With incremental generation we only support BwB mode, so there doesn’t need to be a distinction between resources and extra files. In a follow-up change I’ll do a similar thing for `resource_folders` (by making a new `extra_folders` attribute). This reduces the number of arguments sent to `pbxnativetargets`, since only `srcs` and `non_arc_srcs` were actually read there.