### PR TITLE
Fix markdown highlighting in xcschemes.diagnostics descriptions

### DIFF
--- a/docs/bazel.md
+++ b/docs/bazel.md
@@ -251,8 +251,8 @@ Defines the diagnostics to enable.
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="xcschemes.diagnostics-address_sanitizer"></a>address_sanitizer |  Whether to enable Address Sanitizer.<br><br>If `True`, [`thread_sanitizer`](#xcschemes.diagnostics-thread_sanitizer) must be `False.   |  `False` |
-| <a id="xcschemes.diagnostics-thread_sanitizer"></a>thread_sanitizer |  Whether to enable Thread Sanitizer.<br><br>If `True`, [`address_sanitizer`](#xcschemes.diagnostics-address_sanitizer) must be `False.   |  `False` |
+| <a id="xcschemes.diagnostics-address_sanitizer"></a>address_sanitizer |  Whether to enable Address Sanitizer.<br><br>If `True`, [`thread_sanitizer`](#xcschemes.diagnostics-thread_sanitizer) must be `False`.   |  `False` |
+| <a id="xcschemes.diagnostics-thread_sanitizer"></a>thread_sanitizer |  Whether to enable Thread Sanitizer.<br><br>If `True`, [`address_sanitizer`](#xcschemes.diagnostics-address_sanitizer) must be `False`.   |  `False` |
 | <a id="xcschemes.diagnostics-undefined_behavior_sanitizer"></a>undefined_behavior_sanitizer |  Whether to enable Undefined Behavior Sanitizer.   |  `False` |
 
 

--- a/xcodeproj/internal/xcschemes/xcschemes.bzl
+++ b/xcodeproj/internal/xcschemes/xcschemes.bzl
@@ -1157,12 +1157,12 @@ def _diagnostics(
 
             If `True`,
             [`thread_sanitizer`](#xcschemes.diagnostics-thread_sanitizer) must
-            be `False.
+            be `False`.
         thread_sanitizer: Whether to enable Thread Sanitizer.
 
             If `True`,
             [`address_sanitizer`](#xcschemes.diagnostics-address_sanitizer) must
-            be `False.
+            be `False`.
         undefined_behavior_sanitizer: Whether to enable Undefined Behavior
             Sanitizer.
     """


### PR DESCRIPTION
While going through the documentation, I noticed two missing \` characters. This pull request adds the missing \` characters and fixes the markdown highlighting for those values.