### PR TITLE
Add pre-commit config for buildifier

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+# See CONTRIBUTING.md for instructions.
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: https://github.com/keith/pre-commit-buildifier
+    rev: 8.0.1
+    hooks:
+      - id: buildifier
+      - id: buildifier-lint
+


### PR DESCRIPTION
This is copied from other rules_apple though I updated the version.
We should also write a pre-commit hook to prevent commits that are not signed off.