### PR TITLE
Fix xctest-dynamic-overlay checksum after project renamed

### DIFF
--- a/xcodeproj/repositories.bzl
+++ b/xcodeproj/repositories.bzl
@@ -390,7 +390,7 @@ swift_library(
     visibility = ["//visibility:public"],
 )
 """,
-        sha256 = "97169124feb98b409f5b890bd95bb147c2fba0dba3098f9bf24c539270ee9601",
+        sha256 = "1ebde9c9403d5befb6956556e26f9308000722f7da9e87fed2e770d3918d647c",
         strip_prefix = "xctest-dynamic-overlay-0.2.1",
         url = "https://github.com/pointfreeco/xctest-dynamic-overlay/archive/refs/tags/0.2.1.tar.gz",
         ignore_version_differences = ignore_version_differences,

--- a/xcodeproj/repositories.bzl
+++ b/xcodeproj/repositories.bzl
@@ -391,7 +391,7 @@ swift_library(
 )
 """,
         sha256 = "1ebde9c9403d5befb6956556e26f9308000722f7da9e87fed2e770d3918d647c",
-        strip_prefix = "xctest-dynamic-overlay-0.2.1",
+        strip_prefix = "swift-issue-reporting-0.2.1",
         url = "https://github.com/pointfreeco/xctest-dynamic-overlay/archive/refs/tags/0.2.1.tar.gz",
         ignore_version_differences = ignore_version_differences,
     )


### PR DESCRIPTION
`xctest-dynamic-overlay` has been renamed into `swift-issue-reporting` which somehow affected the sha256 resulting in a build error during fetch.