### PR TITLE
Set bazel_head back to last_green

### DIFF
--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -23,7 +23,7 @@ x_templates:
         USE_BAZEL_VERSION: 8.x
     - &bazel_head
       env:
-        USE_BAZEL_VERSION: 4c2d91e762ab6e492853b021408129dd93fb5904 # TODO: Switch back to last_green once get_cpu has been removed
+        USE_BAZEL_VERSION: last_green
 
     - &normal_resources
       resource_requests: { memory: 6GB }


### PR DESCRIPTION
Per https://github.com/MobileNativeFoundation/rules_xcodeproj/pull/3164, setting `bazel_head` back to `last_green` now that https://github.com/bazelbuild/rules_apple/pull/2670 landed. 

cc @luispadron let me know if that's correct