### PR TITLE
Align the various `--experimental_remote_download_regex` flags

### DIFF
--- a/xcodeproj/internal/bazel_integration_files/generate_bazel_dependencies.sh
+++ b/xcodeproj/internal/bazel_integration_files/generate_bazel_dependencies.sh
@@ -117,11 +117,12 @@ build_pre_config_flags=(
   # - .a and .swiftmodule files for lldb
   # - primary compilation input files (.c, .C, .cc, .cl, .cpp, .cu, .cxx, .c++,
   #   .m, .mm, .swift) for Xcode build input checking
+  # - files needed for Clang importer (headers, modulemaps, yaml files, etc.)
   #
   # This is brittle. If different file extensions are used for compilation
   # inputs, they will need to be added to this list. Ideally we can stop doing
   # this once Bazel adds support for a Remote Output Service.
-  "--experimental_remote_download_regex=.*\.indexstore/.*|.*\.(a|c|C|cc|cl|cpp|cu|cxx|c++|h|H|hh|hpp|hxx|h++|inc|inl|ipp|m|mm|swift|swiftdoc|swiftmodule|swiftsourceinfo|tcc|tlh|tli)$"
+  "--experimental_remote_download_regex=.*\.indexstore/.*|.*\.(a|cfg|c|C|cc|cl|cpp|cu|cxx|c++|def|h|H|hh|hpp|hxx|h++|hmap|ilc|inc|inl|ipp|tcc|tlh|tli|tpp|m|modulemap|mm|pch|swift|swiftdoc|swiftmodule|swiftsourceinfo|yaml)$"
 )
 
 apply_sanitizers=1

--- a/xcodeproj/internal/bazel_integration_files/generate_index_build_bazel_dependencies.sh
+++ b/xcodeproj/internal/bazel_integration_files/generate_index_build_bazel_dependencies.sh
@@ -64,7 +64,7 @@ readonly build_pre_config_flags=(
   # This is brittle. If different file extensions are used for compilation
   # inputs, they will need to be added to this list. Ideally we can stop doing
   # this once Bazel adds support for a Remote Output Service.
-  "--experimental_remote_download_regex=.*\.indexstore/.*|.*\.(cfg|c|C|cc|cl|cpp|cu|cxx|c++|def|h|H|hh|hpp|hxx|h++|hmap|ilc|inc|ipp|tcc|tlh|tpp|m|modulemap|mm|pch|swift|swiftdoc|swiftmodule|swiftsourceinfo|yaml)$"
+  "--experimental_remote_download_regex=.*\.indexstore/.*|.*\.(cfg|c|C|cc|cl|cpp|cu|cxx|c++|def|h|H|hh|hpp|hxx|h++|hmap|ilc|inc|inl|ipp|tcc|tlh|tli|tpp|m|modulemap|mm|pch|swift|swiftdoc|swiftmodule|swiftsourceinfo|yaml)$"
 )
 
 source "$BAZEL_INTEGRATION_DIR/bazel_build.sh"

--- a/xcodeproj/internal/templates/runner.sh
+++ b/xcodeproj/internal/templates/runner.sh
@@ -226,7 +226,7 @@ else
   if [[ $cmd == "build" && -n "${generator_output_groups:-}" ]]; then
     if [[ $download_intermediates -eq 1 ]]; then
       pre_config_flags=(
-        "--experimental_remote_download_regex=.*\.indexstore/.*|.*\.(a|c|C|cc|cl|cpp|cu|cxx|c++|h|H|hh|hpp|hxx|h++|inc|inl|ipp|m|mm|swift|swiftdoc|swiftmodule|swiftsourceinfo|tcc|tlh|tli)$"
+        "--experimental_remote_download_regex=.*\.indexstore/.*|.*\.(a|cfg|c|C|cc|cl|cpp|cu|cxx|c++|def|h|H|hh|hpp|hxx|h++|hmap|ilc|inc|inl|ipp|tcc|tlh|tli|tpp|m|modulemap|mm|pch|swift|swiftdoc|swiftmodule|swiftsourceinfo|yaml)$"
       )
     else
       pre_config_flags=()


### PR DESCRIPTION
Ensures the right files are always downloaded, everywhere.