### PR TITLE
Remove `--noincompatible_struct_has_no_methods`

### DIFF
--- a/bazel_8.bazelrc
+++ b/bazel_8.bazelrc
@@ -1,2 +1,0 @@
-# Disabled until new rules_apple and rules_swift releases
-common --noincompatible_struct_has_no_methods


### PR DESCRIPTION
It no longer exists at Bazel HEAD.