### PR TITLE
Fix incremental project generation swift debugging

### DIFF
--- a/tools/generators/target_build_settings/src/Generator/ProcessSwiftArgs.swift
+++ b/tools/generators/target_build_settings/src/Generator/ProcessSwiftArgs.swift
@@ -161,7 +161,7 @@ extension Generator.ProcessSwiftArgs {
             return (false, [], [], [], [])
         }
         _ = try await iterator.next()
-        
+
         var args: [String] = [
             // Work around stubbed swiftc messing with Indexing setting of
             // `-working-directory` incorrectly

--- a/tools/generators/target_build_settings/src/Generator/ProcessSwiftArgs.swift
+++ b/tools/generators/target_build_settings/src/Generator/ProcessSwiftArgs.swift
@@ -160,7 +160,8 @@ extension Generator.ProcessSwiftArgs {
         else {
             return (false, [], [], [], [])
         }
-
+        _ = try await iterator.next()
+        
         var args: [String] = [
             // Work around stubbed swiftc messing with Indexing setting of
             // `-working-directory` incorrectly


### PR DESCRIPTION
Incremental project generation mode was not setting swift debug settings when top level target (e.g. ios application) is an Obj-c target. This change should fix the issue. 

Before : lldb > `settings show target.swift-extra-clang-flags` is empty 
After : lldb > `settings show target.swift-extra-clang-flags` is not empty 