### PR TITLE
Fix `associated_extra_files` when multiple targets own the same file

### DIFF
--- a/examples/integration/test/fixtures/generated/xcodeproj_bwb/BUILD
+++ b/examples/integration/test/fixtures/generated/xcodeproj_bwb/BUILD
@@ -23,7 +23,7 @@ xcodeproj(
     ios_device_cpus = "arm64",
     ios_simulator_cpus = "",
     minimum_xcode_version = "13.0",
-    owned_extra_files = {"@@//Lib:README.md": "@@//Lib:Lib", "@@//iOSApp:info.yaml": "@@//iOSApp/Source:iOSApp", "@@//iOSApp:ownership.yaml": "@@//iOSApp/Source:iOSApp"},
+    owned_extra_files = {"@@//Lib:README.md": "[\"@@//Lib:Lib\",\"@@//Lib:ios_Lib\"]", "@@//iOSApp:info.yaml": "[\"@@//iOSApp/Source:iOSApp\"]", "@@//iOSApp:ownership.yaml": "[\"@@//iOSApp/Source:iOSApp\"]"},
     post_build = """""",
     pre_build = """set -euo pipefail
 

--- a/examples/integration/xcodeproj_targets.bzl
+++ b/examples/integration/xcodeproj_targets.bzl
@@ -69,6 +69,7 @@ FAIL_FOR_INVALID_EXTRA_FILES_TARGETS = True
 
 ASSOCIATED_EXTRA_FILES = {
     "//Lib": ["//Lib:README.md"],
+    "//Lib:ios_Lib": ["//Lib:README.md"],
     "//iOSApp/Source:iOSApp": [
         "//iOSApp:info.yaml",
         "//iOSApp:ownership.yaml",

--- a/xcodeproj/internal/xcodeproj_incremental_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_incremental_rule.bzl
@@ -122,10 +122,11 @@ def _collect_files(
         unsupported_extra_files,
         xcode_targets):
     target_extra_files = {}
-    for files_target, target_label_str in owned_extra_files.items():
-        target_extra_files.setdefault(target_label_str, []).append(
-            files_target.files,
-        )
+    for files_target, target_label_strs_json in owned_extra_files.items():
+        for target_label_str in json.decode(target_label_strs_json):
+            target_extra_files.setdefault(target_label_str, []).append(
+                files_target.files,
+            )
 
     all_targets = xcode_targets.values() + resource_bundle_xcode_targets
 

--- a/xcodeproj/internal/xcodeproj_macro.bzl
+++ b/xcodeproj/internal/xcodeproj_macro.bzl
@@ -498,9 +498,14 @@ configuration alphabetically ("{default}").
     owned_extra_files = {}
     for label, files in associated_extra_files.items():
         for f in files:
-            owned_extra_files[bazel_labels.normalize_string(f)] = (
-                bazel_labels.normalize_string(label)
-            )
+            owned_extra_files.setdefault(
+                bazel_labels.normalize_string(f),
+                [],
+            ).append(bazel_labels.normalize_string(label))
+    owned_extra_files = {
+        f: json.encode(labels)
+        for f, labels in owned_extra_files.items()
+    }
 
     unowned_extra_files = [
         bazel_labels.normalize_string(f)


### PR DESCRIPTION
Fixes #3021.

We fake a `labed_keyed_list_dict` by JSON encoding the list into a string and use `label_keyed_string_dict`.