### PR TITLE
Use only the debug settings from the most-downstream Swift target

### DIFF
--- a/xcodeproj/internal/processed_targets/incremental_library_targets.bzl
+++ b/xcodeproj/internal/processed_targets/incremental_library_targets.bzl
@@ -151,7 +151,7 @@ def _process_incremental_library_target(
         transitive = [
             info.swift_debug_settings
             for info in transitive_infos
-        ],
+        ] if not swift_debug_settings_file else None,
         order = "topological",
     )
 

--- a/xcodeproj/internal/processed_targets/incremental_library_targets.bzl
+++ b/xcodeproj/internal/processed_targets/incremental_library_targets.bzl
@@ -152,7 +152,6 @@ def _process_incremental_library_target(
             info.swift_debug_settings
             for info in transitive_infos
         ] if not swift_debug_settings_file else None,
-        order = "topological",
     )
 
     if apple_common.AppleDebugOutputs in target:

--- a/xcodeproj/internal/processed_targets/incremental_top_level_targets.bzl
+++ b/xcodeproj/internal/processed_targets/incremental_top_level_targets.bzl
@@ -421,7 +421,6 @@ def _process_focused_top_level_target(
                 info.swift_debug_settings
                 for info in deps_infos
             ],
-            order = "topological",
         )
 
         top_level_focused_deps = [
@@ -749,7 +748,6 @@ def _process_unfocused_top_level_target(
             # FIXME: Exclude `avoid_deps`
             for info in deps_infos
         ],
-        order = "topological",
     )
 
     (

--- a/xcodeproj/internal/processed_targets/incremental_unsupported_targets.bzl
+++ b/xcodeproj/internal/processed_targets/incremental_unsupported_targets.bzl
@@ -128,7 +128,6 @@ def _process_incremental_unsupported_target(
                 info.swift_debug_settings
                 for info in transitive_infos
             ],
-            order = "topological",
         ),
         target_output_groups = output_groups.merge(
             transitive_infos = transitive_infos,

--- a/xcodeproj/internal/processed_targets/mergeable_infos.bzl
+++ b/xcodeproj/internal/processed_targets/mergeable_infos.bzl
@@ -257,13 +257,7 @@ def _mixed_language_mergeable_info(
             ],
         ),
         swift_args = swift.args.swift,
-        swift_debug_settings_to_merge = memory_efficient_depset(
-            transitive = [
-                swift.swift_debug_settings,
-                cc.swift_debug_settings,
-            ],
-            order = "topological",
-        ),
+        swift_debug_settings_to_merge = swift.swift_debug_settings,
     )
 
 def _swift_mergeable_info(


### PR DESCRIPTION
This prevents settings which are specific to a particular Swift module compilation, such as clang module maps in a mixed-language library, from getting accumulated with the public settings. Before this change using `mixed_language_library` would result in module redefinition errors in lldb.

I’m not sure if this has a chance of not setting some flags that would need to be set. In local testing everything worked, but as with all things lldb, wider user testing is needed. Ideally long term we can use serialized debug info instead (and/or explicit modules).

**Note:** For this to work the best, the single dep of a top-level target needs to be a `swift_library` or `mixed_language_target`. This change might result in lldb regressions for custom setups that don't meet that requirement.