### PR TITLE
Make Starlark warnings not bold

### DIFF
--- a/xcodeproj/internal/logging.bzl
+++ b/xcodeproj/internal/logging.bzl
@@ -1,24 +1,25 @@
 """Logging utility functions."""
 
-def _colorize(text, color):
+def _colorize(text, color, *, bold):
     """Applies ANSI color codes around the given text."""
-    return "\033[1;{color}m{text}{reset}".format(
+    return "\033[{modifier};{color}m{text}{reset}".format(
         color = color,
+        modifier = "1" if bold else "0",
         reset = "\033[0m",
         text = text,
     )
 
-def green(text):
+def green(text, *, bold):
     """Applies the ANSI color code for green around the given text."""
-    return _colorize(text, "32")
+    return _colorize(text, "32", bold = bold)
 
-def magenta(text):
+def magenta(text, *, bold):
     """Applies the ANSI color code for magenta around the given text."""
-    return _colorize(text, "35")
+    return _colorize(text, "35", bold = bold)
 
-def yellow(text):
+def yellow(text, *, bold):
     """Applies the ANSI color code for yellow around the given text."""
-    return _colorize(text, "33")
+    return _colorize(text, "33", bold = bold)
 
 def warn(msg):
     """Outputs a warning message."""
@@ -26,5 +27,5 @@ def warn(msg):
     # buildifier: disable=print
     print("\n{prefix} {msg}\n".format(
         msg = msg,
-        prefix = magenta("WARNING:"),
+        prefix = magenta("WARNING:", bold = False),
     ))

--- a/xcodeproj/repositories.bzl
+++ b/xcodeproj/repositories.bzl
@@ -40,8 +40,8 @@ def _maybe(repo_rule, name, ignore_version_differences, **kwargs):
 {existing}. You may run into compatibility issues. To silence this warning, \
 pass `ignore_version_differences = True` to `xcodeproj_rules_dependencies()`.
 """.format(
-                    existing = yellow(existing),
-                    expected = green(expected),
+                    existing = yellow(existing, bold = True),
+                    expected = green(expected, bold = True),
                     repo = name,
                 ))
         return


### PR DESCRIPTION
Matches what Bazel does: https://github.com/bazelbuild/bazel/blob/c031fab778ea1c5df2101c20521aec7c9cd9c02b/src/main/java/com/google/devtools/build/lib/runtime/UiEventHandler.java#L506-L508