### PR TITLE
Set `--experimental_action_cache_store_output_metadata` only with Bazel 6

### DIFF
--- a/bazel_6.bazelrc
+++ b/bazel_6.bazelrc
@@ -7,3 +7,6 @@ build --enable_bzlmod
 build --apple_crosstool_top=@local_config_apple_cc//:toolchain
 build --crosstool_top=@local_config_apple_cc//:toolchain
 build --host_crosstool_top=@local_config_apple_cc//:toolchain
+
+# Work around https://github.com/bazelbuild/bazel/issues/13912
+build --experimental_action_cache_store_output_metadata

--- a/shared.bazelrc
+++ b/shared.bazelrc
@@ -7,9 +7,6 @@ build --experimental_convenience_symlinks=ignore
 # Faster digest hashing with BLAKE3
 startup --digest_function=blake3
 
-# Work around https://github.com/bazelbuild/bazel/issues/13912
-build --experimental_action_cache_store_output_metadata
-
 build --remote_default_exec_properties=OSFamily=darwin
 build --remote_default_exec_properties=cache_bust=macOS_13.0/1
 


### PR DESCRIPTION
It’s a no-op in Bazel 7.