### PR TITLE
Stop un-exporting environment variables

### DIFF
--- a/xcodeproj/internal/bazel_integration_files/generate_index_build_bazel_dependencies.sh
+++ b/xcodeproj/internal/bazel_integration_files/generate_index_build_bazel_dependencies.sh
@@ -2,20 +2,6 @@
 
 set -euo pipefail
 
-# Reset tool overrides, so `bazel` sees the correct version. This is needed
-# for rules_swift_package_manager to work correctly. We do this here as well as
-# in `BazelDependencies` build settings, because we need the overrides at the
-# target level, so we can't unset any target build settings, and we don't want
-# to do it only in `bazel_build.sh`, because we want pre/post-build scripts to
-# get the reset in `BazelDependencies`.
-export CC=
-export CXX=
-export LD=
-export LDPLUSPLUS=
-export LIBTOOL=libtool
-export SWIFT_EXEC=swiftc
-export TAPI_EXEC=
-
 cd "$SRCROOT"
 
 readonly config="${BAZEL_CONFIG}_indexbuild"

--- a/xcodeproj/internal/templates/bazel_build.sh
+++ b/xcodeproj/internal/templates/bazel_build.sh
@@ -22,12 +22,6 @@
 output_groups_flag="--output_groups=$(IFS=, ; echo "${output_groups[*]}")"
 readonly output_groups_flag
 
-# Un-export Xcode set environment variables that mess up Bazel rules. If a user
-# wants these values to be set for their build, they need to use
-# `xcodeproj.bazel_env`.
-export -n LD_LIBRARY_PATH
-export -n SDKROOT
-
 # Set `output_base`
 
 # In `runner.sh` the generator has the build output base set inside of the outer


### PR DESCRIPTION
No longer needed since we now filter out all environment variables for `bazel build`.