### PR TITLE
Fix tvOS Xcode preview framework code signing with incremental generation

### DIFF
--- a/tools/generators/pbxnativetargets/src/Generator/CalculateSharedBuildSettings.swift
+++ b/tools/generators/pbxnativetargets/src/Generator/CalculateSharedBuildSettings.swift
@@ -99,15 +99,17 @@ extension Generator.CalculateSharedBuildSettings {
                     value: label.description.pbxProjEscaped
                 )
             )
-        } else {
-            // Used to work around CODE_SIGNING_ENABLED = YES for resource
-            // bundles in Xcode 14+
-            buildSettings.append(
-                .init(key: "CODE_SIGNING_ALLOWED", value: "NO")
-            )
         }
 
-        if productType == .uiTestBundle {
+        if productType == .framework {
+            // Xcode previews require frameworks to be code signed
+            buildSettings.append(
+                .init(
+                    key: "CODE_SIGNING_ALLOWED",
+                    value: #""$(ENABLE_PREVIEWS)""#
+                )
+            )
+        } else if productType == .uiTestBundle {
             // UI tests require code signing to enable debugging
             buildSettings.append(
                 .init(key: "CODE_SIGNING_ALLOWED", value: "YES")

--- a/tools/generators/pbxnativetargets/test/Generator/CalculateSharedBuildSettingsTests.swift
+++ b/tools/generators/pbxnativetargets/test/Generator/CalculateSharedBuildSettingsTests.swift
@@ -73,6 +73,29 @@ class CalculateSharedBuildSettingsTests: XCTestCase {
         )
     }
 
+    func test_framework() {
+        // Arrange
+
+        let productType = PBXProductType.framework
+
+        let expectedBuildSettings = baseBuildSettings.updating([
+            "CODE_SIGNING_ALLOWED": #""$(ENABLE_PREVIEWS)""#,
+        ])
+
+        // Act
+
+        let buildSettings = calculateSharedBuildSettingsWithDefaults(
+            productType: productType
+        )
+
+        // Assert
+
+        XCTAssertNoDifference(
+            buildSettings.asDictionary,
+            expectedBuildSettings
+        )
+    }
+
     func test_uiTest() {
         // Arrange
 


### PR DESCRIPTION
Seems tvOS frameworks need to be codesigned for Xcode Previews.