### PR TITLE
Add `module.bazel_compatibility` to reflect our minimum supported Bazel version

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,7 @@
 module(
     name = "rules_xcodeproj",
     version = "0.0.0",
+    bazel_compatibility = [">=6.3.0"],
     compatibility_level = 1,
     repo_name = "rules_xcodeproj",
 )


### PR DESCRIPTION
This improves the error experience for Bzlmod users using something less than Bazel 6.3.0.