### PR TITLE
Fix handling of multiple `associated_extra_files` per target in incremental generation mode

### DIFF
--- a/examples/integration/iOSApp/BUILD
+++ b/examples/integration/iOSApp/BUILD
@@ -1,6 +1,9 @@
 load("@build_bazel_rules_apple//apple:versioning.bzl", "apple_bundle_version")
 
-exports_files(["info.yaml", "ownership.yaml"])
+exports_files([
+    "info.yaml",
+    "ownership.yaml",
+])
 
 alias(
     name = "iOSApp",

--- a/examples/integration/iOSApp/BUILD
+++ b/examples/integration/iOSApp/BUILD
@@ -1,6 +1,6 @@
 load("@build_bazel_rules_apple//apple:versioning.bzl", "apple_bundle_version")
 
-exports_files(["ownership.yaml"])
+exports_files(["info.yaml", "ownership.yaml"])
 
 alias(
     name = "iOSApp",

--- a/examples/integration/iOSApp/info.yaml
+++ b/examples/integration/iOSApp/info.yaml
@@ -1,0 +1,1 @@
+something: else

--- a/examples/integration/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -893,6 +893,7 @@
 		482456516779904CDD4DA956 /* iOSAppObjCUnitTests.library.rules_xcodeproj.c.compile.params */ = {isa = PBXFileReference; lastKnownFileType = file; path = iOSAppObjCUnitTests.library.rules_xcodeproj.c.compile.params; sourceTree = "<group>"; };
 		485D8BAA235AA808A00AB5DE /* MixedAnswerLib_Swift.rules_xcodeproj.swift.compile.params */ = {isa = PBXFileReference; lastKnownFileType = file; path = MixedAnswerLib_Swift.rules_xcodeproj.swift.compile.params; sourceTree = "<group>"; };
 		4881EEC5A32BE56448E19924 /* UITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITests.swift; sourceTree = "<group>"; };
+		48B32C677050A403BA366899 /* info.yaml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = info.yaml; sourceTree = "<group>"; };
 		48BD809D7C49CFD4CFCD3B78 /* Entitlements.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Entitlements.entitlements; sourceTree = "<group>"; };
 		4942A330FF2FA587642E6328 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		49B87A833795719D198FB69C /* tool.rules_xcodeproj.c.compile.params */ = {isa = PBXFileReference; lastKnownFileType = file; path = tool.rules_xcodeproj.c.compile.params; sourceTree = "<group>"; };
@@ -1870,6 +1871,7 @@
 				DCB6BFF3C69016E83D11EB51 /* Source */,
 				551CC24E6A60EE2911D166D5 /* Test */,
 				5DE7AF00D3B4EA3E8ED7D9C8 /* BUILD */,
+				48B32C677050A403BA366899 /* info.yaml */,
 				83AFCF96795D66ECA00B0EF0 /* ownership.yaml */,
 			);
 			path = iOSApp;

--- a/examples/integration/test/fixtures/bwb_project_spec.json
+++ b/examples/integration/test/fixtures/bwb_project_spec.json
@@ -458,6 +458,7 @@
         "iOSApp/Test/TestingUtils/Greeting.swift.stencil",
         "iOSApp/Test/TestingUtils/merge.sh",
         "iOSApp/Test/UITests/BUILD",
+        "iOSApp/info.yaml",
         "iOSApp/ownership.yaml",
         "macOSApp/Source/BUILD",
         "macOSApp/Source/Info.plist",

--- a/examples/integration/test/fixtures/generated/xcodeproj_bwb/BUILD
+++ b/examples/integration/test/fixtures/generated/xcodeproj_bwb/BUILD
@@ -24,7 +24,7 @@ xcodeproj(
     ios_device_cpus = "arm64",
     ios_simulator_cpus = "",
     minimum_xcode_version = "13.0",
-    owned_extra_files = {"@@//Lib:README.md": "@@//Lib:Lib", "@@//iOSApp:ownership.yaml": "@@//iOSApp/Source:iOSApp"},
+    owned_extra_files = {"@@//Lib:README.md": "@@//Lib:Lib", "@@//iOSApp:info.yaml": "@@//iOSApp/Source:iOSApp", "@@//iOSApp:ownership.yaml": "@@//iOSApp/Source:iOSApp"},
     post_build = """""",
     pre_build = """set -euo pipefail
 

--- a/examples/integration/xcodeproj_targets.bzl
+++ b/examples/integration/xcodeproj_targets.bzl
@@ -69,7 +69,10 @@ FAIL_FOR_INVALID_EXTRA_FILES_TARGETS = True
 
 ASSOCIATED_EXTRA_FILES = {
     "//Lib": ["//Lib:README.md"],
-    "//iOSApp/Source:iOSApp": ["//iOSApp:ownership.yaml"],
+    "//iOSApp/Source:iOSApp": [
+        "//iOSApp:info.yaml",
+        "//iOSApp:ownership.yaml",
+    ],
 }
 
 UNFOCUSED_TARGETS = [

--- a/xcodeproj/internal/xcodeproj_incremental_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_incremental_rule.bzl
@@ -121,10 +121,11 @@ def _collect_files(
         unowned_extra_files,
         unsupported_extra_files,
         xcode_targets):
-    target_extra_files = {
-        target_label_str: files_target.files
-        for files_target, target_label_str in owned_extra_files.items()
-    }
+    target_extra_files = {}
+    for files_target, target_label_str in owned_extra_files.items():
+        target_extra_files.setdefault(target_label_str, []).append(
+            files_target.files,
+        )
 
     all_targets = xcode_targets.values() + resource_bundle_xcode_targets
 
@@ -143,9 +144,9 @@ def _collect_files(
 
         label = xcode_target.label
         if label:
-            extra_files = target_extra_files.get(str(label))
-            if extra_files:
-                transitive_files.append(extra_files)
+            extra_files_list = target_extra_files.get(str(label))
+            if extra_files_list:
+                transitive_files.extend(extra_files_list)
 
         infoplist = xcode_target.inputs.infoplist
         if infoplist:


### PR DESCRIPTION
Fixes #3009. Closes #3010.

Also added an example.