### PR TITLE
Allow empty string value for xcschemes.env_value

### DIFF
--- a/test/internal/xcschemes/BUILD
+++ b/test/internal/xcschemes/BUILD
@@ -2,12 +2,15 @@ load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load(":info_constructors_tests.bzl", "info_constructors_test_suite")
 load(":infos_from_json_tests.bzl", "infos_from_json_test_suite")
 load(":write_schemes_tests.bzl", "write_schemes_test_suite")
+load(":xcschemes_base_tests.bzl", "xcschemes_base_test_suite")
 
 info_constructors_test_suite(name = "info_constructors")
 
 infos_from_json_test_suite(name = "infos_from_json")
 
 write_schemes_test_suite(name = "write_schemes")
+
+xcschemes_base_test_suite(name = "xcschemes_base")
 
 test_suite(name = "xcschemes")
 

--- a/test/internal/xcschemes/xcschemes_base_tests.bzl
+++ b/test/internal/xcschemes/xcschemes_base_tests.bzl
@@ -1,0 +1,103 @@
+"""Tests for the `xcschemes` module."""
+
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+
+# buildifier: disable=bzl-visibility
+load(
+    "//xcodeproj/internal/xcschemes:xcschemes.bzl",
+    "xcschemes",
+)
+
+def _xcschemes_base_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    # Arrange / Act
+
+    result = json.decode(ctx.attr.result)
+    expected = json.decode(ctx.attr.expected)
+
+    # Assert
+
+    asserts.equals(
+        env,
+        expected,
+        result,
+    )
+
+    return unittest.end(env)
+
+xcschemes_base_test = unittest.make(
+    impl = _xcschemes_base_test_impl,
+    # @unsorted-dict-items
+    attrs = {
+        # Inputs
+        "result": attr.string(mandatory = True),
+
+        # Expected
+        "expected": attr.string(mandatory = True),
+    },
+)
+
+def xcschemes_base_test_suite(name):
+    """Test suite for `xcschemes`.
+
+    Args:
+        name: The base name to be used in things created by this macro. Also the
+            name of the test suite.
+    """
+    test_names = []
+
+    def _add_test(
+            *,
+            name,
+
+            # Inputs
+            result,
+
+            # Expected
+            expected):
+        test_names.append(name)
+        xcschemes_base_test(
+            name = name,
+
+            # Inputs
+            result = json.encode(result),
+
+            # Expected
+            expected = json.encode(expected),
+        )
+
+    # env_value
+
+    _add_test(
+        name = "{}_env_value_default".format(name),
+
+        # Inputs
+        result = xcschemes.env_value(value = "test value"),
+
+        # Expected
+        expected = struct(
+            enabled = "1",
+            value = "test value",
+        ),
+    )
+
+    _add_test(
+        name = "{}_env_value_empty".format(name),
+
+        # Inputs
+        result = xcschemes.env_value(value = ""),
+
+        # Expected
+        expected = struct(
+            enabled = "1",
+            value = "",
+        ),
+    )
+
+    # Test suite
+
+    native.test_suite(
+        name = name,
+        tests = test_names,
+    )

--- a/xcodeproj/internal/xcschemes/xcschemes.bzl
+++ b/xcodeproj/internal/xcschemes/xcschemes.bzl
@@ -1142,7 +1142,7 @@ def _env_value(value, *, enabled = True):
             checked in the scheme. An unchecked checkbox means Xcode won't
             include that environment variable when running a target.
     """
-    if not value:
+    if not value and value != "":
         fail("""
 `value` must be provided to `xcschemes.env_value`.
 """)


### PR DESCRIPTION
Xcode allows defining environment variables without a value. At runtime, sometimes only the presence of the environment variable is checked, not its value (e.g. `CG_NUMERICS_SHOW_BACKTRACE`, `CGBITMAP_CONTEXT_LOG_ERRORS`, etc.).