### PR TITLE
Add `literal_string` arg to `xcschemes.arg`

### DIFF
--- a/docs/bazel.md
+++ b/docs/bazel.md
@@ -223,7 +223,7 @@ load("@rules_xcodeproj//xcodeproj:defs.bzl", "xcschemes")
 ## xcschemes.arg
 
 <pre>
-xcschemes.arg(<a href="#xcschemes.arg-value">value</a>, <a href="#xcschemes.arg-enabled">enabled</a>)
+xcschemes.arg(<a href="#xcschemes.arg-value">value</a>, <a href="#xcschemes.arg-enabled">enabled</a>, <a href="#xcschemes.arg-literal_string">literal_string</a>)
 </pre>
 
 Defines a command-line argument.
@@ -235,6 +235,7 @@ Defines a command-line argument.
 | :------------- | :------------- | :------------- |
 | <a id="xcschemes.arg-value"></a>value |  Positional. The command-line argument.<br><br>Arguments with quotes, spaces, or newlines will be escaped. You should not use additional quotes around arguments with spaces. If you include quotes around your argument, those quotes will be part of the argument.   |  none |
 | <a id="xcschemes.arg-enabled"></a>enabled |  Whether the command-line argument is enabled.<br><br>If `True`, the checkbox for the argument will be checked in the scheme. An unchecked checkbox means Xcode won't include that argument when running a target.   |  `True` |
+| <a id="xcschemes.arg-literal_string"></a>literal_string |  Whether `value` should be interpreted as a literal string.<br><br>If `True`, any spaces will be escaped. This means that `value` will be passed to the launch target as a single string. If `False`, any spaces will not be escaped. This is useful to group multiple arguments under a single checkbox in Xcode.   |  `True` |
 
 
 <a id="xcschemes.diagnostics"></a>

--- a/test/internal/xcschemes/info_constructors_tests.bzl
+++ b/test/internal/xcschemes/info_constructors_tests.bzl
@@ -68,13 +68,47 @@ def info_constructors_test_suite(name):
             expected_info = json.encode(expected_info),
         )
 
