### PR TITLE
Skip processing `exec` configuration targets in incremental generation mode

### DIFF
--- a/xcodeproj/internal/incremental_xcodeprojinfos.bzl
+++ b/xcodeproj/internal/incremental_xcodeprojinfos.bzl
@@ -716,10 +716,10 @@ def _make_xcodeprojinfo(
         `transitive_infos`.
     """
     if not _should_create_provider(
-            bin_dir_path = ctx.bin_dir.path,
-            rule_kind = rule_kind,
-            target = target
-        ):
+        bin_dir_path = ctx.bin_dir.path,
+        rule_kind = rule_kind,
+        target = target,
+    ):
         return None
 
     automatic_target_info = calculate_automatic_target_info(


### PR DESCRIPTION
We never want to include tool targets in the generated project.