### PR TITLE
Expand "Make" variables inside of values in the env dictionary on test rules

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -10,13 +10,13 @@ bazel_dep(name = "bazel_features", version = "1.3.0")
 bazel_dep(name = "bazel_skylib", version = "1.3.0")
 bazel_dep(
     name = "rules_swift",
-    version = "1.6.0",
+    version = "1.18.0",
     max_compatibility_level = 2,
     repo_name = "build_bazel_rules_swift",
 )
 bazel_dep(
     name = "rules_apple",
-    version = "2.0.0",
+    version = "3.6.0",
     repo_name = "build_bazel_rules_apple",
 )
 bazel_dep(name = "rules_python", version = "0.27.1")


### PR DESCRIPTION
Fixes #3056

This PR implements a gap introduced when bazelbuild/rules_apple#2476 was introduced, where expandable env settings on test rules would not be expanded into the xcscheme during generation. There are a couple of things that reviewers should be aware of before proceeding with this change:

- This change is not considerate of the rules_apple being used, meaning that it assumes the developer is using at least version [3.6.0](https://github.com/bazelbuild/rules_apple/releases/tag/3.6.0) (when the breaking changes in #2476 were introduced). This is not good and should be considered a blocker, but I don't know how to address this with the tools offered by the ruleset or Bazel.
- This change as-implemented requires regeneration of the xcschemes if the configured value of the "Make" variable ever changes.

