### PR TITLE
Force bazel_version in `update_all_fixtures.sh` to working SHA

### DIFF
--- a/test/update_all_fixtures.sh
+++ b/test/update_all_fixtures.sh
@@ -13,7 +13,10 @@ for dir in examples/*/ ; do
     if [[ "$dir" == "examples/rules_ios/" ]]; then
       bazel_version="7.1.1"
     else
-      bazel_version="last_green"
+      # See https://github.com/MobileNativeFoundation/rules_xcodeproj/pull/3029
+      #
+      # Temporary change to make CI pass until the fix is in `last_green`
+      bazel_version="dd2464a5933e0a5a6765024573832717b71989bf"
     fi
 
     echo


### PR DESCRIPTION
Similar to: https://github.com/MobileNativeFoundation/rules_xcodeproj/pull/3029

Currently the `./test/update_all_fixtures.sh` script is failing with error (in `main`):
```sh
FATAL: bazel crashed due to an internal error. Printing stack trace:
java.lang.RuntimeException: Unrecoverable error while evaluating node 'ConfiguredTargetKey{label=@@rules_apple~//apple/internal:environment_plist_macos, config=BuildConfigurationKey[b9d3bb9e7707500dae32d8b693576ca2a5d5e2f8c0d56fe0957bab54bf751df7]}' (requested by nodes 'ConfiguredTargetKey{label=//GRPC:echo_client, config=BuildConfigurationKey[b9d3bb9e7707500dae32d8b693576ca2a5d5e2f8c0d56fe0957bab54bf751df7]}', 'ConfiguredTargetKey{label=//GRPC:echo_client.merged_infoplist, config=BuildConfigurationKey[b9d3bb9e7707500dae32d8b693576ca2a5d5e2f8c0d56fe0957bab54bf751df7]}', 'ConfiguredTargetKey{label=//Proto:proto, config=BuildConfigurationKey[b9d3bb9e7707500dae32d8b693576ca2a5d5e2f8c0d56fe0957bab54bf751df7]}', 'ConfiguredTargetKey{label=//Proto:proto.merged_infoplist, config=BuildConfigurationKey[b9d3bb9e7707500dae32d8b693576ca2a5d5e2f8c0d56fe0957bab54bf751df7]}', 'ConfiguredTargetKey{label=//GRPC:echo_server, config=BuildConfigurationKey[b9d3bb9e7707500dae32d8b693576ca2a5d5e2f8c0d56fe0957bab54bf751df7]}', 'ConfiguredTargetKey{label=//GRPC:echo_server.merged_infoplist, config=BuildConfigurationKey[b9d3bb9e7707500dae32d8b693576ca2a5d5e2f8c0d56fe0957bab54bf751df7]}')
        at com.google.devtools.build.skyframe.AbstractParallelEvaluator$Evaluate.run(AbstractParallelEvaluator.java:557)
        at com.google.devtools.build.lib.concurrent.AbstractQueueVisitor$WrappedRunnable.run(AbstractQueueVisitor.java:426)
        at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(Unknown Source)
        at java.base/java.util.concurrent.ForkJoinTask.doExec(Unknown Source)
        at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(Unknown Source)
        at java.base/java.util.concurrent.ForkJoinPool.scan(Unknown Source)
        at java.base/java.util.concurrent.ForkJoinPool.runWorker(Unknown Source)
        at java.base/java.util.concurrent.ForkJoinWorkerThread.run(Unknown Source)
Caused by: net.starlark.java.eval.Starlark$UncheckedEvalException: IllegalArgumentException thrown during Starlark evaluation (@@rules_apple~//apple/internal:environment_plist_macos)
        at <starlark>.multi_arch_platform(<builtin>:0)
        at <starlark>._platform_prerequisites(/Users/thiago/Development/MobileNativeFoundation/rules_xcodeproj/examples/integration/bazel-output-base/rules_xcodeproj.noindex/build_output_base/external/rules_apple~/apple/internal/platform_support.bzl:96)
        at <starlark>._environment_plist_impl(/Users/thiago/Development/MobileNativeFoundation/rules_xcodeproj/examples/integration/bazel-output-base/rules_xcodeproj.noindex/build_output_base/external/rules_apple~/apple/internal/environment_plist.bzl:52)
Caused by: java.lang.IllegalArgumentException: Expected post-split-transition platform type macos to match input macos
```

Keeping an eye on it until the fix is in `last_green`, but working around it for now to unblock development in `main`.