### PR TITLE
Use adjusted `Info.plist` for `extension_infoplists` in incremental generation mode

### DIFF
--- a/xcodeproj/internal/processed_targets/incremental_top_level_targets.bzl
+++ b/xcodeproj/internal/processed_targets/incremental_top_level_targets.bzl
@@ -529,16 +529,13 @@ def _process_focused_top_level_target(
         rule_attr = rule_attr,
     )
 
-    infoplists_attrs = automatic_target_info.infoplists
-    if (infoplists_attrs and bundle_info and
+    if (infoplist and bundle_info and
         bundle_info.bundle_extension == ".appex"):
         extension_infoplists = [
             struct(
                 id = id,
                 infoplist = infoplist,
-            )
-            for attr in infoplists_attrs
-            for infoplist in getattr(ctx.rule.files, attr, [])
+            ),
         ]
     else:
         extension_infoplists = None


### PR DESCRIPTION
1. Removes a use of `XcodeProjAutomaticTargetProcessingInfo.infoplists`
2. Uses the merged version, which can work around issues when people list multiple files in `infoplists
3. Pre-creates some `Info.plist` files, so the scheme icon and editor starts working sooner