### PR TITLE
Limit `rsync` bug check to macOS 15.4.0

### DIFF
--- a/xcodeproj/internal/bazel_integration_files/copy_dsyms.sh
+++ b/xcodeproj/internal/bazel_integration_files/copy_dsyms.sh
@@ -49,10 +49,10 @@ EOF
 if [[ -n "${BAZEL_OUTPUTS_DSYM:-}" ]]; then
   cd "${BAZEL_OUT%/*}"
 
-  if (( $(echo "$(sw_vers -productVersion | cut -d '.' -f 1-2)" | sed 's/\.//g') >= 154 )); then
-    # 15.4's `rsync` has a bug that requires the src to have write permissions.
-    # We normally shouldn't do this as it modifies the bazel output base, so we
-    # limit this to only macOS 15.4 or higher.
+  if [[ "$(sw_vers -productVersion)" == "15.4.0" ]]; then
+    # 15.4.0's `rsync` has a bug that requires the src to have write
+    # permissions. We normally shouldn't do this as it modifies the bazel output
+    # base, so we limit this to only macOS 15.4.0.
     # shellcheck disable=SC2046
     chmod -R +w $(xargs -n1 <<< "$BAZEL_OUTPUTS_DSYM")
   fi

--- a/xcodeproj/internal/bazel_integration_files/copy_outputs.sh
+++ b/xcodeproj/internal/bazel_integration_files/copy_outputs.sh
@@ -30,10 +30,10 @@ if [[ "$ACTION" != indexbuild ]]; then
       # rpaths to work
       ln -sfh "$PWD/$BAZEL_OUTPUTS_PRODUCT_BASENAME" "$TARGET_BUILD_DIR/$PRODUCT_NAME"
     else
-      if (( $(echo "$(sw_vers -productVersion | cut -d '.' -f 1-2)" | sed 's/\.//g') >= 154 )); then
-        # 15.4's `rsync` has a bug that requires the src to have write
+      if [[ "$(sw_vers -productVersion)" == "15.4.0" ]]; then
+        # 15.4.0's `rsync` has a bug that requires the src to have write
         # permissions. We normally shouldn't do this as it modifies the bazel
-        # output base, so we limit this to only macOS 15.4 or higher.
+        # output base, so we limit this to only macOS 15.4.0.
         chmod -R +w "$BAZEL_OUTPUTS_PRODUCT_BASENAME"
       fi
 

--- a/xcodeproj/internal/templates/incremental_installer.sh
+++ b/xcodeproj/internal/templates/incremental_installer.sh
@@ -74,10 +74,10 @@ dest_dir="$(dirname "${dest}")"
 # Copy over `xcschemes`
 readonly dest_xcschemes="$dest/xcshareddata/xcschemes"
 
-if (( $(echo "$(sw_vers -productVersion | cut -d '.' -f 1-2)" | sed 's/\.//g') >= 154 )); then
-  # 15.4's `rsync` has a bug that requires the src to have write permissions.
+if [[ "$(sw_vers -productVersion)" == "15.4.0" ]]; then
+  # 15.4.0's `rsync` has a bug that requires the src to have write permissions.
   # We normally shouldn't do this as it modifies the bazel output base, so we
-  # limit this to only macOS 15.4 or higher.
+  # limit this to only macOS 15.4.0.
   chmod -R +w "$src_xcschemes"
 fi
 

--- a/xcodeproj/internal/templates/legacy_installer.sh
+++ b/xcodeproj/internal/templates/legacy_installer.sh
@@ -136,10 +136,10 @@ fi
 
 # Sync over the project, changing the permissions to be writable
 
-if (( $(echo "$(sw_vers -productVersion | cut -d '.' -f 1-2)" | sed 's/\.//g') >= 154 )); then
-  # 15.4's `rsync` has a bug that requires the src to have write permissions.
+if [[ "$(sw_vers -productVersion)" == "15.4.0" ]]; then
+  # 15.4.0's `rsync` has a bug that requires the src to have write permissions.
   # We normally shouldn't do this as it modifies the bazel output base, so we
-  # limit this to only macOS 15.4 or higher.
+  # limit this to only macOS 15.4.0.
   chmod -R +w "$src"
 fi
 


### PR DESCRIPTION
`rsync` bug was fixed in macOS 15.4.1 and macOS 15.5.0 beta 2.