### PR TITLE
Respect "Continue building after errors" setting

### DIFF
--- a/xcodeproj/internal/bazel_integration_files/generate_bazel_dependencies.sh
+++ b/xcodeproj/internal/bazel_integration_files/generate_bazel_dependencies.sh
@@ -140,6 +140,8 @@ fi
 continue_building_value="$(defaults read com.apple.dt.Xcode IDEBuildingContinueBuildingAfterErrors 2>/dev/null)"
 if [ "$continue_building_value" == "1" ]; then
   build_pre_config_flags+=("--keep_going")
+else
+  build_pre_config_flags+=("--nokeep_going")
 fi
 
 # Runtime Sanitizers

--- a/xcodeproj/internal/bazel_integration_files/generate_bazel_dependencies.sh
+++ b/xcodeproj/internal/bazel_integration_files/generate_bazel_dependencies.sh
@@ -136,6 +136,12 @@ else
   readonly config="_${BAZEL_CONFIG}_build"
 fi
 
+# Respect the "Continue building after errors" setting
+continue_building_value="$(defaults read com.apple.dt.Xcode IDEBuildingContinueBuildingAfterErrors 2>/dev/null)"
+if [ "$continue_building_value" == "1" ]; then
+  build_pre_config_flags+=("--keep_going")
+fi
+
 # Runtime Sanitizers
 if [[ $apply_sanitizers -eq 1 ]]; then
   if [ "${ENABLE_ADDRESS_SANITIZER:-}" == "YES" ]; then


### PR DESCRIPTION
Add the `--keep_going` flag to builds when the "Continue building after errors" flag is set. Maybe there's a better place to add this, but I think it would be nice to respect the setting in the IDE.

![pasted_image_4_29_24__11_45___am_720](https://github.com/MobileNativeFoundation/rules_xcodeproj/assets/925850/859996f2-6775-4496-8639-98d41b4eb3a4)