### PR TITLE
Force `USE_BAZEL_VERSION` to working SHA until last_green is fixed

### DIFF
--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -23,7 +23,7 @@ x_templates:
         USE_BAZEL_VERSION: 7.x
     - &bazel_head
       env:
-        USE_BAZEL_VERSION: last_green
+        USE_BAZEL_VERSION: dd2464a5933e0a5a6765024573832717b71989bf
 
     - &normal_resources
       resource_requests: { memory: 6GB }

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -23,6 +23,9 @@ x_templates:
         USE_BAZEL_VERSION: 7.x
     - &bazel_head
       env:
+        # See https://github.com/MobileNativeFoundation/rules_xcodeproj/pull/3029
+        #
+        # Temporary change to make CI pass until the fix is in `last_green`
         USE_BAZEL_VERSION: dd2464a5933e0a5a6765024573832717b71989bf
 
     - &normal_resources


### PR DESCRIPTION
There are at least two issues causing CI to be 🔴 atm:

1. [See example](https://mnf.buildbuddy.io/invocation/92c4f0ed-72f3-4cf7-a941-43ae28448acb?target=%2F%2FLib%3Agen_Lib.swift&targetStatus=3#@1). Repro:
```sh
cd examples/integration
bazel clean && USE_BAZEL_VERSION=last_green bazel build //Lib:gen_Lib.swift
```
2. [See example](https://mnf.buildbuddy.io/invocation/f51fedc6-8204-4707-8954-a1ea1f40bf35#@191). Repro:
```sh
# From root
bazel clean && USE_BAZEL_VERSION=last_green bazel build //test/internal/bazel_labels:normalize_tests_test_2
```

I confirmed that https://github.com/bazelbuild/bazel/commit/dd2464a5933e0a5a6765024573832717b71989bf is the last commit that does not hit the issues above. Commit https://github.com/bazelbuild/bazel/commit/3fddc7f38ace43981d839ed4558b8a457caf41fb is the first one that repros the above (i.e. you'll also hit the issues above if you replace `last_green` with this SHA).

So proposing we force CI to run on https://github.com/bazelbuild/bazel/commit/dd2464a5933e0a5a6765024573832717b71989bf for now until the issue is fixed upstream. Thoughts?