### PR TITLE
Set the correct actions for `transitivePreviewReferences`

### DIFF
--- a/tools/generators/xcschemes/src/Generator/CreateAutomaticSchemeInfo.swift
+++ b/tools/generators/xcschemes/src/Generator/CreateAutomaticSchemeInfo.swift
@@ -90,25 +90,31 @@ extension Generator.CreateAutomaticSchemeInfo {
 
         let testCommandLineArguments: [CommandLineArgument]
         let testEnvironmentVariables: [EnvironmentVariable]
+        let testTransitivePreviewReferences: [BuildableReference]
         let testUseRunArgsAndEnv: Bool
         let runCommandLineArguments: [CommandLineArgument]
         let runEnvironmentVariables: [EnvironmentVariable]
+        let runTransitivePreviewReferences: [BuildableReference]
         if isTest {
             testUseRunArgsAndEnv = false
             testCommandLineArguments = commandLineArguments
             testEnvironmentVariables =
                 .defaultEnvironmentVariables + environmentVariables
+            testTransitivePreviewReferences = transitivePreviewReferences
 
             runCommandLineArguments = []
             runEnvironmentVariables = []
+            runTransitivePreviewReferences = []
         } else {
             testUseRunArgsAndEnv = true
             testCommandLineArguments = []
             testEnvironmentVariables = []
+            testTransitivePreviewReferences = []
 
             runCommandLineArguments = commandLineArguments
             runEnvironmentVariables =
                 .defaultEnvironmentVariables + environmentVariables
+            runTransitivePreviewReferences = transitivePreviewReferences
         }
 
         return SchemeInfo(
@@ -122,6 +128,7 @@ extension Generator.CreateAutomaticSchemeInfo {
                 environmentVariables: testEnvironmentVariables,
                 testTargets: isTest ?
                     [.init(target: target, isEnabled: true)] : [],
+                transitivePreviewReferences: testTransitivePreviewReferences,
                 useRunArgsAndEnv: testUseRunArgsAndEnv,
                 xcodeConfiguration: nil
             ),
@@ -134,7 +141,7 @@ extension Generator.CreateAutomaticSchemeInfo {
                 enableUBSanitizer: false,
                 environmentVariables: runEnvironmentVariables,
                 launchTarget: launchTarget,
-                transitivePreviewReferences: transitivePreviewReferences,
+                transitivePreviewReferences: runTransitivePreviewReferences,
                 xcodeConfiguration: nil
             ),
             profile: .init(
@@ -143,6 +150,7 @@ extension Generator.CreateAutomaticSchemeInfo {
                 customWorkingDirectory: nil,
                 environmentVariables: [],
                 launchTarget: launchTarget,
+                transitivePreviewReferences: [],
                 useRunArgsAndEnv: true,
                 xcodeConfiguration: nil
             ),

--- a/tools/generators/xcschemes/src/Generator/CreateScheme.swift
+++ b/tools/generators/xcschemes/src/Generator/CreateScheme.swift
@@ -317,6 +317,12 @@ extension Generator.CreateScheme {
         for reference in schemeInfo.run.transitivePreviewReferences {
             adjustBuildActionEntry(for: reference, include: .running)
         }
+        for reference in schemeInfo.profile.transitivePreviewReferences {
+            adjustBuildActionEntry(for: reference, include: .profiling)
+        }
+        for reference in schemeInfo.test.transitivePreviewReferences {
+            adjustBuildActionEntry(for: reference, include: .testing)
+        }
 
         // MARK: Build
 

--- a/tools/generators/xcschemes/src/Generator/SchemeInfo.swift
+++ b/tools/generators/xcschemes/src/Generator/SchemeInfo.swift
@@ -30,6 +30,7 @@ struct SchemeInfo: Equatable {
         let customWorkingDirectory: String?
         let environmentVariables: [EnvironmentVariable]
         let launchTarget: LaunchTarget?
+        let transitivePreviewReferences: [BuildableReference]
         let useRunArgsAndEnv: Bool
         let xcodeConfiguration: String?
     }
@@ -42,6 +43,7 @@ struct SchemeInfo: Equatable {
         let enableUBSanitizer: Bool
         let environmentVariables: [EnvironmentVariable]
         let testTargets: [TestTarget]
+        let transitivePreviewReferences: [BuildableReference]
         let useRunArgsAndEnv: Bool
         let xcodeConfiguration: String?
     }

--- a/tools/generators/xcschemes/test/CreateAutomaticSchemeInfoTests.swift
+++ b/tools/generators/xcschemes/test/CreateAutomaticSchemeInfoTests.swift
@@ -135,6 +135,7 @@ final class CreateAutomaticSchemeInfoTests: XCTestCase {
                 enableUBSanitizer: false,
                 environmentVariables: [],
                 testTargets: [],
+                transitivePreviewReferences: [],
                 useRunArgsAndEnv: true,
                 xcodeConfiguration: nil
             ),
@@ -162,6 +163,7 @@ final class CreateAutomaticSchemeInfoTests: XCTestCase {
                     primary: launchable,
                     extensionHost: nil
                 ),
+                transitivePreviewReferences: [],
                 useRunArgsAndEnv: true,
                 xcodeConfiguration: nil
             ),
@@ -213,6 +215,7 @@ final class CreateAutomaticSchemeInfoTests: XCTestCase {
                 enableUBSanitizer: false,
                 environmentVariables: [],
                 testTargets: [],
+                transitivePreviewReferences: [],
                 useRunArgsAndEnv: true,
                 xcodeConfiguration: nil
             ),
@@ -240,6 +243,7 @@ final class CreateAutomaticSchemeInfoTests: XCTestCase {
                     primary: launchable,
                     extensionHost: extensionHost
                 ),
+                transitivePreviewReferences: [],
                 useRunArgsAndEnv: true,
                 xcodeConfiguration: nil
             ),
@@ -287,6 +291,7 @@ final class CreateAutomaticSchemeInfoTests: XCTestCase {
                 enableUBSanitizer: false,
                 environmentVariables: [],
                 testTargets: [],
+                transitivePreviewReferences: [],
                 useRunArgsAndEnv: true,
                 xcodeConfiguration: nil
             ),
@@ -314,6 +319,7 @@ final class CreateAutomaticSchemeInfoTests: XCTestCase {
                     primary: launchable,
                     extensionHost: nil
                 ),
+                transitivePreviewReferences: [],
                 useRunArgsAndEnv: true,
                 xcodeConfiguration: nil
             ),
@@ -360,6 +366,7 @@ final class CreateAutomaticSchemeInfoTests: XCTestCase {
                 enableUBSanitizer: false,
                 environmentVariables: [],
                 testTargets: [],
+                transitivePreviewReferences: [],
                 useRunArgsAndEnv: true,
                 xcodeConfiguration: nil
             ),
@@ -388,6 +395,7 @@ final class CreateAutomaticSchemeInfoTests: XCTestCase {
                     primary: launchable,
                     extensionHost: nil
                 ),
+                transitivePreviewReferences: [],
                 useRunArgsAndEnv: true,
                 xcodeConfiguration: nil
             ),
