### PR TITLE
Fix file permissions on macOS 15.4

### DIFF
--- a/xcodeproj/internal/bazel_integration_files/copy_outputs.sh
+++ b/xcodeproj/internal/bazel_integration_files/copy_outputs.sh
@@ -31,6 +31,7 @@ if [[ "$ACTION" != indexbuild ]]; then
       ln -sfh "$PWD/$BAZEL_OUTPUTS_PRODUCT_BASENAME" "$TARGET_BUILD_DIR/$PRODUCT_NAME"
     else
       # Product is a bundle
+      chmod -R +w "$BAZEL_OUTPUTS_PRODUCT_BASENAME" "$TARGET_BUILD_DIR" # Starting on MacOS 15.4, rsync will fail if it does not have write access on the src or dst directory
       rsync \
         --copy-links \
         --recursive \

--- a/xcodeproj/internal/templates/incremental_installer.sh
+++ b/xcodeproj/internal/templates/incremental_installer.sh
@@ -73,8 +73,8 @@ dest_dir="$(dirname "${dest}")"
 
 # Copy over `xcschemes`
 readonly dest_xcschemes="$dest/xcshareddata/xcschemes"
-
 mkdir -p "$dest_xcschemes"
+chmod +w "$src_xcschemes" "$dest_xcschemes" # Starting on MacOS 15.4, rsync will fail if it does not have write access on the src or dst directory
 rsync \
   --archive \
   --chmod=u+w,F-x \

--- a/xcodeproj/internal/templates/legacy_installer.sh
+++ b/xcodeproj/internal/templates/legacy_installer.sh
@@ -128,6 +128,7 @@ fi
 # Sync over the project, changing the permissions to be writable
 
 # Don't touch project.xcworkspace as that will make Xcode prompt
+chmod +w "$src/" "$dest/" # Starting on MacOS 15.4, rsync will fail if it does not have write access on the src or dst directory
 rsync \
   --archive \
   --copy-links \


### PR DESCRIPTION
There have been changes to `rsync` on macOS 15.4 which require us to have write permissions here.