### PR TITLE
Pass through `SSH_AUTH_SOCK` to Bazel

### DIFF
--- a/xcodeproj/internal/templates/bazel_build.sh
+++ b/xcodeproj/internal/templates/bazel_build.sh
@@ -47,6 +47,7 @@ readonly allowed_vars=(
   "BUILD_WORKSPACE_DIRECTORY"
   "DEVELOPER_DIR"
   "HOME"
+  "SSH_AUTH_SOCK"
   "TERM"
   "USER"
 )

--- a/xcodeproj/internal/templates/runner.sh
+++ b/xcodeproj/internal/templates/runner.sh
@@ -181,6 +181,7 @@ EOF
 readonly allowed_vars=(
   "BUILD_WORKSPACE_DIRECTORY"
   "HOME"
+  "SSH_AUTH_SOCK"
   "TERM"
   "USER"
 )


### PR DESCRIPTION
Needed for ssh-based git operations.