### PR TITLE
Adjust order of `file_handlers` registration in incremental generation mode

### DIFF
--- a/xcodeproj/internal/files/incremental_input_files.bzl
+++ b/xcodeproj/internal/files/incremental_input_files.bzl
@@ -285,7 +285,6 @@ def _collect_incremental_input_files(
         avoid_deps = EMPTY_LIST,
         cc_info,
         framework_files = EMPTY_DEPSET,
-        id,
         infoplist = None,
         label,
         linker_inputs,
@@ -309,7 +308,6 @@ def _collect_incremental_input_files(
         framework_files: A `depset` of framework files from
             `AppleDynamicFramework.framework_files`, if the target has the
             `AppleDynamicFramework` provider.
-        id: A unique identifier for the target.
         infoplist: A `File` for a rules_xcodeproj modified Info.plist file, or
             None for non-top-level targets.
         label: The effective label of the target.

--- a/xcodeproj/internal/files/incremental_input_files.bzl
+++ b/xcodeproj/internal/files/incremental_input_files.bzl
@@ -309,8 +309,7 @@ def _collect_incremental_input_files(
         framework_files: A `depset` of framework files from
             `AppleDynamicFramework.framework_files`, if the target has the
             `AppleDynamicFramework` provider.
-        id: A unique identifier for the target. Will be `None` for non-Xcode
-            targets.
+        id: A unique identifier for the target.
         infoplist: A `File` for a rules_xcodeproj modified Info.plist file, or
             None for non-top-level targets.
         label: The effective label of the target.
@@ -423,24 +422,16 @@ def _collect_incremental_input_files(
 
     file_handlers = {}
 
-    if id:
-        for attr in automatic_target_info.srcs:
-            file_handlers[attr] = _handle_srcs_file
-        for attr in automatic_target_info.non_arc_srcs:
-            file_handlers[attr] = _handle_non_arc_srcs_file
-    else:
-        # Turn source files into extra files for non-Xcode targets
-        for attr in automatic_target_info.srcs:
-            file_handlers[attr] = _handle_extrafiles_file
-        for attr in automatic_target_info.non_arc_srcs:
-            file_handlers[attr] = _handle_extrafiles_file
-
+    for attr in automatic_target_info.extra_files:
+        file_handlers[attr] = _handle_extrafiles_file
+    for attr in automatic_target_info.srcs:
+        file_handlers[attr] = _handle_srcs_file
+    for attr in automatic_target_info.non_arc_srcs:
+        file_handlers[attr] = _handle_non_arc_srcs_file
     if automatic_target_info.entitlements:
         file_handlers[automatic_target_info.entitlements] = (
             _handle_entitlements_file
         )
-    for attr in automatic_target_info.extra_files:
-        file_handlers[attr] = _handle_extrafiles_file
 
     if swift_proto_info:
         additional_src_files = swift_proto_info.pbswift_files.to_list()

--- a/xcodeproj/internal/processed_targets/incremental_library_targets.bzl
+++ b/xcodeproj/internal/processed_targets/incremental_library_targets.bzl
@@ -110,7 +110,6 @@ def _process_incremental_library_target(
         attrs = attrs,
         automatic_target_info = automatic_target_info,
         cc_info = cc_info,
-        id = id,
         label = label,
         linker_inputs = linker_inputs,
         platform = platform,

--- a/xcodeproj/internal/processed_targets/incremental_top_level_targets.bzl
+++ b/xcodeproj/internal/processed_targets/incremental_top_level_targets.bzl
@@ -555,7 +555,6 @@ def _process_focused_top_level_target(
         avoid_deps = avoid_deps,
         cc_info = cc_info,
         framework_files = framework_files,
-        id = id,
         infoplist = infoplist,
         label = label,
         linker_inputs = linker_inputs,


### PR DESCRIPTION
This ensures that if an attribute is listed both in `XcodeProjAutomaticTargetProcessingInfo.extra_files` and another attribute, the other one takes precedence.

Also removes the `if id` check, since this flow will always have a non-`None` `id`.