-    # make_arg_env
+    # make_arg
 
     _add_test(
-        name = "{}_make_arg_env_minimal".format(name),
+        name = "{}_make_arg_minimal".format(name),
 
         # Inputs
-        info = xcscheme_infos_testable.make_arg_env(value = "a\nnew line"),
+        info = xcscheme_infos_testable.make_arg(value = "a\nnew line"),
+
+        # Expected
+        expected_info = struct(
+            enabled = "1",
+            literal_string = "1",
+            value = "a\nnew line",
+        ),
+    )
+
+    _add_test(
+        name = "{}_make_arg_full".format(name),
+
+        # Inputs
+        info = xcscheme_infos_testable.make_arg(
+            enabled = "0",
+            literal_string = "0",
+            value = "b",
+        ),
+
+        # Expected
+        expected_info = struct(
+            enabled = "0",
+            literal_string = "0",
+            value = "b",
+        ),
+    )
+
+    # make_env
+
+    _add_test(
+        name = "{}_make_env_minimal".format(name),
+
+        # Inputs
+        info = xcscheme_infos_testable.make_env(value = "a\nnew line"),
 
         # Expected
         expected_info = struct(
@@ -84,10 +118,10 @@ def info_constructors_test_suite(name):
     )
 
     _add_test(
-        name = "{}_make_arg_env_full".format(name),
+        name = "{}_make_env_full".format(name),
 
         # Inputs
-        info = xcscheme_infos_testable.make_arg_env(
+        info = xcscheme_infos_testable.make_env(
             enabled = "0",
             value = "b",
         ),
@@ -452,11 +486,11 @@ def info_constructors_test_suite(name):
         # Inputs
         info = xcscheme_infos_testable.make_profile(
             args = [
-                xcscheme_infos_testable.make_arg_env(
+                xcscheme_infos_testable.make_arg(
                     enabled = "1",
                     value = "a\nnew line",
                 ),
-                xcscheme_infos_testable.make_arg_env(
+                xcscheme_infos_testable.make_arg(
                     enabled = "0",
                     value = "b",
                 ),
@@ -466,8 +500,8 @@ def info_constructors_test_suite(name):
                 xcscheme_infos_testable.make_build_target("bt 0"),
             ],
             env = {
-                "VAR\n0": xcscheme_infos_testable.make_arg_env("value 0"),
-                "VAR 1": xcscheme_infos_testable.make_arg_env("value\n1"),
+                "VAR\n0": xcscheme_infos_testable.make_env("value 0"),
+                "VAR 1": xcscheme_infos_testable.make_env("value\n1"),
             },
             env_include_defaults = "1",
             launch_target = xcscheme_infos_testable.make_launch_target("L"),
@@ -478,11 +512,11 @@ def info_constructors_test_suite(name):
         # Expected
         expected_info = struct(
             args = [
-                xcscheme_infos_testable.make_arg_env(
+                xcscheme_infos_testable.make_arg(
                     enabled = "1",
                     value = "a\nnew line",
                 ),
-                xcscheme_infos_testable.make_arg_env(
+                xcscheme_infos_testable.make_arg(
                     enabled = "0",
                     value = "b",
                 ),
@@ -492,8 +526,8 @@ def info_constructors_test_suite(name):
                 xcscheme_infos_testable.make_build_target("bt 0"),
             ],
             env = {
-                "VAR\n0": xcscheme_infos_testable.make_arg_env("value 0"),
-                "VAR 1": xcscheme_infos_testable.make_arg_env("value\n1"),
+                "VAR\n0": xcscheme_infos_testable.make_env("value 0"),
+                "VAR 1": xcscheme_infos_testable.make_env("value\n1"),
             },
             env_include_defaults = "1",
             launch_target = xcscheme_infos_testable.make_launch_target("L"),
@@ -528,11 +562,11 @@ def info_constructors_test_suite(name):
         # Inputs
         info = xcscheme_infos_testable.make_run(
             args = [
-                xcscheme_infos_testable.make_arg_env(
+                xcscheme_infos_testable.make_arg(
                     enabled = "1",
                     value = "a\nnew line",
                 ),
-                xcscheme_infos_testable.make_arg_env(
+                xcscheme_infos_testable.make_arg(
                     enabled = "0",
                     value = "b",
                 ),
@@ -545,8 +579,8 @@ def info_constructors_test_suite(name):
                 undefined_behavior_sanitizer = "1",
             ),
             env = {
-                "VAR\n0": xcscheme_infos_testable.make_arg_env("value 0"),
-                "VAR 1": xcscheme_infos_testable.make_arg_env("value\n1"),
+                "VAR\n0": xcscheme_infos_testable.make_env("value 0"),
+                "VAR 1": xcscheme_infos_testable.make_env("value\n1"),
             },
             env_include_defaults = "0",
             launch_target = xcscheme_infos_testable.make_launch_target("L"),
@@ -556,11 +590,11 @@ def info_constructors_test_suite(name):
         # Expected
         expected_info = struct(
             args = [
-                xcscheme_infos_testable.make_arg_env(
+                xcscheme_infos_testable.make_arg(
                     enabled = "1",
                     value = "a\nnew line",
                 ),
-                xcscheme_infos_testable.make_arg_env(
+                xcscheme_infos_testable.make_arg(
                     enabled = "0",
                     value = "b",
                 ),
@@ -573,8 +607,8 @@ def info_constructors_test_suite(name):
                 undefined_behavior_sanitizer = "1",
             ),
             env = {
-                "VAR\n0": xcscheme_infos_testable.make_arg_env("value 0"),
-                "VAR 1": xcscheme_infos_testable.make_arg_env("value\n1"),
+                "VAR\n0": xcscheme_infos_testable.make_env("value 0"),
+                "VAR 1": xcscheme_infos_testable.make_env("value\n1"),
             },
             env_include_defaults = "0",
             launch_target = xcscheme_infos_testable.make_launch_target(
@@ -660,11 +694,11 @@ def info_constructors_test_suite(name):
         # Inputs
         info = xcscheme_infos_testable.make_test(
             args = [
-                xcscheme_infos_testable.make_arg_env(
+                xcscheme_infos_testable.make_arg(
                     enabled = "1",
                     value = "a\nnew line",
                 ),
-                xcscheme_infos_testable.make_arg_env(
+                xcscheme_infos_testable.make_arg(
                     enabled = "0",
                     value = "b",
                 ),
@@ -677,8 +711,8 @@ def info_constructors_test_suite(name):
                 thread_sanitizer = "1",
             ),
             env = {
-                "VAR\n0": xcscheme_infos_testable.make_arg_env("value 0"),
-                "VAR 1": xcscheme_infos_testable.make_arg_env("value\n1"),
+                "VAR\n0": xcscheme_infos_testable.make_env("value 0"),
+                "VAR 1": xcscheme_infos_testable.make_env("value\n1"),
             },
             env_include_defaults = "1",
             test_targets = [
@@ -693,11 +727,11 @@ def info_constructors_test_suite(name):
         # Expected
         expected_info = struct(
             args = [
-                xcscheme_infos_testable.make_arg_env(
+                xcscheme_infos_testable.make_arg(
                     enabled = "1",
                     value = "a\nnew line",
                 ),
-                xcscheme_infos_testable.make_arg_env(
+                xcscheme_infos_testable.make_arg(
                     enabled = "0",
                     value = "b",
                 ),
@@ -710,8 +744,8 @@ def info_constructors_test_suite(name):
                 thread_sanitizer = "1",
             ),
             env = {
-                "VAR\n0": xcscheme_infos_testable.make_arg_env("value 0"),
-                "VAR 1": xcscheme_infos_testable.make_arg_env("value\n1"),
+                "VAR\n0": xcscheme_infos_testable.make_env("value 0"),
+                "VAR 1": xcscheme_infos_testable.make_env("value\n1"),
             },
             env_include_defaults = "1",
             test_targets = [

--- a/test/internal/xcschemes/infos_from_json_tests.bzl
+++ b/test/internal/xcschemes/infos_from_json_tests.bzl
@@ -151,29 +151,31 @@ def infos_from_json_test_suite(name):
 
     full_args = [
         "-a\nnewline",
-        xcscheme_infos_testable.make_arg_env(
+        xcscheme_infos_testable.make_arg(
             "B",
+            literal_string = "0",
             enabled = "0",
         ),
     ]
     expected_full_args = [
-        xcscheme_infos_testable.make_arg_env("-a\nnewline"),
-        xcscheme_infos_testable.make_arg_env(
+        xcscheme_infos_testable.make_arg("-a\nnewline"),
+        xcscheme_infos_testable.make_arg(
             "B",
+            literal_string = "0",
             enabled = "0",
         ),
     ]
 
     full_env = {
         "A": "B",
-        "ENV\nVAR": xcscheme_infos_testable.make_arg_env(
+        "ENV\nVAR": xcscheme_infos_testable.make_env(
             "1\n2",
             enabled = "0",
         ),
     }
     expected_full_env = {
-        "A": xcscheme_infos_testable.make_arg_env("B"),
-        "ENV\nVAR": xcscheme_infos_testable.make_arg_env(
+        "A": xcscheme_infos_testable.make_env("B"),
+        "ENV\nVAR": xcscheme_infos_testable.make_env(
             "1\n2",
             enabled = "0",
         ),
@@ -611,7 +613,7 @@ def infos_from_json_test_suite(name):
                     use_run_args_and_env = "1",
                 ),
                 run = xcscheme_infos_testable.make_run(
-                    args = [xcscheme_infos_testable.make_arg_env("-v")],
+                    args = [xcscheme_infos_testable.make_arg("-v")],
                     build_targets = (
                         expected_full_launch_build_targets +
                         expected_full_build_targets
@@ -619,7 +621,7 @@ def infos_from_json_test_suite(name):
                     diagnostics = xcscheme_infos_testable.make_diagnostics(
                         address_sanitizer = "1",
                     ),
-                    env = {"A": xcscheme_infos_testable.make_arg_env("B")},
+                    env = {"A": xcscheme_infos_testable.make_env("B")},
                     env_include_defaults = "1",
                     launch_target = expected_full_launch_target,
                     xcode_configuration = "custom",

--- a/test/internal/xcschemes/utils.bzl
+++ b/test/internal/xcschemes/utils.bzl
@@ -1,6 +1,6 @@
 """Utility test functions for xcshemes tests."""
 
-def _dict_of_dicts_to_arg_env_infos(dict_of_dicts):
+def _dict_of_dicts_to_env_infos(dict_of_dicts):
     if dict_of_dicts == None:
         return None
     return {
@@ -39,9 +39,9 @@ def _dict_to_launch_target_info(d):
 
 def _dict_to_profile_info(d):
     return struct(
-        args = _dicts_to_arg_env_infos(d["args"]),
+        args = _dicts_to_arg_infos(d["args"]),
         build_targets = _dicts_to_build_target_infos(d["build_targets"]),
-        env = _dict_of_dicts_to_arg_env_infos(d["env"]),
+        env = _dict_of_dicts_to_env_infos(d["env"]),
         env_include_defaults = d["env_include_defaults"],
         launch_target = _dict_to_launch_target_info(d["launch_target"]),
         use_run_args_and_env = d["use_run_args_and_env"],
@@ -50,10 +50,10 @@ def _dict_to_profile_info(d):
 
 def _dict_to_run_info(d):
     return struct(
-        args = _dicts_to_arg_env_infos(d["args"]),
+        args = _dicts_to_arg_infos(d["args"]),
         build_targets = _dicts_to_build_target_infos(d["build_targets"]),
         diagnostics = _dict_to_diagnostics_info(d["diagnostics"]),
-        env = _dict_of_dicts_to_arg_env_infos(d["env"]),
+        env = _dict_of_dicts_to_env_infos(d["env"]),
         env_include_defaults = d["env_include_defaults"],
         launch_target = _dict_to_launch_target_info(d["launch_target"]),
         xcode_configuration = d["xcode_configuration"],
@@ -61,10 +61,10 @@ def _dict_to_run_info(d):
 
 def _dict_to_test_info(d):
     return struct(
-        args = _dicts_to_arg_env_infos(d["args"]),
+        args = _dicts_to_arg_infos(d["args"]),
         build_targets = _dicts_to_build_target_infos(d["build_targets"]),
         diagnostics = _dict_to_diagnostics_info(d["diagnostics"]),
-        env = _dict_of_dicts_to_arg_env_infos(d["env"]),
+        env = _dict_of_dicts_to_env_infos(d["env"]),
         env_include_defaults = d["env_include_defaults"],
         test_targets = _dicts_to_test_target_infos(d["test_targets"]),
         use_run_args_and_env = d["use_run_args_and_env"],
@@ -89,12 +89,13 @@ def _dicts_to_build_target_infos(dicts):
         for d in dicts
     ]
 
-def _dicts_to_arg_env_infos(dicts):
+def _dicts_to_arg_infos(dicts):
     if dicts == None:
         return None
     return [
         struct(
             enabled = d["enabled"],
+            literal_string = d["literal_string"],
             value = d["value"],
         )
         for d in dicts

--- a/test/internal/xcschemes/write_schemes_tests.bzl
+++ b/test/internal/xcschemes/write_schemes_tests.bzl
@@ -491,11 +491,16 @@ def write_schemes_test_suite(name):
                 name = "Scheme 1",
                 profile = xcscheme_infos_testable.make_profile(
                     args = [
-                        xcscheme_infos_testable.make_arg_env(
+                        xcscheme_infos_testable.make_arg(
                             enabled = "1",
                             value = "simple value",
                         ),
-                        xcscheme_infos_testable.make_arg_env(
+                        xcscheme_infos_testable.make_arg(
+                            enabled = "1",
+                            literal_string = "0",
+                            value = "simple value",
+                        ),
+                        xcscheme_infos_testable.make_arg(
                             enabled = "0",
                             value = "value\nwith\nnewlines",
                         ),
@@ -534,7 +539,7 @@ def write_schemes_test_suite(name):
                         ),
                     ],
                     env = {
-                        "B": xcscheme_infos_testable.make_arg_env(
+                        "B": xcscheme_infos_testable.make_env(
                             enabled = "1",
                             value = "a",
                         ),
@@ -578,11 +583,11 @@ def write_schemes_test_suite(name):
                 ),
                 run = xcscheme_infos_testable.make_run(
                     args = [
-                        xcscheme_infos_testable.make_arg_env(
+                        xcscheme_infos_testable.make_arg(
                             enabled = "0",
                             value = "a",
                         ),
-                        xcscheme_infos_testable.make_arg_env(
+                        xcscheme_infos_testable.make_arg(
                             enabled = "1",
                             value = "bb",
                         ),
@@ -626,11 +631,11 @@ def write_schemes_test_suite(name):
                         undefined_behavior_sanitizer = "1",
                     ),
                     env = {
-                        "A": xcscheme_infos_testable.make_arg_env(
+                        "A": xcscheme_infos_testable.make_env(
                             enabled = "0",
                             value = "value with spaces",
                         ),
-                        "VAR WITH SPACES": xcscheme_infos_testable.make_arg_env(
+                        "VAR WITH SPACES": xcscheme_infos_testable.make_env(
                             enabled = "1",
                             value = "value\nwith\nnewlines",
                         ),
@@ -673,7 +678,7 @@ def write_schemes_test_suite(name):
                 ),
                 test = xcscheme_infos_testable.make_test(
                     args = [
-                        xcscheme_infos_testable.make_arg_env(
+                        xcscheme_infos_testable.make_arg(
                             enabled = "0",
                             value = "-v",
                         ),
@@ -720,7 +725,7 @@ def write_schemes_test_suite(name):
                         undefined_behavior_sanitizer = "1",
                     ),
                     env = {
-                        "VAR\nWITH\nNEWLINES": xcscheme_infos_testable.make_arg_env(
+                        "VAR\nWITH\nNEWLINES": xcscheme_infos_testable.make_env(
                             enabled = "0",
                             value = "simple",
                         ),
@@ -900,6 +905,8 @@ def write_schemes_test_suite(name):
                 "-v",
                 # - test - commandLineArguments - enabled
                 "0",
+                # - test - commandLineArguments - literalString
+                "1",
                 # - test - environmentVariables count
                 "1",
                 # - test - environmentVariables - key
@@ -929,9 +936,13 @@ def write_schemes_test_suite(name):
                 "a",
                 # - run - commandLineArguments - enabled
                 "0",
+                # - run - commandLineArguments - literalString
+                "1",
                 # - run - commandLineArguments - value
                 "bb",
                 # - run - commandLineArguments - enabled
+                "1",
+                # - run - commandLineArguments - literalString
                 "1",
                 # - run - environmentVariables count
                 "2",
@@ -969,15 +980,25 @@ def write_schemes_test_suite(name):
                 "profile bt",
                 "",
                 # - profile - commandLineArguments count
-                "2",
+                "3",
                 # - profile - commandLineArguments - value
                 "simple value",
                 # - profile - commandLineArguments - enabled
                 "1",
+                # - profile - commandLineArguments - literalString
+                "1",
+                # - profile - commandLineArguments - value
+                "simple value",
+                # - profile - commandLineArguments - enabled
+                "1",
+                # - profile - commandLineArguments - literalString
+                "0",
                 # - profile - commandLineArguments - value
                 "value\0with\0newlines",
                 # - profile - commandLineArguments - enabled
                 "0",
+                # - profile - commandLineArguments - literalString
+                "1",
                 # - profile - environmentVariables count
                 "1",
                 # - profile - environmentVariables - key

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -180,8 +180,10 @@ _XCSCHEMES = [
                 # developmentRegion
                 "enGB",
                 # organizationName
-                "--organization-name",
-                "MobileNativeFoundation",
+                xcschemes.arg(
+                    "--organization-name MobileNativeFoundation",
+                    literal_string = False,
+                ),
                 # platforms
                 "--platforms",
                 "macosx",

--- a/tools/generators/lib/XCScheme/src/CommandLineArguments.swift
+++ b/tools/generators/lib/XCScheme/src/CommandLineArguments.swift
@@ -1,10 +1,16 @@
 public struct CommandLineArgument: Equatable {
     let value: String
-    let enabled: Bool
+    let isEnabled: Bool
+    let isLiteralString: Bool
 
-    public init(value: String, enabled: Bool = true) {
+    public init(
+        value: String,
+        isEnabled: Bool = true,
+        isLiteralString: Bool = true
+    ) {
         self.value = value
-        self.enabled = enabled
+        self.isEnabled = isEnabled
+        self.isLiteralString = isLiteralString
     }
 }
 
@@ -27,7 +33,9 @@ extension Array where Element == CommandLineArgument {
 
 private func createCommandLineArgument(_ arg: CommandLineArgument) -> String {
     let argument: String
-    if arg.value.isEmpty {
+    if !arg.isLiteralString {
+        argument = arg.value.schemeXmlEscaped
+    } else if arg.value.isEmpty {
         argument = "''"
     } else {
         argument = arg.value
@@ -41,7 +49,7 @@ private func createCommandLineArgument(_ arg: CommandLineArgument) -> String {
     return #"""
          <CommandLineArgument
             argument = "\#(argument)"
-            isEnabled = "\#(arg.enabled.xmlString)">
+            isEnabled = "\#(arg.isEnabled.xmlString)">
          </CommandLineArgument>
 """#
 }

--- a/tools/generators/lib/XCScheme/src/CreateTestAction.swift
+++ b/tools/generators/lib/XCScheme/src/CreateTestAction.swift
@@ -125,14 +125,14 @@ buildConfiguration = "\#(buildConfiguration)"
 
 public struct Testable {
     public let buildableReference: BuildableReference
-    let skipped: Bool
+    let isSkipped: Bool
 
     public init(
         buildableReference: BuildableReference,
-        skipped: Bool
+        isSkipped: Bool
     ) {
         self.buildableReference = buildableReference
-        self.skipped = skipped
+        self.isSkipped = isSkipped
     }
 }
 
@@ -142,7 +142,7 @@ private func createTestableElement(_ testable: Testable) -> String {
     // 3 spaces for indentation is intentional
     return #"""
          <TestableReference
-            skipped = "\#(testable.skipped.xmlString)">
+            skipped = "\#(testable.isSkipped.xmlString)">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "\#(reference.blueprintIdentifier)"

--- a/tools/generators/lib/XCScheme/src/EnvironmentVariables.swift
+++ b/tools/generators/lib/XCScheme/src/EnvironmentVariables.swift
@@ -1,12 +1,12 @@
 public struct EnvironmentVariable: Equatable {
     let key: String
     let value: String
-    let enabled: Bool
+    let isEnabled: Bool
 
-    public init(key: String, value: String, enabled: Bool = true) {
+    public init(key: String, value: String, isEnabled: Bool = true) {
         self.key = key
         self.value = value
-        self.enabled = enabled
+        self.isEnabled = isEnabled
     }
 }
 
@@ -34,7 +34,7 @@ private func createEnvironmentVariableElement(
          <EnvironmentVariable
             key = "\#(variable.key.schemeXmlEscaped)"
             value = "\#(variable.value.schemeXmlEscaped)"
-            isEnabled = "\#(variable.enabled.xmlString)">
+            isEnabled = "\#(variable.isEnabled.xmlString)">
          </EnvironmentVariable>
 """#
 }

--- a/tools/generators/lib/XCScheme/test/CreateLaunchActionTests.swift
+++ b/tools/generators/lib/XCScheme/test/CreateLaunchActionTests.swift
@@ -41,7 +41,7 @@ final class CreateLaunchActionTests: XCTestCase {
             .init(value: "-ARGUMENT_3"),
             .init(value: ""),
             .init(value: "multi\nline\nargument"),
-            .init(value: "ARGUMENT_Z", enabled: false),
+            .init(value: "ARGUMENT_Z", isEnabled: false),
             .init(value: "something with spaces"),
             .init(value: "'ARGUMENT 1'"),
         ]

--- a/tools/generators/lib/XCScheme/test/CreateProfileActionTests.swift
+++ b/tools/generators/lib/XCScheme/test/CreateProfileActionTests.swift
@@ -35,7 +35,7 @@ final class CreateProfileActionTests: XCTestCase {
         let buildConfiguration = "Debug"
         let commandLineArguments: [CommandLineArgument] = [
             .init(value: "-ARGUMENT_42"),
-            .init(value: "ARGUMENT_F", enabled: false),
+            .init(value: "ARGUMENT_F", isEnabled: false),
             .init(value: "'ARGUMENT 3'"),
         ]
 

--- a/tools/generators/lib/XCScheme/test/CreateTestActionTests.swift
+++ b/tools/generators/lib/XCScheme/test/CreateTestActionTests.swift
@@ -36,7 +36,7 @@ final class CreateTestActionTests: XCTestCase {
         let buildConfiguration = "Debug"
         let commandLineArguments: [CommandLineArgument] = [
             .init(value: "-ARGUMENT_1"),
-            .init(value: "ARGUMENT_A", enabled: false),
+            .init(value: "ARGUMENT_A", isEnabled: false),
             .init(value: "'ARGUMENT 2'"),
         ]
 
@@ -175,7 +175,7 @@ final class CreateTestActionTests: XCTestCase {
             .init(
                 key: "BUILD_WORKING_DIRECTORY",
                 value: "$(BUILT_PRODUCTS_DIR)",
-                enabled: false
+                isEnabled: false
             ),
             .init(key: "VAR", value: "'Value 1'"),
         ]
@@ -270,7 +270,7 @@ final class CreateTestActionTests: XCTestCase {
                     blueprintName: "BLUEPRINT_NAME_3",
                     referencedContainer: "REFERENCED_CONTAINER_3"
                 ),
-                skipped: false
+                isSkipped: false
             ),
             .init(
                 buildableReference: .init(
@@ -279,7 +279,7 @@ final class CreateTestActionTests: XCTestCase {
                     blueprintName: "BLUEPRINT_NAME_1",
                     referencedContainer: "REFERENCED_CONTAINER_1"
                 ),
-                skipped: true
+                isSkipped: true
             ),
         ]
 

--- a/tools/generators/xcschemes/src/Generator/CreateAutomaticSchemeInfo.swift
+++ b/tools/generators/xcschemes/src/Generator/CreateAutomaticSchemeInfo.swift
@@ -121,7 +121,7 @@ extension Generator.CreateAutomaticSchemeInfo {
                 enableUBSanitizer: false,
                 environmentVariables: testEnvironmentVariables,
                 testTargets: isTest ?
-                    [.init(target: target, enabled: true)] : [],
+                    [.init(target: target, isEnabled: true)] : [],
                 useRunArgsAndEnv: testUseRunArgsAndEnv,
                 xcodeConfiguration: nil
             ),

--- a/tools/generators/xcschemes/src/Generator/CreateCustomSchemeInfos.swift
+++ b/tools/generators/xcschemes/src/Generator/CreateCustomSchemeInfos.swift
@@ -571,7 +571,8 @@ set
         for _ in (0..<testTargetCount) {
             let id =
                 try consumeArg("test-target-id", as: TargetID.self, in: url)
-            let enabled = try consumeArg("test-enabled", as: Bool.self, in: url)
+            let isEnabled =
+                try consumeArg("test-isEnabled", as: Bool.self, in: url)
 
             testTargets.append(
                 .init(
@@ -579,7 +580,7 @@ set
                         for: id,
                         context: "Test target"
                     ),
-                    enabled: enabled
+                    isEnabled: isEnabled
                 )
             )
         }

--- a/tools/generators/xcschemes/src/Generator/CreateCustomSchemeInfos.swift
+++ b/tools/generators/xcschemes/src/Generator/CreateCustomSchemeInfos.swift
@@ -158,8 +158,15 @@ private extension ArraySlice where Element == String {
                 file: file,
                 line: line
             ).nullsToNewlines
-            let enabled = try consumeArg(
-                "\(namePrefix)-arg-enabled",
+            let isEnabled = try consumeArg(
+                "\(namePrefix)-arg-isEnabled",
+                as: Bool.self,
+                in: url,
+                file: file,
+                line: line
+            )
+            let isLiteralString = try consumeArg(
+                "\(namePrefix)-arg-isLiteralString",
                 as: Bool.self,
                 in: url,
                 file: file,
@@ -167,7 +174,11 @@ private extension ArraySlice where Element == String {
             )
 
             commandLineArguments.append(
-                .init(value: value, enabled: enabled)
+                .init(
+                    value: value,
+                    isEnabled: isEnabled,
+                    isLiteralString: isLiteralString
+                )
             )
         }
 
@@ -208,8 +219,8 @@ private extension ArraySlice where Element == String {
                 file: file,
                 line: line
             ).nullsToNewlines
-            let enabled = try consumeArg(
-                "\(namePrefix)-env-var-enabled",
+            let isEnabled = try consumeArg(
+                "\(namePrefix)-env-var-isEnabled",
                 as: Bool.self,
                 in: url,
                 file: file,
@@ -217,7 +228,7 @@ private extension ArraySlice where Element == String {
             )
 
             environmentVariables.append(
-                .init(key: key, value: value, enabled: enabled)
+                .init(key: key, value: value, isEnabled: isEnabled)
             )
         }
 

--- a/tools/generators/xcschemes/src/Generator/CreateScheme.swift
+++ b/tools/generators/xcschemes/src/Generator/CreateScheme.swift
@@ -292,7 +292,7 @@ extension Generator.CreateScheme {
             testables.append(
                 .init(
                     buildableReference: buildableReference,
-                    skipped: !testTarget.enabled
+                    isSkipped: !testTarget.isEnabled
                 )
             )
         }

--- a/tools/generators/xcschemes/src/Generator/SchemeInfo.swift
+++ b/tools/generators/xcschemes/src/Generator/SchemeInfo.swift
@@ -48,7 +48,7 @@ struct SchemeInfo: Equatable {
 
     struct TestTarget: Equatable {
         let target: Target
-        let enabled: Bool
+        let isEnabled: Bool
     }
 
     struct Run: Equatable {

--- a/tools/generators/xcschemes/test/CreateAutomaticSchemeInfoTests.swift
+++ b/tools/generators/xcschemes/test/CreateAutomaticSchemeInfoTests.swift
@@ -272,8 +272,9 @@ final class CreateAutomaticSchemeInfoTests: XCTestCase {
             )
         )
         let commandLineArguments: [CommandLineArgument] = [
-            .init(value: "S", enabled: false),
-            .init(value: "A", enabled: true),
+            .init(value: "S", isEnabled: false),
+            .init(value: "A", isEnabled: true),
+            .init(value: "G A", isLiteralString: false),
         ]
 
         let expectedSchemeInfo = SchemeInfo(
@@ -345,8 +346,8 @@ final class CreateAutomaticSchemeInfoTests: XCTestCase {
             )
         )
         let environmentVariables: [EnvironmentVariable] = [
-            .init(key: "D", value: "999", enabled: true),
-            .init(key: "H", value: "2 2", enabled: false),
+            .init(key: "D", value: "999", isEnabled: true),
+            .init(key: "H", value: "2 2", isEnabled: false),
         ]
 
         let expectedSchemeInfo = SchemeInfo(
@@ -494,7 +495,7 @@ final class CreateAutomaticSchemeInfoTests: XCTestCase {
                 enableThreadSanitizer: false,
                 enableUBSanitizer: false,
                 environmentVariables: baseEnvironmentVariables,
-                testTargets: [.init(target: test, enabled: true)],
+                testTargets: [.init(target: test, isEnabled: true)],
                 useRunArgsAndEnv: false,
                 xcodeConfiguration: nil
             ),
@@ -547,8 +548,9 @@ final class CreateAutomaticSchemeInfoTests: XCTestCase {
             )
         )
         let commandLineArguments: [CommandLineArgument] = [
-            .init(value: "B", enabled: false),
-            .init(value: "F", enabled: true),
+            .init(value: "B", isEnabled: false),
+            .init(value: "G AA", isLiteralString: false),
+            .init(value: "F", isEnabled: true),
         ]
 
         let expectedSchemeInfo = SchemeInfo(
@@ -560,7 +562,7 @@ final class CreateAutomaticSchemeInfoTests: XCTestCase {
                 enableThreadSanitizer: false,
                 enableUBSanitizer: false,
                 environmentVariables: baseEnvironmentVariables,
-                testTargets: [.init(target: test, enabled: true)],
+                testTargets: [.init(target: test, isEnabled: true)],
                 useRunArgsAndEnv: false,
                 xcodeConfiguration: nil
             ),
@@ -614,8 +616,8 @@ final class CreateAutomaticSchemeInfoTests: XCTestCase {
             )
         )
         let environmentVariables: [EnvironmentVariable] = [
-            .init(key: "Z", value: "1", enabled: true),
-            .init(key: "A", value: "2", enabled: false),
+            .init(key: "Z", value: "1", isEnabled: true),
+            .init(key: "A", value: "2", isEnabled: false),
         ]
 
         let expectedSchemeInfo = SchemeInfo(
@@ -628,7 +630,7 @@ final class CreateAutomaticSchemeInfoTests: XCTestCase {
                 enableUBSanitizer: false,
                 environmentVariables:
                     baseEnvironmentVariables + environmentVariables,
-                testTargets: [.init(target: test, enabled: true)],
+                testTargets: [.init(target: test, isEnabled: true)],
                 useRunArgsAndEnv: false,
                 xcodeConfiguration: nil
             ),

--- a/tools/generators/xcschemes/test/CreateAutomaticSchemeInfosTests.swift
+++ b/tools/generators/xcschemes/test/CreateAutomaticSchemeInfosTests.swift
@@ -169,21 +169,22 @@ final class CreateAutomaticSchemeInfosTests: XCTestCase {
 
         let commandLineArguments: [TargetID: [CommandLineArgument]] = [
             "A": [
-                .init(value: "-v", enabled: true),
-                .init(value: "version", enabled: false),
+                .init(value: "-v", isEnabled: true),
+                .init(value: "version", isEnabled: false),
+                .init(value: "grouped arg", isLiteralString: false),
             ],
             "C": [],
-            "Z": [.init(value: "No", enabled: false)],
+            "Z": [.init(value: "No", isEnabled: false)],
         ]
         let customSchemeNames: Set<String> = [
             "Z",
         ]
         let environmentVariables: [TargetID: [EnvironmentVariable]] = [
             "B": [
-                .init(key: "VAR", value: "not enabled", enabled: false),
-                .init(key: "ENV VAR", value: "1", enabled: true),
+                .init(key: "VAR", value: "not enabled", isEnabled: false),
+                .init(key: "ENV VAR", value: "1", isEnabled: true),
             ],
-            "Z": [.init(key: "X", value: "No", enabled: false)],
+            "Z": [.init(key: "X", value: "No", isEnabled: false)],
         ]
         let extensionHostIDs: [TargetID : [TargetID]] = [
             "XyZ": ["3", "WWW"],
@@ -230,8 +231,9 @@ final class CreateAutomaticSchemeInfosTests: XCTestCase {
             ),
             .init(
                 commandLineArguments: [
-                    .init(value: "-v", enabled: true),
-                    .init(value: "version", enabled: false),
+                    .init(value: "-v", isEnabled: true),
+                    .init(value: "version", isEnabled: false),
+                    .init(value: "grouped arg", isLiteralString: false),
                 ],
                 customSchemeNames: customSchemeNames,
                 environmentVariables: [],
@@ -245,8 +247,8 @@ final class CreateAutomaticSchemeInfosTests: XCTestCase {
                 commandLineArguments: [],
                 customSchemeNames: customSchemeNames,
                 environmentVariables: [
-                    .init(key: "VAR", value: "not enabled", enabled: false),
-                    .init(key: "ENV VAR", value: "1", enabled: true),
+                    .init(key: "VAR", value: "not enabled", isEnabled: false),
+                    .init(key: "ENV VAR", value: "1", isEnabled: true),
                 ],
                 extensionHostIDs: extensionHostIDs,
                 target: .mock(key: "B", productType: .appExtension),

--- a/xcodeproj/internal/xcschemes/xcscheme_infos.bzl
+++ b/xcodeproj/internal/xcschemes/xcscheme_infos.bzl
@@ -10,7 +10,14 @@ load(
 
 # Constructors
 
-def _make_arg_env(value, *, enabled = TRUE_ARG):
+def _make_arg(value, *, enabled = TRUE_ARG, literal_string = TRUE_ARG):
+    return struct(
+        enabled = enabled,
+        literal_string = literal_string,
+        value = value,
+    )
+
+def _make_env(value, *, enabled = TRUE_ARG):
     return struct(
         enabled = enabled,
         value = value,
@@ -174,21 +181,33 @@ def _make_scheme(
 
 # JSON
 
-def _arg_env_info_from_dict(arg_env):
-    if type(arg_env) == "string":
-        return _make_arg_env(
-            value = arg_env,
+def _arg_info_from_dict(arg):
+    if type(arg) == "string":
+        return _make_arg(
+            value = arg,
         )
 
-    return _make_arg_env(
-        enabled = arg_env["enabled"],
-        value = arg_env["value"],
+    return _make_arg(
+        enabled = arg["enabled"],
+        literal_string = arg["literal_string"],
+        value = arg["value"],
+    )
+
+def _env_info_from_dict(env):
+    if type(env) == "string":
+        return _make_env(
+            value = env,
+        )
+
+    return _make_env(
+        enabled = env["enabled"],
+        value = env["value"],
     )
 
 def _arg_infos_from_list(args):
     if args == "inherit":
         return None
-    return [_arg_env_info_from_dict(arg) for arg in args]
+    return [_arg_info_from_dict(arg) for arg in args]
 
 def _build_target_infos_from_dict(
         build_target,
@@ -259,7 +278,7 @@ def _env_infos_from_dict(env):
     if env == "inherit":
         return None
     return {
-        key: _arg_env_info_from_dict(value)
+        key: _env_info_from_dict(value)
         for key, value in env.items()
     }
 
@@ -715,8 +734,9 @@ xcscheme_infos = struct(
 
 # These functions are exposed only for access in unit tests
 xcscheme_infos_testable = struct(
-    make_arg_env = _make_arg_env,
+    make_arg = _make_arg,
     make_build_target = _make_build_target,
+    make_env = _make_env,
     make_diagnostics = _make_diagnostics,
     make_launch_target = _make_launch_target,
     make_pre_post_action = _make_pre_post_action,

--- a/xcodeproj/internal/xcschemes/xcschemes.bzl
+++ b/xcodeproj/internal/xcschemes/xcschemes.bzl
@@ -1081,7 +1081,7 @@ _pre_post_actions = struct(
 
 # Other
 
-def _arg(value, *, enabled = True):
+def _arg(value, *, enabled = True, literal_string = True):
     """Defines a command-line argument.
 
     Args:
@@ -1096,6 +1096,13 @@ def _arg(value, *, enabled = True):
             If `True`, the checkbox for the argument will be
             checked in the scheme. An unchecked checkbox means Xcode won't
             include that argument when running a target.
+        literal_string: Whether `value` should be interpreted as a literal
+            string.
+
+            If `True`, any spaces will be escaped. This means that `value` will
+            be passed to the launch target as a single string. If `False`, any
+            spaces will not be escaped. This is useful to group multiple
+            arguments under a single checkbox in Xcode.
     """
     if not value:
         fail("""
@@ -1104,6 +1111,7 @@ def _arg(value, *, enabled = True):
 
     return struct(
         enabled = TRUE_ARG if enabled else FALSE_ARG,
+        literal_string = TRUE_ARG if literal_string else FALSE_ARG,
         value = value,
     )
 

--- a/xcodeproj/internal/xcschemes/xcschemes_execution.bzl
+++ b/xcodeproj/internal/xcschemes/xcschemes_execution.bzl
@@ -251,6 +251,7 @@ def _write_schemes(
         for arg in args:
             custom_scheme_args.add_all([arg.value], map_each = _null_newlines)
             custom_scheme_args.add(arg.enabled)
+            custom_scheme_args.add(arg.literal_string)
 
     # buildifier: disable=uninitialized
     def _add_build_targets(build_targets, *, action_name, scheme_name):


### PR DESCRIPTION
This allows having multiple arguments under a single checkbox in Xcode.

Also changes `enabled` and `skipped` to `isEnabled` and `isSkipped` to match Swift API naming guidelines.