### PR TITLE
Fix `rsync` on macOS 15.4

### DIFF
--- a/xcodeproj/internal/bazel_integration_files/copy_outputs.sh
+++ b/xcodeproj/internal/bazel_integration_files/copy_outputs.sh
@@ -30,6 +30,13 @@ if [[ "$ACTION" != indexbuild ]]; then
       # rpaths to work
       ln -sfh "$PWD/$BAZEL_OUTPUTS_PRODUCT_BASENAME" "$TARGET_BUILD_DIR/$PRODUCT_NAME"
     else
+      if [[ $(sw_vers -productVersion | cut -d '.' -f 1-2) == "15.4" ]]; then
+        # 15.4's `rsync` has a bug that requires the src to have write
+        # permissions. We normally shouldn't do this as it modifies the bazel
+        # output base, so we limit this to only macOS 15.4.
+        chmod -R +w "$BAZEL_OUTPUTS_PRODUCT_BASENAME"
+      fi
+
       # Product is a bundle
       rsync \
         --copy-links \

--- a/xcodeproj/internal/templates/incremental_installer.sh
+++ b/xcodeproj/internal/templates/incremental_installer.sh
@@ -74,6 +74,13 @@ dest_dir="$(dirname "${dest}")"
 # Copy over `xcschemes`
 readonly dest_xcschemes="$dest/xcshareddata/xcschemes"
 
+if [[ $(sw_vers -productVersion | cut -d '.' -f 1-2) == "15.4" ]]; then
+  # 15.4's `rsync` has a bug that requires the src to have write permissions.
+  # We normally shouldn't do this as it modifies the bazel output base, so we
+  # limit this to only macOS 15.4.
+  chmod -R +w "$src_xcschemes"
+fi
+
 mkdir -p "$dest_xcschemes"
 rsync \
   --archive \

--- a/xcodeproj/internal/templates/legacy_installer.sh
+++ b/xcodeproj/internal/templates/legacy_installer.sh
@@ -136,6 +136,13 @@ fi
 
 # Sync over the project, changing the permissions to be writable
 
+if [[ $(sw_vers -productVersion | cut -d '.' -f 1-2) == "15.4" ]]; then
+  # 15.4's `rsync` has a bug that requires the src to have write permissions.
+  # We normally shouldn't do this as it modifies the bazel output base, so we
+  # limit this to only macOS 15.4.
+  chmod -R +w "$src"
+fi
+
 # Don't touch project.xcworkspace as that will make Xcode prompt
 rsync \
   --archive \


### PR DESCRIPTION
15.4's `rsync` has a bug that requires the src to have write permissions. We normally shouldn't do this as it modifies the Bazel output base, so we limit this to only macOS 15.4 (as it’s fixed in 15.5).

Also fixes a slight bug in the `patch_dsym` function.