### PR TITLE
Stop collecting uncategorized files for unfocused targets

### DIFF
--- a/xcodeproj/internal/files/incremental_input_files.bzl
+++ b/xcodeproj/internal/files/incremental_input_files.bzl
@@ -693,6 +693,7 @@ def _collect_unsupported_input_files(
         attrs = attrs,
         cc_info = None,
         collect_uncategorized = (
+            include_extra_files and
             automatic_target_info.collect_uncategorized_files
         ),
         extra_files = extra_files,


### PR DESCRIPTION
Besides for being more memory efficient, this actually fixes an edge case where before some extra files were added for unfocused unsupported targets (e.g. a modulemap like rule that is referenced in a categorized attribute).

In the future we should probably rethink the “uncategorized files become extra files if the target is listed in a categorized attribute downstream” logic. I believe it was originally to show inputs of custom code gen rules, but I think that can be handled differently.