@@ -432,6 +440,7 @@ final class CreateAutomaticSchemeInfoTests: XCTestCase {
                 enableUBSanitizer: false,
                 environmentVariables: [],
                 testTargets: [],
+                transitivePreviewReferences: [],
                 useRunArgsAndEnv: true,
                 xcodeConfiguration: nil
             ),
@@ -453,6 +462,7 @@ final class CreateAutomaticSchemeInfoTests: XCTestCase {
                 customWorkingDirectory: nil,
                 environmentVariables: [],
                 launchTarget: nil,
+                transitivePreviewReferences: [],
                 useRunArgsAndEnv: true,
                 xcodeConfiguration: nil
             ),
@@ -496,6 +506,7 @@ final class CreateAutomaticSchemeInfoTests: XCTestCase {
                 enableUBSanitizer: false,
                 environmentVariables: baseEnvironmentVariables,
                 testTargets: [.init(target: test, isEnabled: true)],
+                transitivePreviewReferences: [],
                 useRunArgsAndEnv: false,
                 xcodeConfiguration: nil
             ),
@@ -517,6 +528,7 @@ final class CreateAutomaticSchemeInfoTests: XCTestCase {
                 customWorkingDirectory: nil,
                 environmentVariables: [],
                 launchTarget: nil,
+                transitivePreviewReferences: [],
                 useRunArgsAndEnv: true,
                 xcodeConfiguration: nil
             ),
