### PR TITLE
Remove `TARGET_DEVICE_PLATFORM_NAME` matching from `Info.plist` touching

### DIFF
--- a/xcodeproj/internal/bazel_integration_files/copy_outputs.sh
+++ b/xcodeproj/internal/bazel_integration_files/copy_outputs.sh
@@ -73,8 +73,7 @@ if [[ "$ACTION" != indexbuild ]]; then
       # Source: https://github.com/bazelbuild/tulsi/commit/27354027fada7aa3ec3139fd686f85cc5039c564
       # TODO: Pass the exact list of files to touch to this script
       readonly plugins_dir="$TARGET_BUILD_DIR/${PLUGINS_FOLDER_PATH:-}"
-      if [[ "${TARGET_DEVICE_PLATFORM_NAME:-}" == "iphoneos" && \
-            -d "$plugins_dir" ]]; then
+      if [[ -d "$plugins_dir" ]]; then
         find "$plugins_dir" -depth 2 -name "Info.plist" -exec touch {} \;
       fi
 


### PR DESCRIPTION
It appears that the `TARGET_DEVICE_PLATFORM_NAME` check didn't account for `iphonesimulator` platform name which was causing unit tests running on a test host to not reflect changes made in source code.