### PR TITLE
Make indexbuild macos QoS 'utility' by default

### DIFF
--- a/xcodeproj/internal/templates/bazel_build.sh
+++ b/xcodeproj/internal/templates/bazel_build.sh
@@ -48,10 +48,13 @@ if [ "$ACTION" == "indexbuild" ]; then
   # Use current path for "bazel-out/" and "external/"
   # This fixes Index Build to use its version of generated and external files
   readonly vfs_overlay_roots="{\"external-contents\": \"$output_path\",\"name\": \"$BAZEL_OUT\",\"type\": \"directory-remap\"},{\"external-contents\": \"$output_base/external\",\"name\": \"$BAZEL_EXTERNAL\",\"type\": \"directory-remap\"}"
+
+  readonly indexbuild_startup_flag="--macos_qos_class=utility"
 else
   readonly output_base="$build_output_base"
   readonly output_path="$BAZEL_OUT"
   readonly vfs_overlay_roots=""
+  readonly indexbuild_startup_flag=""
 fi
 
 # Set `bazel_cmd` for calling `bazel`
@@ -79,6 +82,8 @@ readonly bazel_cmd=(
   "${bazelrcs[@]}"
 
   --output_base "$output_base"
+
+  "$indexbuild_startup_flag"
 )
 
 readonly base_pre_config_flags=(


### PR DESCRIPTION
**What changed?**
- Adds startup flag to set index builds MacOS QoS to `utility` by default

**Why did it change?**
- Developers have reported excessive battery usage related to background indexing

**How is it tested?**
- Added debug statements to the `bazel_build.sh` to see the startup flag being added for index builds
- I was unable to directly confirm (via my macbook) that the java process was actually set to utility - open to suggestions on how to do this.