### PR TITLE
Reduce work that incremental generation mode installer does for generated directories

### DIFF
--- a/tools/BUILD
+++ b/tools/BUILD
@@ -560,6 +560,7 @@ filegroup(
         "//" + package_name() + "/import_indexstores:release_files",
         "//" + package_name() + "/params_processors:release_files",
         "//" + package_name() + "/swiftc_stub:release_files",
+        "//" + package_name() + "/unique_directories:release_files",
         "//" + package_name() + "/xccurrentversions_parser:release_files",
     ],
     tags = ["manual"],

--- a/tools/unique_directories/BUILD
+++ b/tools/unique_directories/BUILD
@@ -1,0 +1,24 @@
+load("@rules_python//python:defs.bzl", "py_binary")
+
+py_binary(
+    name = "unique_directories",
+    srcs = ["unique_directories.py"],
+    python_version = "PY3",
+    srcs_version = "PY3",
+    # TODO: Restrict visibility
+    visibility = ["//visibility:public"],
+)
+
+# Release
+
+filegroup(
+    name = "release_files",
+    srcs = glob(
+        ["**"],
+        exclude = [
+            "**/.*",
+        ],
+    ),
+    tags = ["manual"],
+    visibility = ["//:__subpackages__"],
+)

--- a/tools/unique_directories/unique_directories.py
+++ b/tools/unique_directories/unique_directories.py
@@ -1,0 +1,37 @@
+#!/usr/bin/python3
+
+import os
+import sys
+
+def _insert_into_trie(trie, components):
+    if not components:
+        return
+    _insert_into_trie(trie.setdefault(components[0], {}), components[1:])
+
+def _trie_to_list(trie, prefix_components, output):
+    for component, sub_trie in trie.items():
+        if not sub_trie:
+            output.append(os.sep.join(prefix_components + [component]))
+        else:
+            _trie_to_list(sub_trie, prefix_components + [component], output)
+
+def _main(input_filelist, output_filelist):
+    trie = {}
+
+    with open(input_filelist, 'r', encoding='utf-8') as fp:
+        for directory in fp:
+            _insert_into_trie(trie, directory.rstrip().split(os.sep))
+
+    directories = []
+    _trie_to_list(trie, [], directories)
+
+    with open(output_filelist, 'w', encoding='utf-8') as fp:
+        fp.write("\n".join(directories))
+        fp.write("\n")
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("Usage: unique_directories.py <input.filelist> <output.filelist>")
+        exit(1)
+
+    _main(sys.argv[1], sys.argv[2])

--- a/xcodeproj/internal/files/incremental_input_files.bzl
+++ b/xcodeproj/internal/files/incremental_input_files.bzl
@@ -579,10 +579,7 @@ def _collect_incremental_input_files(
                     transitive = transitive_extra_files,
                 ),
                 extra_folders = extra_folders,
-                infoplist_path = (
-                    # Removing "bazel-out" prefix
-                    "$(BAZEL_OUT){}".format(infoplist.path[9:]) if infoplist else None
-                ),
+                infoplist = infoplist,
                 non_arc_srcs = memory_efficient_depset(non_arc_srcs),
                 srcs = memory_efficient_depset(srcs),
             ),

--- a/xcodeproj/internal/incremental_xcode_targets.bzl
+++ b/xcodeproj/internal/incremental_xcode_targets.bzl
@@ -27,7 +27,7 @@ def _from_resource_bundle(bundle):
             extra_files = bundle.resources,
             extra_file_paths = EMPTY_DEPSET,
             extra_folders = bundle.folder_resources,
-            infoplist_path = None,
+            infoplist = None,
             non_arc_srcs = EMPTY_DEPSET,
             srcs = EMPTY_DEPSET,
         ),
@@ -181,7 +181,7 @@ def _merge_xcode_inputs(*, dest_inputs, mergeable_info):
             ],
         ),
         extra_folders = dest_inputs.extra_folders,
-        infoplist_path = dest_inputs.infoplist_path,
+        infoplist = dest_inputs.infoplist,
         non_arc_srcs = mergeable_info.non_arc_srcs,
         srcs = mergeable_info.srcs,
     )

--- a/xcodeproj/internal/pbxproj_partials.bzl
+++ b/xcodeproj/internal/pbxproj_partials.bzl
@@ -49,11 +49,23 @@ def _keys_and_files(pair):
     key, file = pair
     return [key, file.path]
 
+def _dirname(file):
+    return file.dirname
+
+def _generated_dirname(file):
+    if file.is_source:
+        return None
+
+    return file.dirname
+
+def _always_generated_file_path(file):
+    return "$(BAZEL_OUT){}".format(file.path[9:])
+
 def _generated_file_path(file):
     if file.is_source:
         return None
 
