### PR TITLE
Set `explicitFileType` for bazel and bzl extensions

### DIFF
--- a/tools/generators/files_and_groups/src/Xcode.swift
+++ b/tools/generators/files_and_groups/src/Xcode.swift
@@ -267,11 +267,24 @@ enum Xcode {
         "zip": "archive.zip",
     ]
 
+    private static let pbxProjImpliedFileExtensions = [
+        "BUILD": "bazel",
+        "Podfile": "rb",
+    ]
+
     /// Returns the Xcode file type for any given extension.
     ///
     /// - Parameters:
     ///   - extension: The file extension.
     public static func pbxProjEscapedFileType(extension: String) -> String? {
         pbxProjEscapedFileTypes[`extension`]
+    }
+
+    /// Returns the implied file extension for any given file name.
+    ///
+    /// - Parameters:
+    ///   - basename: The file name.
+    public static func impliedExtension(basename: String) -> String? {
+        pbxProjImpliedFileExtensions[basename]
     }
 }

--- a/tools/generators/files_and_groups/test/ElementCreator/CreateFileElementTests.swift
+++ b/tools/generators/files_and_groups/test/ElementCreator/CreateFileElementTests.swift
@@ -178,9 +178,9 @@ final class CreateFileElementTests: XCTestCase {
     func test_element_content_lastKnownFileType_file() {
         // Arrange
 
-        let name = "node_name.bazel"
-        let ext = "bazel"
-        let bazelPath = BazelPath("a/bazel/path/node_name.bazel")
+        let name = "node_name.foo"
+        let ext = "foo"
+        let bazelPath = BazelPath("a/bazel/path/node_name.foo")
         let createAttributes = ElementCreator.CreateAttributes.stub(
             elementAttributes: ElementAttributes(
                 sourceTree: .group, name: nil, path: "a_path"
@@ -189,7 +189,40 @@ final class CreateFileElementTests: XCTestCase {
         )
 
         let expectedContent = #"""
-{isa = PBXFileReference; lastKnownFileType = text.script.python; path = a_path; sourceTree = "<group>"; }
+{isa = PBXFileReference; lastKnownFileType = file; path = a_path; sourceTree = "<group>"; }
+"""#
+
+        // Act
+
+        let result = ElementCreator.CreateFileElement.defaultCallable(
+            name: name,
+            ext: ext,
+            bazelPath: bazelPath,
+            specialRootGroupType: nil,
+            createAttributes: createAttributes,
+            createIdentifier: ElementCreator.Stubs.createIdentifier
+        )
+
+        // Assert
+
+        XCTAssertEqual(result.element.object.content, expectedContent)
+    }
+
+    func test_element_content_lastKnownFileType_knownExtension() {
+        // Arrange
+
+        let name = "node_name.rb"
+        let ext = "rb"
+        let bazelPath = BazelPath("a/bazel/path/node_name.rb")
+        let createAttributes = ElementCreator.CreateAttributes.stub(
+            elementAttributes: ElementAttributes(
+                sourceTree: .group, name: nil, path: "a_path"
+            ),
+            resolvedRepository: nil
+        )
+
+        let expectedContent = #"""
+{isa = PBXFileReference; lastKnownFileType = text.script.ruby; path = a_path; sourceTree = "<group>"; }
 """#
 
         // Act
@@ -275,6 +308,72 @@ final class CreateFileElementTests: XCTestCase {
     }
 
     // MARK: element.content - explicitFileType
+    
+    func test_element_content_explicitFileType_bazel() {
+        // Arrange
+
+        let name = "node_name.bazel"
+        let ext = "bazel"
+        let bazelPath = BazelPath("a/bazel/path/node_name.bazel")
+        let createAttributes = ElementCreator.CreateAttributes.stub(
+            elementAttributes: ElementAttributes(
+                sourceTree: .group, name: nil, path: "a_path"
+            ),
+            resolvedRepository: nil
+        )
+
+        let expectedContent = #"""
+{isa = PBXFileReference; explicitFileType = text.script.python; path = a_path; sourceTree = "<group>"; }
+"""#
+
+        // Act
+
+        let result = ElementCreator.CreateFileElement.defaultCallable(
+            name: name,
+            ext: ext,
+            bazelPath: bazelPath,
+            specialRootGroupType: nil,
+            createAttributes: createAttributes,
+            createIdentifier: ElementCreator.Stubs.createIdentifier
+        )
+
+        // Assert
+
+        XCTAssertEqual(result.element.object.content, expectedContent)
+    }
+    
+    func test_element_content_explicitFileType_bzl() {
+        // Arrange
+
+        let name = "node_name.bzl"
+        let ext = "bzl"
+        let bazelPath = BazelPath("a/bazel/path/node_name.bzl")
+        let createAttributes = ElementCreator.CreateAttributes.stub(
+            elementAttributes: ElementAttributes(
+                sourceTree: .group, name: nil, path: "a_path"
+            ),
+            resolvedRepository: nil
+        )
+
+        let expectedContent = #"""
+{isa = PBXFileReference; explicitFileType = text.script.python; path = a_path; sourceTree = "<group>"; }
+"""#
+
+        // Act
+
+        let result = ElementCreator.CreateFileElement.defaultCallable(
+            name: name,
+            ext: ext,
+            bazelPath: bazelPath,
+            specialRootGroupType: nil,
+            createAttributes: createAttributes,
+            createIdentifier: ElementCreator.Stubs.createIdentifier
+        )
+
+        // Assert
+
+        XCTAssertEqual(result.element.object.content, expectedContent)
+    }
 
     func test_element_content_explicitFileType_BUILD() {
         // Arrange


### PR DESCRIPTION
BUILD.bazel and .bzl files are not being recognized as a text.script.python in Xcode when using the incremental generator.

Replacing lastKnownFileType with explicitFileType for these extensions fixed the issue.

| Before  | After |
| ------------- | ------------- |
| ![image](https://github.com/MobileNativeFoundation/rules_xcodeproj/assets/7773955/7cc23b81-5a24-42d0-92f1-bf4241199ad5)  | ![image](https://github.com/MobileNativeFoundation/rules_xcodeproj/assets/7773955/2eb3e4ec-1f6f-4467-9591-726122db67bc) |