### PR TITLE
Fix argument length error for WriteSwiftDebugSettings

### DIFF
--- a/xcodeproj/internal/pbxproj_partials.bzl
+++ b/xcodeproj/internal/pbxproj_partials.bzl
@@ -1049,6 +1049,8 @@ def _write_swift_debug_settings(
     )
 
     args = actions.args()
+    args.use_param_file("@%s")
+    args.set_param_file_format(format = "multiline")
 
     # colorize
     args.add(TRUE_ARG if colorize else FALSE_ARG)


### PR DESCRIPTION
Fix argument length errors by switching WriteSwiftDebugSettings to use a param file when needed.

Previously when generating a very large project with 7000+ targets:
```
ERROR: /private/var/tmp/_bazel_jszumski/399f2da8a1f92cab020446a488e7bec6/rules_xcodeproj.noindex/build_output_base/external/rules_xcodeproj_generated/generator/tools/rules/xcodeproj/bazel-project/BUILD:12:10: Generating bazel-project.xcodeproj Debug-swift_debug_settings.py failed: (Exit -1): universal_swift_debug_settings failed: error executing WriteSwiftDebugSettings command (from target @@rules_xcodeproj_generated//generator/tools/rules/xcodeproj/bazel-project:bazel-project) 
  (cd /private/var/tmp/_bazel_jszumski/399f2da8a1f92cab020446a488e7bec6/rules_xcodeproj.noindex/build_output_base/execroot/register && \
  exec env - \
  bazel-out/darwin_x86_64-opt-exec-macos-x86_64-min13.0-applebin_macos-ST-5b758c1c0c80/bin/external/rules_xcodeproj/tools/generators/swift_debug_settings/universal_swift_debug_settings 1 {...lots of pairs here...}
# Configuration: 794c86670c8dbf3648f6dfd018247dc9402b8c0a923a1790920ea9bf34028e6a
# Execution platform: @@internal_platforms_do_not_use//host:host
Action failed to execute: java.io.IOException: Cannot run program "/var/tmp/_bazel_jszumski/install/fd0e803cd377e5d6c999b9f309de8848/process-wrapper" (in directory "/private/var/tmp/_bazel_jszumski/399f2da8a1f92cab020446a488e7bec6/rules_xcodeproj.noindex/build_output_base/execroot/register"): error=7, Argument list too long
```