### PR TITLE
Filter environment variables when building with Bazel

### DIFF
--- a/xcodeproj/internal/templates/bazel_build.sh
+++ b/xcodeproj/internal/templates/bazel_build.sh
@@ -68,8 +68,23 @@ if [[ -s "$BAZEL_INTEGRATION_DIR/xcodeproj_extra_flags.bazelrc" ]]; then
 fi
 readonly bazelrcs
 
+readonly allowed_vars=(
+  "BUILD_WORKSPACE_DIRECTORY"
+  "DEVELOPER_DIR"
+  "HOME"
+  "TERM"
+  "USER"
+)
+passthrough_env=()
+for var in "${allowed_vars[@]}"; do
+  if [[ -n "${!var:-}" ]]; then
+    passthrough_env+=("$var=${!var}")
+  fi
+done
+
 readonly bazel_cmd=(
-  env
+  env -i
+  "${passthrough_env[@]}"
 %bazel_env%
   "%bazel_path%"
 

--- a/xcodeproj/internal/templates/runner.sh
+++ b/xcodeproj/internal/templates/runner.sh
@@ -178,8 +178,23 @@ common:rules_xcodeproj --repo_env=USE_CLANG_CL=%xcode_version%
 common:rules_xcodeproj --repo_env=XCODE_VERSION=%xcode_version%
 EOF
 
+readonly allowed_vars=(
+  "BUILD_WORKSPACE_DIRECTORY"
+  "HOME"
+  "TERM"
+  "USER"
+)
+passthrough_env=()
+for var in "${allowed_vars[@]}"; do
+  if [[ -n "${!var:-}" ]]; then
+    passthrough_env+=("$var=${!var}")
+  fi
+done
+
 bazel_cmd=(
-  env
+  env -i
+  "DEVELOPER_DIR=$developer_dir"
+  "${passthrough_env[@]}"
   "${envs[@]}"
   "$bazel_path"
 


### PR DESCRIPTION
In order for Xcode builds to work with custom environment variables you need to use `xcodeproj.bazel_env`. This just takes the extra step of filtering out all other environment variables, ensuring more analysis cache hits. You can already do this in your own `tools/bazel`, but now people can get the benefit regardless.

This change is needed for shared outputs bases to be performant.