### PR TITLE
Make `build_mode = "bazel"` when set to `None` or `""`

### DIFF
--- a/xcodeproj/internal/xcodeproj_macro.bzl
+++ b/xcodeproj/internal/xcodeproj_macro.bzl
@@ -406,7 +406,7 @@ removed in a future release.\
     if "PATH" not in bazel_env:
         bazel_env["PATH"] = "/bin:/usr/bin"
     if not build_mode:
-        build_mode = "xcode"
+        build_mode = "bazel"
     if install_directory == None:
         install_directory = native.package_name()
     if not project_name:


### PR DESCRIPTION
Missed in 0c3ad2bcddd84c91e7b61546918e08810de04a4f.