### PR TITLE
Bazel 8: Replace swiftcopt with rules_swift//:swift:copt

### DIFF
--- a/xcodeproj/internal/bazel_integration_files/generate_bazel_dependencies.sh
+++ b/xcodeproj/internal/bazel_integration_files/generate_bazel_dependencies.sh
@@ -153,7 +153,7 @@ if [[ $apply_sanitizers -eq 1 ]]; then
       --copt=-fno-sanitize-recover=all
       --copt=-fsanitize=address
       --linkopt=-fsanitize=address
-      --swiftcopt=-sanitize=address
+      --@build_bazel_rules_swift//swift:copt=-sanitize=address
       --copt=-Wno-macro-redefined
       --copt=-D_FORTIFY_SOURCE=0
     )
@@ -164,7 +164,7 @@ if [[ $apply_sanitizers -eq 1 ]]; then
       --copt=-fno-sanitize-recover=all
       --copt=-fsanitize=thread
       --linkopt=-fsanitize=thread
-      --swiftcopt=-sanitize=thread
+      --@build_bazel_rules_swift//swift:copt=-sanitize=thread
       )
   fi
   if [ "${ENABLE_UNDEFINED_BEHAVIOR_SANITIZER:-}" == "YES" ]; then

--- a/xcodeproj/internal/templates/xcodeproj.bazelrc
+++ b/xcodeproj/internal/templates/xcodeproj.bazelrc
@@ -98,9 +98,9 @@ common:rules_xcodeproj_swiftuipreviews --config=rules_xcodeproj
 common:rules_xcodeproj_swiftuipreviews --linkopt="-Wl,-rpath,@loader_path/SwiftUIPreviewsFrameworks"
 
 # `swiftc` flags needed for SwiftUI Previews
-common:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-implicit-dynamic
-common:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-private-imports
-common:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-dynamic-replacement-chaining
+common:rules_xcodeproj_swiftuipreviews --@build_bazel_rules_swift//swift:copt=-Xfrontend --@build_bazel_rules_swift//swift:copt=-enable-implicit-dynamic
+common:rules_xcodeproj_swiftuipreviews --@build_bazel_rules_swift//swift:copt=-Xfrontend --@build_bazel_rules_swift//swift:copt=-enable-private-imports
+common:rules_xcodeproj_swiftuipreviews --@build_bazel_rules_swift//swift:copt=-Xfrontend --@build_bazel_rules_swift//swift:copt=-enable-dynamic-replacement-chaining
 
 ### `--config=_rules_xcodeproj_build`
 #


### PR DESCRIPTION
`--swiftcopt` was removed on Bazel 8, causing Thread Sanitizer builds using rules_xcodeproj to fail.