### PR TITLE
Fix building with sanitizers

### DIFF
--- a/xcodeproj/internal/bazel_integration_files/generate_bazel_dependencies.sh
+++ b/xcodeproj/internal/bazel_integration_files/generate_bazel_dependencies.sh
@@ -141,7 +141,6 @@ if [[ $apply_sanitizers -eq 1 ]]; then
       --copt=-fno-sanitize-recover=all
       --copt=-fsanitize=address
       --linkopt=-fsanitize=address
-      --swiftcopt=-sanitize=address
       --copt=-Wno-macro-redefined
       --copt=-D_FORTIFY_SOURCE=0
     )
@@ -152,7 +151,6 @@ if [[ $apply_sanitizers -eq 1 ]]; then
       --copt=-fno-sanitize-recover=all
       --copt=-fsanitize=thread
       --linkopt=-fsanitize=thread
-      --swiftcopt=-sanitize=thread
       )
   fi
   if [ "${ENABLE_UNDEFINED_BEHAVIOR_SANITIZER:-}" == "YES" ]; then


### PR DESCRIPTION
After enabling address or thread sanitizers we see:

```
ERROR: --swiftcopt=-sanitize=address :: Unrecognized option: --swiftcopt=-sanitize=address
```
Removing `--swiftcopt=-sanitize=address` allows the build to succeed but sanitizers don't seem to work.