### PR TITLE
Fix non-experimental remote_download_regex flag

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -203,7 +203,7 @@ bazel run //:xcodeproj -- 'build --remote_download_minimal --output_groups=all_t
 This requires knowing the internal name of the generator target
 (`//:xcodeproj.generator` in this example), and it also doesn’t apply some flags
 that Xcode `bazel build` command applies (e.g.
-`--experimental_remote_download_regex`). Instead, it’s recommended that you use
+`--remote_download_regex`). Instead, it’s recommended that you use
 the [`--generator_output_groups` option](#--generator_output_groups):
 
 ```
@@ -302,7 +302,7 @@ bazel run //:xcodeproj -- --config=swiftuipreviews --generator_output_groups=all
 
 If the Bazel command is `build`, then this builds the specified generator
 outputs groups, potentially adding additional flags to match the behavior of
-Xcode’s `bazel build` (e.g. `--experimental_remote_download_regex`).
+Xcode’s `bazel build` (e.g. `--remote_download_regex`).
 
 <a id="output-groups"></a>
 These are the available output groups to use:

--- a/xcodeproj/internal/bazel_integration_files/generate_bazel_dependencies.sh
+++ b/xcodeproj/internal/bazel_integration_files/generate_bazel_dependencies.sh
@@ -122,7 +122,7 @@ build_pre_config_flags=(
   # This is brittle. If different file extensions are used for compilation
   # inputs, they will need to be added to this list. Ideally we can stop doing
   # this once Bazel adds support for a Remote Output Service.
-  "--experimental_remote_download_regex=.*\.indexstore/.*|.*\.(a|cfg|c|C|cc|cl|cpp|cu|cxx|c++|def|h|H|hh|hpp|hxx|h++|hmap|ilc|inc|inl|ipp|tcc|tlh|tli|tpp|m|modulemap|mm|pch|swift|swiftdoc|swiftmodule|swiftsourceinfo|yaml)$"
+  "--remote_download_regex=.*\.indexstore/.*|.*\.(a|cfg|c|C|cc|cl|cpp|cu|cxx|c++|def|h|H|hh|hpp|hxx|h++|hmap|ilc|inc|inl|ipp|tcc|tlh|tli|tpp|m|modulemap|mm|pch|swift|swiftdoc|swiftmodule|swiftsourceinfo|yaml)$"
 )
 
 apply_sanitizers=1

--- a/xcodeproj/internal/bazel_integration_files/generate_index_build_bazel_dependencies.sh
+++ b/xcodeproj/internal/bazel_integration_files/generate_index_build_bazel_dependencies.sh
@@ -12,7 +12,7 @@ output_groups=(
   "bc $BAZEL_TARGET_ID"
   # Products (i.e. bundles) and index store data. The products themselves aren't
   # used, they cause transitive files to be created. We use
-  # `--experimental_remote_download_regex` below to collect the files we care
+  # `--remote_download_regex` below to collect the files we care
   # about.
   "bp $BAZEL_TARGET_ID"
 )
@@ -58,7 +58,7 @@ readonly build_pre_config_flags=(
   # This is brittle. If different file extensions are used for compilation
   # inputs, they will need to be added to this list. Ideally we can stop doing
   # this once Bazel adds support for a Remote Output Service.
-  "--experimental_remote_download_regex=${indexstores_regex}.*|.*\.(cfg|c|C|cc|cl|cpp|cu|cxx|c++|def|h|H|hh|hpp|hxx|h++|hmap|ilc|inc|inl|ipp|tcc|tlh|tli|tpp|m|modulemap|mm|pch|swift|swiftdoc|swiftmodule|swiftsourceinfo|yaml)$"
+  "--remote_download_regex=${indexstores_regex}.*|.*\.(cfg|c|C|cc|cl|cpp|cu|cxx|c++|def|h|H|hh|hpp|hxx|h++|hmap|ilc|inc|inl|ipp|tcc|tlh|tli|tpp|m|modulemap|mm|pch|swift|swiftdoc|swiftmodule|swiftsourceinfo|yaml)$"
 )
 
 source "$BAZEL_INTEGRATION_DIR/bazel_build.sh"

--- a/xcodeproj/internal/files/legacy_output_files.bzl
+++ b/xcodeproj/internal/files/legacy_output_files.bzl
@@ -470,7 +470,7 @@ def swift_to_outputs(swift):
     return (
         # We only need the single swiftmodule in order to download everything
         # from the remote cache (because of
-        # `--experimental_remote_download_regex`). Reducing the number of
+        # `--remote_download_regex`). Reducing the number of
         # items in an output group keeps the BEP small.
         [module.swiftmodule],
         getattr(module, "indexstore", None),

--- a/xcodeproj/internal/templates/runner.sh
+++ b/xcodeproj/internal/templates/runner.sh
@@ -239,7 +239,7 @@ else
   if [[ $cmd == "build" && -n "${generator_output_groups:-}" ]]; then
     if [[ $download_intermediates -eq 1 ]]; then
       pre_config_flags=(
-        "--experimental_remote_download_regex=.*\.indexstore/.*|.*\.(a|cfg|c|C|cc|cl|cpp|cu|cxx|c++|def|h|H|hh|hpp|hxx|h++|hmap|ilc|inc|inl|ipp|tcc|tlh|tli|tpp|m|modulemap|mm|pch|swift|swiftdoc|swiftmodule|swiftsourceinfo|yaml)$"
+        "--remote_download_regex=.*\.indexstore/.*|.*\.(a|cfg|c|C|cc|cl|cpp|cu|cxx|c++|def|h|H|hh|hpp|hxx|h++|hmap|ilc|inc|inl|ipp|tcc|tlh|tli|tpp|m|modulemap|mm|pch|swift|swiftdoc|swiftmodule|swiftsourceinfo|yaml)$"
       )
     else
       pre_config_flags=()


### PR DESCRIPTION
This flag in Bazel 7.0 is no longer experimental so you get the following warning:

```
WARNING: Option 'experimental_remote_download_regex' is deprecated: Use --remote_download_regex instead
```

We can update to the non-experimental flag as we now only support Bazel 7+.