### PR TITLE
Add homebrew paths to `copy_outputs.sh` rsync call

### DIFF
--- a/xcodeproj/internal/bazel_integration_files/copy_dsyms.sh
+++ b/xcodeproj/internal/bazel_integration_files/copy_dsyms.sh
@@ -49,8 +49,13 @@ EOF
 if [[ -n "${BAZEL_OUTPUTS_DSYM:-}" ]]; then
   cd "${BAZEL_OUT%/*}"
 
+  # NOTE: use `which` to find the path to `rsync`.
+  # In macOS 15.4, the system `rsync` is using `openrsync` which contains some permission issues.
+  # This allows users to workaround the issue by overriding the system `rsync` with a working version.
+  # Remove this once we no longer support macOS versions with broken `rsync`.
   # shellcheck disable=SC2046
-  rsync \
+  PATH="/opt/homebrew/bin:/usr/local/bin:$PATH" \
+    rsync \
     --copy-links \
     --recursive \
     --times \

--- a/xcodeproj/internal/bazel_integration_files/copy_outputs.sh
+++ b/xcodeproj/internal/bazel_integration_files/copy_outputs.sh
@@ -31,7 +31,12 @@ if [[ "$ACTION" != indexbuild ]]; then
       ln -sfh "$PWD/$BAZEL_OUTPUTS_PRODUCT_BASENAME" "$TARGET_BUILD_DIR/$PRODUCT_NAME"
     else
       # Product is a bundle
-      rsync \
+      # NOTE: use `which` to find the path to `rsync`.
+      # In macOS 15.4, the system `rsync` is using `openrsync` which contains some permission issues.
+      # This allows users to workaround the issue by overriding the system `rsync` with a working version.
+      # Remove this once we no longer support macOS versions with broken `rsync`.
+      PATH="/opt/homebrew/bin:/usr/local/bin:$PATH" \
+        rsync \
         --copy-links \
         --recursive \
         --times \

--- a/xcodeproj/internal/templates/incremental_installer.sh
+++ b/xcodeproj/internal/templates/incremental_installer.sh
@@ -75,7 +75,14 @@ dest_dir="$(dirname "${dest}")"
 readonly dest_xcschemes="$dest/xcshareddata/xcschemes"
 
 mkdir -p "$dest_xcschemes"
-rsync \
+
+# NOTE: use `which` to find the path to `rsync`.
+# In macOS 15.4, the system `rsync` is using `openrsync` which contains some permission issues.
+# This allows users to workaround the issue by overriding the system `rsync` with a working version.
+# Remove this once we no longer support macOS versions with broken `rsync`.
+# shellcheck disable=SC2046
+PATH="/opt/homebrew/bin:/usr/local/bin:$PATH" \
+  rsync \
   --archive \
   --perms \
   --chmod=u+w,F-x \

--- a/xcodeproj/internal/templates/legacy_installer.sh
+++ b/xcodeproj/internal/templates/legacy_installer.sh
@@ -137,7 +137,13 @@ fi
 # Sync over the project, changing the permissions to be writable
 
 # Don't touch project.xcworkspace as that will make Xcode prompt
-rsync \
+# NOTE: use `which` to find the path to `rsync`.
+# In macOS 15.4, the system `rsync` is using `openrsync` which contains some permission issues.
+# This allows users to workaround the issue by overriding the system `rsync` with a working version.
+# Remove this once we no longer support macOS versions with broken `rsync`.
+# shellcheck disable=SC2046
+PATH="/opt/homebrew/bin:/usr/local/bin:$PATH" \
+  rsync \
   --archive \
   --copy-links \
   --perms \


### PR DESCRIPTION
This works around an issue in macOS 15.4