### PR TITLE
Stop including test hosts in schemes when `adjust_schemes_for_swiftui_previews = True`

### DIFF
--- a/test/internal/xcschemes/write_schemes_tests.bzl
+++ b/test/internal/xcschemes/write_schemes_tests.bzl
@@ -50,6 +50,7 @@ def _dict_to_xcode_target(d):
         product = struct(
             type = d["product_type"],
         ),
+        test_host = depset(d["test_host"]),
         transitive_dependencies = depset(d["transitive_dependencies"]),
     )
 
@@ -88,11 +89,13 @@ def _mock_xcode_target(
         id,
         apple_platform,
         product_type,
+        test_host = None,
         transitive_dependencies = []):
     return struct(
         id = id,
         apple_platform = apple_platform,
         product_type = product_type,
+        test_host = test_host,
         transitive_dependencies = transitive_dependencies,
     )
 

--- a/xcodeproj/internal/xcschemes/xcschemes_execution.bzl
+++ b/xcodeproj/internal/xcschemes/xcschemes_execution.bzl
@@ -193,10 +193,11 @@ def _write_schemes(
                 ids = [
                     id
                     for id in xcode_target.transitive_dependencies.to_list()
-                    if _is_same_platform_xcode_preview_target(
-                        platform = xcode_target.platform,
-                        xcode_target = xcode_targets.get(id),
-                    )
+                    if (id != xcode_target.test_host and
+                        _is_same_platform_xcode_preview_target(
+                            platform = xcode_target.platform,
+                            xcode_target = xcode_targets.get(id),
+                        ))
                 ]
                 if ids:
                     transitive_preview_targets_args.add(xcode_target.id)


### PR DESCRIPTION
Fixes #2990.

Including the test host can break some people’s workflows (e.g. a test host that is set to only compile for a certain target environment). Also, the test host is implicitly included in the scheme at the right action.

Other transitive dependencies are still built in the wrong action. In a future change we need to have test-based targets have their transitive dependencies listed under the test action, not run.