### PR TITLE
xctest-dynamic-overlay → swift-issue-reporting

### DIFF
--- a/xcodeproj/repositories.bzl
+++ b/xcodeproj/repositories.bzl
@@ -390,8 +390,8 @@ swift_library(
     visibility = ["//visibility:public"],
 )
 """,
-        sha256 = "97169124feb98b409f5b890bd95bb147c2fba0dba3098f9bf24c539270ee9601",
-        strip_prefix = "xctest-dynamic-overlay-0.2.1",
+        sha256 = "1ebde9c9403d5befb6956556e26f9308000722f7da9e87fed2e770d3918d647c",
+        strip_prefix = "swift-issue-reporting-0.2.1",
         url = "https://github.com/pointfreeco/xctest-dynamic-overlay/archive/refs/tags/0.2.1.tar.gz",
         ignore_version_differences = ignore_version_differences,
     )


### PR DESCRIPTION
This dependency has been renamed, and the archive has since been regenerated. Consequently, the new archive contains the new folder prefix.