### PR TITLE
Adopt latest index-import version (v6.1.0.1) to fix issue with libzstd.1.dylib

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -10,7 +10,7 @@ bazel_dep(name = "bazel_features", version = "1.3.0")
 bazel_dep(name = "bazel_skylib", version = "1.3.0")
 bazel_dep(
     name = "rules_swift",
-    version = "2.8.0",
+    version = "2.8.2",
     max_compatibility_level = 2,
     repo_name = "build_bazel_rules_swift",
 )

--- a/xcodeproj/repositories.bzl
+++ b/xcodeproj/repositories.bzl
@@ -121,8 +121,8 @@ def xcodeproj_rules_dependencies(
         _maybe(
             http_archive,
             name = "build_bazel_rules_swift",
-            sha256 = "68290c747eab415d924a3e2a8d2d32a4686dd1e0b091a6b4db4892d1bc0e8308",
-            url = "https://github.com/bazelbuild/rules_swift/releases/download/2.8.0/rules_swift.2.8.0.tar.gz",
+            sha256 = "a632eaf9d0d7564ae7dbd12f94fc2047cc00706a7f037a4af1fc10e20b7875a4",
+            url = "https://github.com/bazelbuild/rules_swift/releases/download/2.8.2/rules_swift.2.8.2.tar.gz",
             ignore_version_differences = ignore_version_differences,
         )
 

--- a/xcodeproj/repositories.bzl
+++ b/xcodeproj/repositories.bzl
@@ -174,9 +174,9 @@ native_binary(
         http_archive,
         name = "rules_xcodeproj_index_import",
         build_file_content = index_import_build_file_content,
-        canonical_id = "index-import-6.1.0",
-        sha256 = "54d0477526bba0dc1560189dfc4f02d90aea536e9cb329e911f32b2a564b66f1",
-        url = "https://github.com/MobileNativeFoundation/index-import/releases/download/6.1.0/index-import.tar.gz",
+        canonical_id = "index-import-6.1.0.1",
+        sha256 = "9a54fc1674af6031125a9884480a1e31e1bcf48b8f558b3e8bcc6b6fcd6e8b61",
+        url = "https://github.com/MobileNativeFoundation/index-import/releases/download/6.1.0.1/index-import.tar.gz",
         ignore_version_differences = ignore_version_differences,
     )
 


### PR DESCRIPTION
### Description 

Update to latest `index-import` version In order to fix [this issue](https://github.com/MobileNativeFoundation/index-import/issues/135) with `libzstd.1.dylib`

```
ERROR: /Users/user.name/development/iOSApp/Sources/ios/SomeDirectory/ModuleName/BUILD.bazel:7:14: Compiling Swift module //Sources/ios/SomeDirectory/ModuleName:ModuleName failed: (Exit 6): worker failed: error executing SwiftCompile command (from target //Sources/ios/SomeDirectory/ModuleName:ModuleName)
  (cd /private/var/tmp/_bazel_user.name/6a5e437287601edde41b207a856d8f03/rules_xcodeproj.noindex/build_output_base/execroot/_main && \
  exec env - \
    APPLE_SDK_PLATFORM=iPhoneSimulator \
    APPLE_SDK_VERSION_OVERRIDE=18.4 \
    PATH=/bin:/usr/bin \
    XCODE_VERSION_OVERRIDE=16.3.0.16E140 \
  bazel-out/darwin_arm64-opt-exec-ST-d57f47055a04/bin/external/rules_swift+/tools/worker/worker swiftc @bazel-out/ios_sim_arm64-dbg-ios-sim_arm64-min16.0-applebin_ios-ST-6e2671526308/bin/Sources/ios/SomeDirectory/ModuleName/ModuleName.swiftmodule-0.params)
# Configuration: b0ceba1133f56978950e06b51b3c16e1564509c2be138544537871ebbdd13844
# Execution platform: @@platforms//host:host
dyld[5952]: Library not loaded: /opt/homebrew/opt/zstd/lib/libzstd.1.dylib
  Referenced from: <9F95D36C-F1F1-3C2B-A2B2-08DD7E0943D2> /private/var/tmp/_bazel_user.name/6a5e437287601edde41b207a856d8f03/rules_xcodeproj.noindex/build_output_base/external/rules_swift++non_module_deps+build_bazel_rules_swift_index_import_6_1/index-import
  Reason: tried: '/opt/homebrew/opt/zstd/lib/libzstd.1.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/opt/homebrew/opt/zstd/lib/libzstd.1.dylib' (no such file), '/opt/homebrew/opt/zstd/lib/libzstd.1.dylib' (no such file)
``` 