### PR TITLE
Set `--incompatible_use_default_test_toolchain=no` for now

### DIFF
--- a/bazel_9.bazelrc
+++ b/bazel_9.bazelrc
@@ -1,0 +1,2 @@
+# TODO: Remove once rules_apple is updated to support the new test toolchain
+common --@bazel_tools//tools/test:incompatible_use_default_test_toolchain=no

--- a/examples/integration/tools/bazel
+++ b/examples/integration/tools/bazel
@@ -20,7 +20,7 @@ readonly override_bazelrc="$archive_output_base/override.bazelrc"
 
 bazel_version=$("$BAZEL_REAL" info release | /usr/bin/cut -d ' ' -f 2 | /usr/bin/cut -d '.' -f 1)
 if [[ "$bazel_version" == "version" ]]; then
-  bazel_version=8
+  bazel_version=9
 fi
 
 # Don't update the release archive if doing a build inside of Xcode, or if we


### PR DESCRIPTION
Needed for Bazel 9, until rules_apple is updated.