@@ -563,6 +575,7 @@ final class CreateAutomaticSchemeInfoTests: XCTestCase {
                 enableUBSanitizer: false,
                 environmentVariables: baseEnvironmentVariables,
                 testTargets: [.init(target: test, isEnabled: true)],
+                transitivePreviewReferences: [],
                 useRunArgsAndEnv: false,
                 xcodeConfiguration: nil
             ),
@@ -584,6 +597,7 @@ final class CreateAutomaticSchemeInfoTests: XCTestCase {
                 customWorkingDirectory: nil,
                 environmentVariables: [],
                 launchTarget: nil,
+                transitivePreviewReferences: [],
                 useRunArgsAndEnv: true,
                 xcodeConfiguration: nil
             ),
@@ -631,6 +645,7 @@ final class CreateAutomaticSchemeInfoTests: XCTestCase {
                 environmentVariables:
                     baseEnvironmentVariables + environmentVariables,
                 testTargets: [.init(target: test, isEnabled: true)],
+                transitivePreviewReferences: [],
                 useRunArgsAndEnv: false,
                 xcodeConfiguration: nil
             ),
@@ -652,6 +667,7 @@ final class CreateAutomaticSchemeInfoTests: XCTestCase {
                 customWorkingDirectory: nil,
                 environmentVariables: [],
                 launchTarget: nil,
+                transitivePreviewReferences: [],
                 useRunArgsAndEnv: true,
                 xcodeConfiguration: nil
             ),

--- a/tools/generators/xcschemes/test/SchemeInfo+Testing.swift
+++ b/tools/generators/xcschemes/test/SchemeInfo+Testing.swift
@@ -27,6 +27,7 @@ extension SchemeInfo.Profile {
         customWorkingDirectory: String? = nil,
         environmentVariables: [EnvironmentVariable] = [],
         launchTarget: SchemeInfo.LaunchTarget? = nil,
+        transitivePreviewReferences: [BuildableReference] = [],
         useRunArgsAndEnv: Bool = true,
         xcodeConfiguration: String? = nil
     ) -> Self {
@@ -36,6 +37,7 @@ extension SchemeInfo.Profile {
             customWorkingDirectory: customWorkingDirectory,
             environmentVariables: environmentVariables,
             launchTarget: launchTarget,
+            transitivePreviewReferences: transitivePreviewReferences,
             useRunArgsAndEnv: useRunArgsAndEnv,
             xcodeConfiguration: xcodeConfiguration
         )
@@ -80,6 +82,7 @@ extension SchemeInfo.Test {
         enableUBSanitizer: Bool = false,
         environmentVariables: [EnvironmentVariable] = [],
         testTargets: [SchemeInfo.TestTarget] = [],
+        transitivePreviewReferences: [BuildableReference] = [],
         useRunArgsAndEnv: Bool = true,
         xcodeConfiguration: String? = nil
     ) -> Self {
@@ -91,6 +94,7 @@ extension SchemeInfo.Test {
             enableUBSanitizer: enableUBSanitizer,
             environmentVariables: environmentVariables,
             testTargets: testTargets,
+            transitivePreviewReferences: transitivePreviewReferences,
             useRunArgsAndEnv: useRunArgsAndEnv,
             xcodeConfiguration: xcodeConfiguration
         )


### PR DESCRIPTION
This means that if a target is listed as a Profile action, its `transitivePreviewReferences` will also be Profile actions.