### PR TITLE
Fix mistranslation of external sources

### DIFF
--- a/tools/import_indexstores/ImportIndexstores.swift
+++ b/tools/import_indexstores/ImportIndexstores.swift
@@ -127,7 +127,7 @@ Intermediates\.noindex/Previews/[^/]*/Intermediates\.noindex
             }
 
             let xcodeOutputBase = xcodeExecutionRoot
-                .split(separator: "/")
+                .split(separator: "/", omittingEmptySubsequences: false)
                 .dropLast(2)
                 .joined(separator: "/")
 


### PR DESCRIPTION
Remapping of external sources in the index is done by replacing the path with `xcodeOutputBase`, which is built by removing paths from `xcodeExecutionRoot`. However, when `split()` is called, the leading `/` from `xcodeExecutionRoot` is lost, which was causing `index-import` to not translate these files correctly.

<img width="798" alt="Screenshot 2024-05-16 at 15 57 02" src="https://github.com/MobileNativeFoundation/rules_xcodeproj/assets/11647449/801563a0-9fca-4674-93e8-a6989fe32ad0">
