### PR TITLE
Add proper support for the `processed` resource type

### DIFF
--- a/tools/generators/files_and_groups/src/Generator/ReadFilePathsFile.swift
+++ b/tools/generators/files_and_groups/src/Generator/ReadFilePathsFile.swift
@@ -31,7 +31,11 @@ extension Generator.ReadFilePathsFile {
     static func defaultCallable(
         _ url: URL
     ) async throws -> [BazelPath] {
-        return try await url.lines.collect()
+        // The file can have at most 1 duplicate for each entry because of
+        // preprocessed resource files being represented as file paths, while
+        // they can also be an input to another action (e.g. codegen). Because
+        // of this we use a `Set` to deduplicate the paths.
+        return Set(try await url.lines.collect())
             .map { BazelPath($0, isFolder: false) }
     }
 }

--- a/xcodeproj/internal/incremental_xcode_targets.bzl
+++ b/xcodeproj/internal/incremental_xcode_targets.bzl
@@ -25,7 +25,7 @@ def _from_resource_bundle(bundle):
         inputs = struct(
             entitlements = EMPTY_DEPSET,
             extra_files = bundle.resources,
-            extra_file_paths = EMPTY_DEPSET,
+            extra_file_paths = bundle.resource_file_paths,
             extra_folders = bundle.folder_resources,
             extra_generated_folders = bundle.generated_folder_resources,
             infoplist = None,


### PR DESCRIPTION
This effectively adds support for the `apple_precompiled_resource_bundle` rule, which extensively uses the `processed` resource type.

This is only supported by the incremental generation mode.