### PR TITLE
Skip targets without "compiles" output group in compile_only aspect

### DIFF
--- a/xcodeproj/compile_only_aspect.bzl
+++ b/xcodeproj/compile_only_aspect.bzl
@@ -66,17 +66,13 @@ def _compile_only_aspect_impl(target, ctx):
     else:
         return []
 
-    for dep in deps:
-        if OutputGroupInfo in dep and not hasattr(dep[OutputGroupInfo], "compiles"):
-            fail(target, dep)
-
     return [
         OutputGroupInfo(
             compiles = depset(
                 transitive = outs + [
                     dep[OutputGroupInfo].compiles
                     for dep in deps
-                    if OutputGroupInfo in dep
+                    if OutputGroupInfo in dep and hasattr(dep[OutputGroupInfo], "compiles")
                 ],
             ),
         ),


### PR DESCRIPTION
We are running some additional targets which are not Apple / Swift specific but still required and the build was failing since there was no "compiles" output group.

I could add those rules to the list in the aspect definition. However I fear that it would set the bad example and the list would probably grow a lot over time.