### PR TITLE
Remove duplicate post/pre actions

### DIFF
--- a/test/internal/xcschemes/infos_from_json_tests.bzl
+++ b/test/internal/xcschemes/infos_from_json_tests.bzl
@@ -380,6 +380,8 @@ def infos_from_json_test_suite(name):
             ],
         ),
     ]
+    expected_id_full_launch_build_targets = [xcscheme_infos_testable.make_build_target(t.id) for t in expected_full_launch_build_targets]
+    expected_id_full_build_targets = [xcscheme_infos_testable.make_build_target(t.id) for t in expected_full_build_targets]
 
     # Empty
 
@@ -605,8 +607,8 @@ def infos_from_json_test_suite(name):
                 name = "A scheme",
                 profile = xcscheme_infos_testable.make_profile(
                     build_targets = (
-                        expected_full_launch_build_targets +
-                        expected_full_build_targets
+                        expected_id_full_launch_build_targets +
+                        expected_id_full_build_targets
                     ),
                     env_include_defaults = "0",
                     launch_target = expected_profile_same_as_run_launch_target,
@@ -791,7 +793,7 @@ def infos_from_json_test_suite(name):
             xcscheme_infos_testable.make_scheme(
                 name = "A scheme",
                 profile = xcscheme_infos_testable.make_profile(
-                    build_targets = expected_full_build_targets,
+                    build_targets = expected_id_full_build_targets,
                     env_include_defaults = "0",
                     launch_target = expected_profile_same_as_run_launch_path,
                 ),

--- a/xcodeproj/internal/xcschemes/xcscheme_infos.bzl
+++ b/xcodeproj/internal/xcschemes/xcscheme_infos.bzl
@@ -531,7 +531,7 @@ def _profile_info_from_dict(
         top_level_deps):
     if profile == "same_as_run":
         return _make_profile(
-            build_targets = run.build_targets,
+            build_targets = [_make_build_target(t.id) for t in run.build_targets],
             launch_target = _make_same_as_run_launch_target(
                 run.launch_target,
             ),


### PR DESCRIPTION
When using custom schemes with "same_as_run" for the profile action, I noticed that the build target's pre/post build actions were being duplicated in the generated scheme because we copy the whole build target into the profile action (incl post_actions and pre_actions).

This just copies the `id` from the build target instead.