### PR TITLE
Create param files with absolute path 

### DIFF
--- a/tools/generators/target_build_settings/README.md
+++ b/tools/generators/target_build_settings/README.md
@@ -15,6 +15,7 @@ The generator accepts the following command-line arguments:
 - If `swift-debug-settings-output-path` is set: positional `include-self-swift-debug-settings`
 - If `swift-debug-settings-output-path` is set: positional `transitive-swift-debug-setting-paths-count`
 - If `swift-debug-settings-output-path` is set: positional list `<transitive-swift-debug-setting-paths> ...`
+- Positional `execution-root-file-path`
 - Positional `device-family`
 - Positional `extension-safe`
 - Positional `generates-dsyms`

--- a/tools/generators/target_build_settings/src/Generator/Generator.swift
+++ b/tools/generators/target_build_settings/src/Generator/Generator.swift
@@ -48,13 +48,16 @@ struct Generator {
             transitiveSwiftDebugSettingPaths = []
         }
 
+        let executionRootFilePath = try rawArguments.consumeArg("execution-root-file-path", as: URL?.self)
+
         let (buildSettings, clangArgs, frameworkIncludes, swiftIncludes) =
             try await environment.processArgs(
                 rawArguments: rawArguments,
                 generateBuildSettings: buildSettingsOutputPath != nil,
                 includeSelfSwiftDebugSettings: includeSelfSwiftDebugSettings,
                 transitiveSwiftDebugSettingPaths:
-                    transitiveSwiftDebugSettingPaths
+                    transitiveSwiftDebugSettingPaths,
+                executionRootFilePath: executionRootFilePath
             )
 
         let writeBuildSettingsTask = Task {

--- a/tools/generators/target_build_settings/src/Generator/ProcessArgs.swift
+++ b/tools/generators/target_build_settings/src/Generator/ProcessArgs.swift
@@ -30,7 +30,8 @@ extension Generator {
             rawArguments: Array<String>.SubSequence,
             generateBuildSettings: Bool,
             includeSelfSwiftDebugSettings: Bool,
-            transitiveSwiftDebugSettingPaths: [URL]
+            transitiveSwiftDebugSettingPaths: [URL],
+            executionRootFilePath: URL?
         ) async throws -> (
             buildSettings: [(key: String, value: String)],
             clangArgs: [String],
@@ -44,6 +45,7 @@ extension Generator {
                     includeSelfSwiftDebugSettings,
                 /*transitiveSwiftDebugSettingPaths:*/
                     transitiveSwiftDebugSettingPaths,
+                /*executionRootFilePath:*/ executionRootFilePath,
                 /*processCArgs:*/ processCArgs,
                 /*processCxxArgs:*/ processCxxArgs,
                 /*processSwiftArgs:*/ processSwiftArgs
@@ -60,6 +62,7 @@ extension Generator.ProcessArgs {
         _ generateBuildSettings: Bool,
         _ includeSelfSwiftDebugSettings: Bool,
         _ transitiveSwiftDebugSettingPaths: [URL],
+        _ executionRootFilePath: URL?,
         _ processCArgs: Generator.ProcessCArgs,
         _ processCxxArgs: Generator.ProcessCxxArgs,
         _ processSwiftArgs: Generator.ProcessSwiftArgs
@@ -75,6 +78,7 @@ extension Generator.ProcessArgs {
         generateBuildSettings: Bool,
         includeSelfSwiftDebugSettings: Bool,
         transitiveSwiftDebugSettingPaths: [URL],
+        executionRootFilePath: URL?,
         processCArgs: Generator.ProcessCArgs,
         processCxxArgs: Generator.ProcessCxxArgs,
         processSwiftArgs: Generator.ProcessSwiftArgs
@@ -130,12 +134,14 @@ extension Generator.ProcessArgs {
 
         let cHasDebugInfo = try await processCArgs(
             argsStream: argsStream,
-            buildSettings: &buildSettings
+            buildSettings: &buildSettings,
+            executionRootFilePath: executionRootFilePath
         )
 
         let cxxHasDebugInfo = try await processCxxArgs(
             argsStream: argsStream,
-            buildSettings: &buildSettings
+            buildSettings: &buildSettings,
+            executionRootFilePath: executionRootFilePath
         )
 
         if generatesDsyms || swiftHasDebugInfo || cHasDebugInfo ||

--- a/tools/generators/target_build_settings/src/Generator/ProcessCxxArgs.swift
+++ b/tools/generators/target_build_settings/src/Generator/ProcessCxxArgs.swift
@@ -1,5 +1,6 @@
 import Foundation
 import PBXProj
+import ToolCommon
 
 extension Generator {
     struct ProcessCxxArgs {
@@ -25,11 +26,13 @@ extension Generator {
         /// Processes all the C++/Objective-C++ arguments.
         func callAsFunction(
             argsStream: AsyncThrowingStream<String, Error>,
-            buildSettings: inout [(key: String, value: String)]
+            buildSettings: inout [(key: String, value: String)],
+            executionRootFilePath: URL?
         ) async throws -> Bool {
             try await callable(
                 /*argsStream:*/ argsStream,
                 /*buildSettings:*/ &buildSettings,
+                executionRootFilePath,
                 /*processCcArgs:*/ processCcArgs,
                 /*write:*/ write
             )
@@ -43,6 +46,7 @@ extension Generator.ProcessCxxArgs {
     typealias Callable = (
         _ argsStream: AsyncThrowingStream<String, Error>,
         _ buildSettings: inout [(key: String, value: String)],
+        _ executionRootFilePath: URL?,
         _ processCcArgs: Generator.ProcessCcArgs,
         _ write: Write
     ) async throws -> Bool
@@ -50,6 +54,7 @@ extension Generator.ProcessCxxArgs {
     static func defaultCallable(
         argsStream: AsyncThrowingStream<String, Error>,
         buildSettings: inout [(key: String, value: String)],
+        executionRootFilePath: URL?,
         processCcArgs: Generator.ProcessCcArgs,
         write: Write
     ) async throws -> Bool {
@@ -70,7 +75,34 @@ extension Generator.ProcessCxxArgs {
             argsStream: argsStream
         )
 
-        let content = args.map { $0 + "\n" }.joined()
+        var PROJECT_DIR = ""
+        if let execRootURL = executionRootFilePath {
+            PROJECT_DIR = try String(contentsOf: execRootURL, encoding: .utf8).trimmingCharacters(in: .whitespacesAndNewlines)
+        } 
+        let BAZEL_OUT = PROJECT_DIR + "/bazel-out"
+
+        let (DEVELOPER_DIR, SDKROOT) = (ProcessInfo.processInfo.environment["DEVELOPER_DIR"] ?? "", ProcessInfo.processInfo.environment["SDKROOT"] ?? "")
+        guard !DEVELOPER_DIR.isEmpty, !SDKROOT.isEmpty, !PROJECT_DIR.isEmpty else {
+            throw PreconditionError(message: """
+`DEVELOPER_DIR`, `SDKROOT`, and `PROJECT_DIR` must be set in the environment.
+""")
+        }
+        
+        let environmentVariables: [String: String] = [
+            "$(PROJECT_DIR)": PROJECT_DIR,
+            "$(BAZEL_OUT)": BAZEL_OUT,
+            "$(DEVELOPER_DIR)": DEVELOPER_DIR,
+            "$(SDKROOT)": SDKROOT
+        ]
+
+        let content = try args.map { arg -> String in
+            var newArg = arg
+            for (key, value) in environmentVariables {
+                newArg = newArg.replacingOccurrences(of: key, with: value)
+            }
+            return newArg + "\n"
+        }.joined()
+
         try write(content, to: URL(fileURLWithPath: String(outputPath)))
 
         buildSettings.append(
@@ -93,7 +125,7 @@ extension Generator.ProcessCxxArgs {
                 (
                     "ASAN_OTHER_CPLUSPLUSFLAGS__NO",
                     #"""
-"@$(DERIVED_FILE_DIR)/cxx.compile.params \#
+"@$(BAZEL_OUT)\#(outputPath.dropFirst(9)) \#
 -D_FORTIFY_SOURCE=\#(fortifySourceLevel)"
 """#
                 )
@@ -101,7 +133,9 @@ extension Generator.ProcessCxxArgs {
             buildSettings.append(
                 (
                     "ASAN_OTHER_CPLUSPLUSFLAGS__YES",
-                    #""@$(DERIVED_FILE_DIR)/cxx.compile.params""#
+                    #"""
+"@$(BAZEL_OUT)\#(outputPath.dropFirst(9))"
+"""#
                 )
             )
             buildSettings.append(
@@ -116,7 +150,9 @@ extension Generator.ProcessCxxArgs {
             buildSettings.append(
                 (
                     "OTHER_CPLUSPLUSFLAGS",
-                    #""@$(DERIVED_FILE_DIR)/cxx.compile.params""#
+                    #"""
+"@$(BAZEL_OUT)\#(outputPath.dropFirst(9))"
+"""#
                 )
             )
         }

--- a/xcodeproj/internal/processed_targets/incremental_library_targets.bzl
+++ b/xcodeproj/internal/processed_targets/incremental_library_targets.bzl
@@ -129,6 +129,9 @@ def _process_incremental_library_target(
         target = target,
     )
 
+    xcode_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig]
+    apple_fragment = ctx.fragments.apple
+
     (
         target_build_settings,
         swift_debug_settings_file,
@@ -144,6 +147,9 @@ def _process_incremental_library_target(
         name = label.name,
         swift_args = args.swift,
         tool = ctx.executable._target_build_settings_generator,
+        xcode_config = xcode_config,
+        apple_fragment = apple_fragment,
+        bin_dir_path = bin_dir_path,
     )
 
     swift_debug_settings = depset(

--- a/xcodeproj/internal/processed_targets/incremental_top_level_targets.bzl
+++ b/xcodeproj/internal/processed_targets/incremental_top_level_targets.bzl
@@ -439,6 +439,9 @@ def _process_focused_top_level_target(
             ),
         ]
 
+    xcode_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig]
+    apple_fragment = ctx.fragments.apple
+
     (
         target_build_settings,
         swift_debug_settings_file,
@@ -472,6 +475,9 @@ def _process_focused_top_level_target(
         swift_debug_settings_to_merge = swift_debug_settings_to_merge,
         team_id = provisioning_profile_props.team_id,
         tool = ctx.executable._target_build_settings_generator,
+        xcode_config = xcode_config,
+        apple_fragment = apple_fragment,
+        bin_dir_path = bin_dir_path,
     )
 
     xcode_product = product.xcode_product
@@ -756,6 +762,9 @@ def _process_unfocused_top_level_target(
         ],
     )
 
+    xcode_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig]
+    apple_fragment = ctx.fragments.apple
+
     (
         _,
         swift_debug_settings_file,
@@ -774,6 +783,9 @@ def _process_unfocused_top_level_target(
         swift_args = args.swift,
         swift_debug_settings_to_merge = swift_debug_settings_to_merge,
         tool = ctx.executable._target_build_settings_generator,
+        xcode_config = xcode_config,
+        apple_fragment = apple_fragment,
+        bin_dir_path = ctx.bin_dir.path,
     )
 
     xcode_product = slim_product.xcode_product

--- a/xcodeproj/internal/processed_targets/mixed_language_library_targets.bzl
+++ b/xcodeproj/internal/processed_targets/mixed_language_library_targets.bzl
@@ -147,6 +147,9 @@ def _process_mixed_language_library_target(
         )
         indexstore_overrides = []
 
+    xcode_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig]
+    apple_fragment = ctx.fragments.apple
+
     (
         target_build_settings,
         _,
@@ -163,6 +166,9 @@ def _process_mixed_language_library_target(
         name = label.name,
         swift_args = args.swift,
         tool = ctx.executable._target_build_settings_generator,
+        xcode_config = xcode_config,
+        apple_fragment = apple_fragment,
+        bin_dir_path = bin_dir_path,
     )
 
     (


### PR DESCRIPTION
This change would make the index-compile for single source file (.m and .mm) to not depend on params file generated by index-build of the target containing the source file. 