### PR TITLE
Expand `SUPPORTED_PLATFORMS` for application extensions

### DIFF
--- a/tools/generators/pbxnativetargets/src/Generator/CreateXcodeConfigurations.swift
+++ b/tools/generators/pbxnativetargets/src/Generator/CreateXcodeConfigurations.swift
@@ -155,11 +155,11 @@ extension Generator.CreateXcodeConfigurations {
         let sharedBuildSettings = calculateSharedBuildSettings(
             name: name,
             label: label,
-            productType: productType,
-            productName: productName,
             platforms: OrderedSet(
                 platformVariants.map(\.platform).sorted()
             ),
+            productType: productType,
+            productName: productName,
             uiTestHostName: uiTestHostName
         )
 

--- a/tools/generators/pbxnativetargets/test/Generator/CalculateSharedBuildSettingsTests.swift
+++ b/tools/generators/pbxnativetargets/test/Generator/CalculateSharedBuildSettingsTests.swift
@@ -157,6 +157,8 @@ class CalculateSharedBuildSettingsTests: XCTestCase {
 
         let platforms: OrderedSet<Platform> = [
             .tvOSSimulator,
+            .visionOSDevice,
+            .visionOSSimulator,
             .macOS,
             .watchOSDevice,
             .iOSSimulator,
@@ -167,7 +169,7 @@ class CalculateSharedBuildSettingsTests: XCTestCase {
         // function
         let expectedBuildSettings = baseBuildSettings.updating([
             "SDKROOT": "appletvos",
-            "SUPPORTED_PLATFORMS": #""appletvsimulator appletvos macosx watchos iphonesimulator iphoneos""#,
+            "SUPPORTED_PLATFORMS": #""appletvsimulator appletvos xros xrsimulator macosx watchos iphonesimulator iphoneos""#,
             "SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD": "NO",
         ])
 

--- a/tools/generators/pbxnativetargets/test/Generator/CalculateSharedBuildSettingsTests.swift
+++ b/tools/generators/pbxnativetargets/test/Generator/CalculateSharedBuildSettingsTests.swift
@@ -152,6 +152,40 @@ class CalculateSharedBuildSettingsTests: XCTestCase {
         )
     }
 
+    func test_platforms_appExtension() {
+        // Arrange
+
+        let platforms: OrderedSet<Platform> = [
+            .tvOSSimulator,
+            .macOS,
+            .watchOSDevice,
+            .iOSSimulator,
+        ]
+        let productType = PBXProductType.appExtension
+
+        // Order is wrong, but it shows that we don't do sorting in this
+        // function
+        let expectedBuildSettings = baseBuildSettings.updating([
+            "SDKROOT": "appletvos",
+            "SUPPORTED_PLATFORMS": #""appletvsimulator appletvos macosx watchos iphonesimulator iphoneos""#,
+            "SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD": "NO",
+        ])
+
+        // Act
+
+        let buildSettings = calculateSharedBuildSettingsWithDefaults(
+            platforms: platforms,
+            productType: productType
+        )
+
+        // Assert
+
+        XCTAssertNoDifference(
+            buildSettings.asDictionary,
+            expectedBuildSettings
+        )
+    }
+
     func test_staticFramework() {
         // Arrange
 
@@ -237,17 +271,17 @@ class CalculateSharedBuildSettingsTests: XCTestCase {
 private func calculateSharedBuildSettingsWithDefaults(
         name: String = "A",
         label: BazelLabel = "@//A",
+        platforms: OrderedSet<Platform> = [.macOS],
         productType: PBXProductType = .staticLibrary,
         productName: String = "product_name",
-        platforms: OrderedSet<Platform> = [.macOS],
         uiTestHostName: String? = nil
 ) -> [BuildSetting] {
     return Generator.CalculateSharedBuildSettings.defaultCallable(
         name: name,
         label: label,
+        platforms: platforms,
         productType: productType,
         productName: productName,
-        platforms: platforms,
         uiTestHostName: uiTestHostName
     )
 }


### PR DESCRIPTION
Fixes #2979.

Xcode has a bug where if we don't include device platforms in app extension targets, then it will fail to install the hosting application.