### PR TITLE
Bump rules_ios to 4.6.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -73,7 +73,7 @@ single_version_override(
 # For Stardoc
 single_version_override(
     module_name = "bazel_skylib",
-    version = "1.5.0",
+    version = "1.6.0",
 )
 
 apple_cc_configure = use_extension(

--- a/examples/rules_ios/MODULE.bazel
+++ b/examples/rules_ios/MODULE.bazel
@@ -20,7 +20,7 @@ bazel_dep(
 )
 bazel_dep(
     name = "rules_ios",
-    version = "4.4.0",
+    version = "4.6.0",
     repo_name = "build_bazel_rules_ios",
 )
 

--- a/examples/rules_ios/WORKSPACE
+++ b/examples/rules_ios/WORKSPACE
@@ -2,8 +2,8 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "build_bazel_rules_ios",
-    sha256 = "eccb4509a820204b80260bde9f5d6ec989d5dd12fdc96fc480bd39c7ff5596d6",
-    url = "https://github.com/bazel-ios/rules_ios/releases/download/4.4.0/rules_ios.4.4.0.tar.gz",
+    sha256 = "c417b69639a737eb44e2af13309f1b00950d6d0c48f67c64ee36d3ea750f687e",
+    url = "https://github.com/bazel-ios/rules_ios/releases/download/4.6.0/rules_ios.4.6.0.tar.gz",
 )
 
 load(


### PR DESCRIPTION
Also bump the Stardoc `bazel_skylib` dep to the [first version containing @@bazel_skylib~//lib:modules.bzl](https://github.com/bazelbuild/bazel-skylib/commit/553c08dc60d550b7ec70ba80ecd91b8f6e563877) to fix [this CI failure](https://mnf.buildbuddy.io/invocation/6d48b88b-9c2d-40c4-b1ec-84630ab6585c#@4).