### PR TITLE
Optionally allow `WriteTargetBuildSettings` to use remote cache or RBE

### DIFF
--- a/test/internal/pbxproj_partials/write_target_build_settings_tests.bzl
+++ b/test/internal/pbxproj_partials/write_target_build_settings_tests.bzl
@@ -73,6 +73,7 @@ def _write_target_build_settings_test_impl(ctx):
         params,
     ) = pbxproj_partials.write_target_build_settings(
         actions = actions.mock,
+        allow_remote = ctx.attr.allow_remote,
         apple_generate_dsym = ctx.attr.apple_generate_dsym,
         certificate_name = ctx.attr.certificate_name,
         colorize = ctx.attr.colorize,
@@ -167,6 +168,7 @@ write_target_build_settings_test = unittest.make(
     # @unsorted-dict-items
     attrs = {
         # Inputs
+        "allow_remote": attr.bool(mandatory = True),
         "apple_generate_dsym": attr.bool(mandatory = True),
         "certificate_name": attr.string(),
         "colorize": attr.bool(mandatory = True),
@@ -210,6 +212,7 @@ def write_target_build_settings_test_suite(name):
             name,
 
             # Inputs
+            allow_remote = False,
             apple_generate_dsym = False,
             certificate_name = None,
             colorize = False,
@@ -241,6 +244,7 @@ def write_target_build_settings_test_suite(name):
             name = name,
 
             # Inputs
+            allow_remote = allow_remote,
             apple_generate_dsym = apple_generate_dsym,
             certificate_name = certificate_name,
             colorize = colorize,

--- a/xcodeproj/BUILD
+++ b/xcodeproj/BUILD
@@ -7,6 +7,20 @@ bool_flag(
     visibility = ["//visibility:public"],
 )
 
+# `WriteTargetBuildSettings` is very fast, and there are potentially thousands
+# of the action for a project, which results in caching overhead slowing down
+# clean builds. So by default we disable remote cache/execution. This also
+# prevents DDoSing the remote cache.
+#
+# Currently on Linux you need to enable this flag and use multi-platform RBE,
+# since `WriteTargetBuildSettings` is precompiled for macOS. It might also be
+# beneficial to enable this on CI to speed up project generation validation.
+bool_flag(
+    name = "allow_remote_write_target_build_settings",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
 string_flag(
     name = "extra_common_flags",
     build_setting_default = "",

--- a/xcodeproj/internal/processed_targets/incremental_library_targets.bzl
+++ b/xcodeproj/internal/processed_targets/incremental_library_targets.bzl
@@ -136,6 +136,10 @@ def _process_incremental_library_target(
         params_files,
     ) = pbxproj_partials.write_target_build_settings(
         actions = actions,
+        allow_remote = (
+            ctx.attr._allow_remote_write_target_build_settings[BuildSettingInfo]
+                .value
+        ),
         apple_generate_dsym = ctx.fragments.cpp.apple_generate_dsym,
         colorize = ctx.attr._colorize[BuildSettingInfo].value,
         conly_args = args.conly,

--- a/xcodeproj/internal/processed_targets/incremental_top_level_targets.bzl
+++ b/xcodeproj/internal/processed_targets/incremental_top_level_targets.bzl
@@ -461,6 +461,10 @@ def _process_focused_top_level_target(
         params_files,
     ) = pbxproj_partials.write_target_build_settings(
         actions = actions,
+        allow_remote = (
+            ctx.attr._allow_remote_write_target_build_settings[BuildSettingInfo]
+                .value
+        ),
         apple_generate_dsym = ctx.fragments.cpp.apple_generate_dsym,
         certificate_name = provisioning_profile_props.certificate_name,
         colorize = ctx.attr._colorize[BuildSettingInfo].value,
@@ -778,6 +782,10 @@ def _process_unfocused_top_level_target(
         _,
     ) = pbxproj_partials.write_target_build_settings(
         actions = actions,
+        allow_remote = (
+            ctx.attr._allow_remote_write_target_build_settings[BuildSettingInfo]
+                .value
+        ),
         apple_generate_dsym = False,
         colorize = ctx.attr._colorize[BuildSettingInfo].value,
         # FIXME: Should this be args.conly?

--- a/xcodeproj/internal/processed_targets/mixed_language_library_targets.bzl
+++ b/xcodeproj/internal/processed_targets/mixed_language_library_targets.bzl
@@ -153,6 +153,10 @@ def _process_mixed_language_library_target(
         params_files,
     ) = pbxproj_partials.write_target_build_settings(
         actions = actions,
+        allow_remote = (
+            ctx.attr._allow_remote_write_target_build_settings[BuildSettingInfo]
+                .value
+        ),
         apple_generate_dsym = ctx.fragments.cpp.apple_generate_dsym,
         colorize = ctx.attr._colorize[BuildSettingInfo].value,
         conly_args = args.conly,

--- a/xcodeproj/internal/xcodeproj_incremental_aspect.bzl
+++ b/xcodeproj/internal/xcodeproj_incremental_aspect.bzl
@@ -59,6 +59,10 @@ def _xcodeproj_incremental_aspect_attrs(
         generator_name,
         unfocused_labels):
     return {
+        "_allow_remote_write_target_build_settings": attr.label(
+            default = Label("//xcodeproj:color"),
+            providers = [BuildSettingInfo],
+        ),
         "_cc_compiler_params_processor": attr.label(
             cfg = "exec",
             default = Label(


### PR DESCRIPTION
Currently needed for generating a project on RBE.