### PR TITLE
Remove incremental generation mode extra `CODE_SIGNING_ALLOWED` logic

### DIFF
--- a/test/internal/pbxproj_partials/write_target_build_settings_tests.bzl
+++ b/test/internal/pbxproj_partials/write_target_build_settings_tests.bzl
@@ -95,7 +95,6 @@ def _write_target_build_settings_test_impl(ctx):
         previews_include_path = ctx.attr.previews_include_path,
         provisioning_profile_is_xcode_managed = ctx.attr.provisioning_profile_is_xcode_managed,
         provisioning_profile_name = ctx.attr.provisioning_profile_name,
-        skip_codesigning = ctx.attr.skip_codesigning,
         swift_args = swift_args,
         swift_debug_settings_to_merge = swift_debug_settings_to_merge,
         team_id = ctx.attr.team_id,
@@ -184,7 +183,6 @@ write_target_build_settings_test = unittest.make(
         "previews_include_path": attr.string(mandatory = True),
         "provisioning_profile_is_xcode_managed": attr.bool(mandatory = True),
         "provisioning_profile_name": attr.string(),
-        "skip_codesigning": attr.bool(mandatory = True),
         "swift_debug_settings_to_merge": attr.string_list(mandatory = True),
         "swift_args": attr.string_list(mandatory = True),
         "team_id": attr.string(),
@@ -228,7 +226,6 @@ def write_target_build_settings_test_suite(name):
             previews_include_path = "",
             provisioning_profile_is_xcode_managed = False,
             provisioning_profile_name = None,
-            skip_codesigning = False,
             swift_args,
             swift_debug_settings_to_merge = [],
             team_id = None,
@@ -260,7 +257,6 @@ def write_target_build_settings_test_suite(name):
             previews_include_path = previews_include_path,
             provisioning_profile_is_xcode_managed = provisioning_profile_is_xcode_managed,
             provisioning_profile_name = provisioning_profile_name,
-            skip_codesigning = skip_codesigning,
             swift_args = swift_args,
             swift_debug_settings_to_merge = swift_debug_settings_to_merge,
             team_id = team_id,
@@ -324,8 +320,6 @@ def write_target_build_settings_test_suite(name):
             "",
             # entitlements
             "",
-            # skipCodesigning
-            "0",
             # certificateName
             "",
             # provisioningProfileName
@@ -373,8 +367,6 @@ def write_target_build_settings_test_suite(name):
             "",
             # entitlements
             "",
-            # skipCodesigning
-            "0",
             # certificateName
             "",
             # provisioningProfileName
@@ -420,8 +412,6 @@ def write_target_build_settings_test_suite(name):
             "",
             # entitlements
             "",
-            # skipCodesigning
-            "0",
             # certificateName
             "",
             # provisioningProfileName
@@ -467,8 +457,6 @@ def write_target_build_settings_test_suite(name):
             "",
             # entitlements
             "",
-            # skipCodesigning
-            "0",
             # certificateName
             "",
             # provisioningProfileName
@@ -521,8 +509,6 @@ def write_target_build_settings_test_suite(name):
             "",
             # entitlements
             "",
-            # skipCodesigning
-            "0",
             # certificateName
             "",
             # provisioningProfileName
@@ -551,7 +537,6 @@ def write_target_build_settings_test_suite(name):
         generate_build_settings = True,
         provisioning_profile_is_xcode_managed = True,
         provisioning_profile_name = "a profile",
-        skip_codesigning = True,
         swift_args = [],
         team_id = "12345-a 54",
 
@@ -576,8 +561,6 @@ def write_target_build_settings_test_suite(name):
             "",
             # entitlements
             "some/app.entitlements",
-            # skipCodesigning
-            "1",
             # certificateName
             "best certificate",
             # provisioningProfileName
@@ -629,8 +612,6 @@ def write_target_build_settings_test_suite(name):
             "",
             # entitlements
             "",
-            # skipCodesigning
-            "0",
             # certificateName
             "",
             # provisioningProfileName
@@ -686,8 +667,6 @@ def write_target_build_settings_test_suite(name):
             "",
             # entitlements
             "",
-            # skipCodesigning
-            "0",
             # certificateName
             "",
             # provisioningProfileName
@@ -761,8 +740,6 @@ def write_target_build_settings_test_suite(name):
             "some/Info.plist",
             # entitlements
             "",
-            # skipCodesigning
-            "0",
             # certificateName
             "",
             # provisioningProfileName

--- a/tools/generators/pbxnativetargets/src/Generator/CreateXcodeConfigurations.swift
+++ b/tools/generators/pbxnativetargets/src/Generator/CreateXcodeConfigurations.swift
@@ -197,14 +197,7 @@ extension Generator.CreateXcodeConfigurations {
 
                 return createBuildSettingsAttribute(
                     buildSettings:
-                        // Apply `sharedBuildSettings` after
-                        // `configurationBuildSettings` to ensure that
-                        // `CODE_SIGNING_ALLOWED` is set correctly. If we ever
-                        // need `target_build_settings` to override what we set
-                        // in `sharedBuildSettings`, we'll need to flip this and
-                        // change the logic in `target_build_settings` to
-                        // account for product type.
-                        configurationBuildSettings + sharedBuildSettings
+                        sharedBuildSettings + configurationBuildSettings
                 )
             }
 

--- a/tools/generators/target_build_settings/src/Generator/ProcessArgs.swift
+++ b/tools/generators/target_build_settings/src/Generator/ProcessArgs.swift
@@ -93,8 +93,6 @@ extension Generator.ProcessArgs {
             try rawArguments.consumeArg("generates-dsyms", as: Bool.self)
         let infoPlist = try rawArguments.consumeArg("info-plist")
         let entitlements = try rawArguments.consumeArg("entitlements")
-        let skipCodesigning =
-            try rawArguments.consumeArg("skip-codesigning", as: Bool.self)
         let certificateName = try rawArguments.consumeArg("certificate-name")
         let provisioningProfileName =
             try rawArguments.consumeArg("provisioning-profile-name")
@@ -188,10 +186,6 @@ extension Generator.ProcessArgs {
             buildSettings.append(
                 ("CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION", "YES")
             )
-        }
-
-        if skipCodesigning {
-            buildSettings.append(("CODE_SIGNING_ALLOWED", "NO"))
         }
 
         if !certificateName.isEmpty {

--- a/xcodeproj/internal/pbxproj_partials.bzl
+++ b/xcodeproj/internal/pbxproj_partials.bzl
@@ -974,7 +974,6 @@ def _write_target_build_settings(
         previews_include_path = EMPTY_STRING,
         provisioning_profile_is_xcode_managed = False,
         provisioning_profile_name = None,
-        skip_codesigning = False,
         swift_args,
         swift_debug_settings_to_merge,
         team_id = None,
@@ -1010,7 +1009,6 @@ def _write_target_build_settings(
             provisioning profile is managed by Xcode.
         provisioning_profile_name: The name of the provisioning profile to use
             for code signing.
-        skip_codesigning: If `True`, `CODE_SIGNING_ALLOWED = NO` will be set.
         swift_args: A `list` of `Args` for the `SwiftCompile` action for this
             target.
         swift_debug_settings_to_merge: A `depset` of `Files` containing
@@ -1097,9 +1095,6 @@ def _write_target_build_settings(
 
     # entitlements
     args.add(entitlements or EMPTY_STRING)
-
-    # skipCodesigning
-    args.add(TRUE_ARG if skip_codesigning else FALSE_ARG)
 
     # certificateName
     args.add(certificate_name or EMPTY_STRING)

--- a/xcodeproj/internal/processed_targets/incremental_top_level_targets.bzl
+++ b/xcodeproj/internal/processed_targets/incremental_top_level_targets.bzl
@@ -721,14 +721,6 @@ def _process_focused_top_level_target(
             provisioning_profile_props.is_xcode_managed
         ),
         provisioning_profile_name = provisioning_profile_props.name,
-        skip_codesigning = _should_skip_codesigning(
-            ctx = ctx,
-            bundle_info = bundle_info,
-            is_missing_provisioning_profile = (
-                provisioning_profile_props.is_missing_profile
-            ),
-            platform = platform,
-        ),
         swift_args = args.swift,
         swift_debug_settings_to_merge = swift_debug_settings_to_merge,
         team_id = provisioning_profile_props.team_id,
@@ -1086,42 +1078,6 @@ def _process_unfocused_top_level_target(
         transitive_dependencies = transitive_dependencies,
         xcode_target = None,
     )
-
-def _should_skip_codesigning(
-        *,
-        ctx,
-        bundle_info,
-        is_missing_provisioning_profile,
-        platform):
-    """Returns whether we should skip cosigning for this target.
-
-    Args:
-        ctx: The aspect context.
-        bundle_info: An instance of `BundleInfo`.
-        is_missing_provisioning_profile: Whether a provisioning profile is
-            is able to be set on the target, and it's missing.
-        platform: A value from `platforms.collect`.
-
-    Returns:
-        A `bool` indicating if we should skip codesigning.
-    """
-    if not bundle_info:
-        return False
-
-    if (is_missing_provisioning_profile and
-        bundle_info.product_type == "com.apple.product-type.framework"):
-        return True
-
-    if not platforms.is_simulator(platform):
-        return (is_missing_provisioning_profile and
-                platforms.is_not_macos(platform))
-
-    enabled_features = _compute_enabled_features(
-        requested_features = ctx.features,
-        unsupported_features = ctx.disabled_features,
-    )
-
-    return "apple.skip_codesign_simulator_bundles" in enabled_features
 
 # API
 

--- a/xcodeproj/internal/processed_targets/incremental_top_level_targets.bzl
+++ b/xcodeproj/internal/processed_targets/incremental_top_level_targets.bzl
@@ -276,27 +276,6 @@ def _calculate_product_type(*, target_files, bundle_info):
 
     return "T"  # com.apple.product-type.tool
 
-def _compute_enabled_features(*, requested_features, unsupported_features):
-    """Returns a list of features for the given build.
-
-    Args:
-        requested_features: A list of features requested. Typically from
-            `ctx.features`.
-        unsupported_features: A list of features to ignore. Typically from
-            `ctx.disabled_features`.
-
-    Returns:
-        A set (`dict` of `None`) containing the subset of features that should
-        be used.
-    """
-    unsupported_features = {f: None for f in unsupported_features}
-    enabled_features = {
-        f: None
-        for f in requested_features
-        if f not in unsupported_features
-    }
-    return enabled_features
-
 def _create_link_params(
         *,
         actions,


### PR DESCRIPTION
This seems to be a remnant from when incremental generation mode was going to support BwX mode. Now we default to not signing, and this additional logic isn’t needed and is error prone.