### PR TITLE
Simplify indexstore `.filelist` creation

### DIFF
--- a/xcodeproj/internal/files/incremental_output_files.bzl
+++ b/xcodeproj/internal/files/incremental_output_files.bzl
@@ -246,7 +246,6 @@ def _collect_incremental_output_files(
     indexstores_filelist = indexstore_filelists.write(
         actions = actions,
         indexstore_and_target_overrides = transitive_indexstore_overrides,
-        indexstores = transitive_indexstores,
         name = "bi",
         rule_name = name,
     )
@@ -348,7 +347,6 @@ def _collect_mixed_language_output_files(
     indexstores_filelist = indexstore_filelists.write(
         actions = actions,
         indexstore_and_target_overrides = transitive_indexstore_overrides,
-        indexstores = transitive_indexstores,
         name = "bi",
         rule_name = name,
     )

--- a/xcodeproj/internal/files/legacy_output_files.bzl
+++ b/xcodeproj/internal/files/legacy_output_files.bzl
@@ -257,7 +257,6 @@ def _collect_legacy_output_files(
         indexstores_filelist = indexstore_filelists.write(
             actions = ctx.actions,
             indexstore_and_target_overrides = transitive_indexstore_overrides,
-            indexstores = transitive_indexstores,
             name = "bi",
             rule_name = rule_attr.name,
         )

--- a/xcodeproj/internal/indexstore_filelists.bzl
+++ b/xcodeproj/internal/indexstore_filelists.bzl
@@ -9,8 +9,7 @@ def _write(
         actions,
         name,
         rule_name,
-        indexstore_and_target_overrides,
-        indexstores):
+        indexstore_and_target_overrides):
     args = actions.args()
     args.use_param_file("%s", use_always = True)
     args.set_param_file_format("multiline")
@@ -22,29 +21,7 @@ def _write(
 
     output = actions.declare_file("{}-{}.filelist".format(rule_name, name))
 
-    # We make an action to copy the params file, because we want to force the
-    # downloading of `indexstores`. We don't want to directly place the
-    # `indexstores` in an output group to prevent the explosion of the BEP.
-    actions.run_shell(
-        arguments = [args, output.path],
-        inputs = indexstores,
-        outputs = [output],
-        command = """\
-if [[ $(stat -f '%d' "$1") == $(stat -f '%d' "${2%/*}") ]]; then
-  cp -c "$1" "$2"
-else
-  cp "$1" "$2"
-fi
-""",
-        mnemonic = "WriteIndexstoreFilelist",
-        # The action is simply a file copy, would be slower if remote.
-        # Same for caching in any way.  Also no need for sandboxing.
-        execution_requirements = {
-            "no-cache": "1",
-            "no-remote": "1",
-            "no-sandbox": "1",
-        },
-    )
+    actions.write(output, args)
 
     return output
 


### PR DESCRIPTION
Now that we can use `--remote_download_regex` we no longer need the weird hack that `indexstore_filelists.write` was doing to force the indexstores to download. Plus there are times when we don’t want to download the indexstores, like when cache warming on CI.