-    return "$(BAZEL_OUT){}".format(file.path[9:])
+    return _always_generated_file_path(file)
 
 # Partials
 
@@ -517,18 +529,54 @@ def _write_files_and_groups(
         resolved_repositories_file,
     )
 
+def _write_generated_directories_filelist(
+        *,
+        actions,
+        generator_name,
+        infoplists,
+        install_path,
+        srcs,
+        tool):
+    directories_args = actions.args()
+    directories_args.set_param_file_format("multiline")
+    directories_args.use_param_file("%s", use_always = True)
+
+    directories_args.add_all(infoplists, map_each = _dirname)
+    directories_args.add_all(srcs, map_each = _generated_dirname)
+
+    filelist = actions.declare_file(
+        "{}-generated_directories.filelist".format(generator_name),
+    )
+
+    args = actions.args()
+    args.add(filelist)
+
+    message = (
+        "Generating {} generated directories filelist".format(install_path)
+    )
+
+    actions.run(
+        arguments = [directories_args, args],
+        executable = tool,
+        outputs = [filelist],
+        mnemonic = "WriteGeneratedDirectoriesFilelist",
+        progress_message = message,
+    )
+
+    return filelist
+
 def _write_generated_xcfilelist(
         *,
         actions,
         generator_name,
-        infoplist_paths,
+        infoplists,
         srcs):
     args = actions.args()
     args.set_param_file_format("multiline")
 
     # Info.plists are tracked as build files by Xcode, so top-level targets
     # will fail the first time they are built if we don't track them
-    args.add_all(infoplist_paths)
+    args.add_all(infoplists, map_each = _always_generated_file_path)
 
     # Source files are tracked as build files by Xcode, so building targets that
     # directly use generated source files will fail the first time they are
@@ -1316,6 +1364,9 @@ cat "$@" > "{output}"
 
 pbxproj_partials = struct(
     write_files_and_groups = _write_files_and_groups,
+    write_generated_directories_filelist = (
+        _write_generated_directories_filelist
+    ),
     write_generated_xcfilelist = _write_generated_xcfilelist,
     write_pbxproj_prefix = _write_pbxproj_prefix,
     write_pbxtargetdependencies = _write_pbxtargetdependencies,

--- a/xcodeproj/internal/templates/incremental_installer.sh
+++ b/xcodeproj/internal/templates/incremental_installer.sh
@@ -55,6 +55,7 @@ fi
 
 # Resolve the inputs
 readonly src_generated_xcfilelist="$PWD/%generated_xcfilelist%"
+readonly src_generated_directories_filelist="$PWD/%generated_directories_filelist%"
 readonly src_project_pbxproj="$PWD/%project_pbxproj%"
 readonly src_xcschememanagement="$PWD/%xcschememanagement%"
 readonly src_xcschemes="$PWD/%xcschemes%/"
@@ -179,21 +180,16 @@ readonly indexbuild_exec_root="$output_base/rules_xcodeproj.noindex/indexbuild_o
 mkdir -p "$indexbuild_exec_root"
 
 # Create folder structure in bazel-out to work around Xcode red generated files
-if [[ -f "$dest/rules_xcodeproj/generated.xcfilelist" ]]; then
+if [[ -s "$src_generated_directories_filelist" ]]; then
   cd "$BUILD_WORKSPACE_DIRECTORY"
 
-  readonly nested_build_output_base="$output_base/rules_xcodeproj.noindex/build_output_base"
-  readonly bazel_out="$nested_build_output_base/execroot/$workspace_name/bazel-out"
+  readonly nested_execution_root="$output_base/rules_xcodeproj.noindex/build_output_base/execroot/$workspace_name"
 
   # Create directory structure in bazel-out
-  cd "$bazel_out"
-  sed 's|^\$(BAZEL_OUT)\/\(.*\)\/[^\/]*$|\1|' \
-    "$dest/rules_xcodeproj/generated.xcfilelist" \
-    | uniq \
-    | while IFS= read -r dir
-  do
+  cd "$nested_execution_root"
+  while IFS= read -r dir; do
     mkdir -p "$dir"
-  done
+  done < "$src_generated_directories_filelist"
 fi
 
 echo 'Updated project at "%output_path%"'


### PR DESCRIPTION
A couple of optimizations:

- We create the list of generated directories with Bazel, allowing it to be cached
- The generated directories are the unique leaf directories, no longer including any intermediate parent directories. This is accomplished using a trie.