### PR TITLE
Stop setting `--experimental_remote_download_regex` by default with command-line API

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -316,6 +316,23 @@ For example, this will build all targets the same way that Xcode does:
 bazel run //:xcodeproj -- --generator_output_groups=all_targets build
 ```
 
+### `--download_intermediates`
+
+By default, when using
+[`--generator_output_groups`][#--generator_output_groups],
+intermediate outputs (such as generated files and index stores) won't be
+downloaded from a remote cache if `--remote_download_toplevel` or
+`--remote_download_minimal` is used. This is to support the common use case of
+using the command-line API to warm a remote cache on a CI job that uses
+`--remote_download_minimal` and doesn't want anything downloaded.
+
+To cause intermediates to be downloaded the same way that a normal Xcode build
+downloads them, pass the `--download_intermediates` flag:
+
+```
+bazel run //:xcodeproj -- --generator_output_groups=all_targets --download_intermediates build
+```
+
 ## Substitutions
 
 In your command, any reference to these variables will be expanded:

--- a/xcodeproj/internal/templates/runner.sh
+++ b/xcodeproj/internal/templates/runner.sh
@@ -32,6 +32,7 @@ installer_flags=(
 
 config="build"
 original_arg_count=$#
+download_intermediates=0
 verbose=0
 while (("$#")); do
   case "$1" in
@@ -45,6 +46,10 @@ while (("$#")); do
       ;;
     --config=*)
       config="${1#*=}"
+      shift 1
+      ;;
+    --download_intermediates)
+      download_intermediates=1
       shift 1
       ;;
     -v|--verbose)
@@ -219,9 +224,13 @@ else
   cmd="${cmd_args[0]}"
 
   if [[ $cmd == "build" && -n "${generator_output_groups:-}" ]]; then
-    pre_config_flags=(
-      "--experimental_remote_download_regex=.*\.indexstore/.*|.*\.a$|.*\.swiftdoc$|.*\.swiftmodule$|.*\.swiftsourceinfo$|.*\.swift$"
-    )
+    if [[ $download_intermediates -eq 1 ]]; then
+      pre_config_flags=(
+        "--experimental_remote_download_regex=.*\.indexstore/.*|.*\.(a|c|C|cc|cl|cpp|cu|cxx|c++|m|mm|swift|swiftdoc|swiftmodule|swiftsourceinfo)$"
+      )
+    else
+      pre_config_flags=()
+    fi
 
     # `--output_groups`
     post_config_flags=(


### PR DESCRIPTION
Also fixes the regex used to match what we changed `build_build.sh` to use.

This is to optimize bandwidth usage of cache warming calls.