### PR TITLE
Add rules_ios example depending on `swift_library`

### DIFF
--- a/examples/rules_ios/LibTwo/BUILD.bazel
+++ b/examples/rules_ios/LibTwo/BUILD.bazel
@@ -1,0 +1,39 @@
+load(
+    "@build_bazel_rules_ios//rules:framework.bzl",
+    rules_ios_apple_framework = "apple_framework",
+)
+load(
+    "@build_bazel_rules_ios//rules:test.bzl",
+    rules_ios_unit_test = "ios_unit_test",
+)
+load(
+    "@build_bazel_rules_swift//swift:swift.bzl",
+    "swift_library",
+    "swift_library_group",
+)
+
+rules_ios_apple_framework(
+    name = "LibTwo",
+    srcs = ["Sources/LibTwo.swift"],
+    platforms = {"ios": "15.0"},
+    deps = [
+        ":External",
+    ],
+    visibility = ["@rules_xcodeproj//xcodeproj:generated"],
+)
+
+rules_ios_unit_test(
+    name = "LibTwoTests",
+    srcs = ["Tests/LibTwoTests.swift"],
+    minimum_os_version = "15.0",
+    deps = [
+        ":LibTwo",
+    ],
+    visibility = ["@rules_xcodeproj//xcodeproj:generated"],
+)
+
+swift_library(
+    name = "External",
+    srcs = ["External/External.swift"],
+    module_name = "External",
+)

--- a/examples/rules_ios/LibTwo/External/External.swift
+++ b/examples/rules_ios/LibTwo/External/External.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+public struct External {
+    public var text = "Hello, World from External!"
+
+    public init() {}
+}

--- a/examples/rules_ios/LibTwo/Sources/LibTwo.swift
+++ b/examples/rules_ios/LibTwo/Sources/LibTwo.swift
@@ -1,0 +1,6 @@
+import External
+
+public enum LibTwo {
+    public static let text = "Hello, World!"
+    public static let external = External()
+}

--- a/examples/rules_ios/LibTwo/Tests/LibTwoTests.swift
+++ b/examples/rules_ios/LibTwo/Tests/LibTwoTests.swift
@@ -1,0 +1,9 @@
+import XCTest
+
+@testable import LibTwo
+
+final class LibTwoTests: XCTestCase {
+    func testExample() throws {
+        XCTAssertEqual(LibTwo.text, "Hello, World!")
+    }
+}

--- a/examples/rules_ios/xcodeproj_targets.bzl
+++ b/examples/rules_ios/xcodeproj_targets.bzl
@@ -26,6 +26,7 @@ XCODEPROJ_TARGETS = [
     "//iOSApp/Test/ObjCUnitTests:iOSAppObjCUnitTestSuite_macro",
     "//iOSApp/Test/UITests:iOSAppUITests_macro",
     "//iOSApp/Test/UITests:iOSAppUITestSuite_macro",
+    "//LibTwo:LibTwoTests",
 ]
 
 IOS_BUNDLE_ID = "rules-xcodeproj.example"
@@ -50,6 +51,22 @@ XCSCHEMES = [
                         ),
                     ],
                 ),
+            ],
+        ),
+    ),
+    xcschemes.scheme(
+        name = "LibTwo_Scheme",
+        run = xcschemes.run(
+            build_targets = [
+                "//LibTwo",
+            ],
+        ),
+        test = xcschemes.test(
+            build_targets = [
+                "//LibTwo",
+            ],
+            test_targets = [
+                "//LibTwo:LibTwoTests",
             ],
         ),
     ),


### PR DESCRIPTION
Adds an example to the rules_ios fixture for showcasing a target merging bug.

Reproducing the issue:

1. `cd examples/rules_ios`
2. `bazel run //:xcodeproj-incremental`
3. `xed rules_ios.xcodeproj`
4. Select the `LibTwo_Scheme` target
5. Attempt to build the target
6. Observe the failure:

  ```
  /path/_CompileStub_.m Build input file cannot be found: '/path/_CompileStub_.m'.
  Did you forget to declare this file as an output of a script phase or custom build rule which produces it?
  ```

This is happening because in the `LibTwo_Scheme` the target selected is `LibTwo (Static Framework)` when it should be `LibTwo (Library)` which builds fine. This only happens when `swift_library` is directly used as a `deps` of the `apple_framework` target. Target merging fails here and you end up with two `LibTwo` targets in the generated Xcode project.