### PR TITLE
Fix build log parsing for 'fatal error:' diagnostics

### DIFF
--- a/xcodeproj/internal/bazel_integration_files/process_bazel_build_log.py
+++ b/xcodeproj/internal/bazel_integration_files/process_bazel_build_log.py
@@ -45,7 +45,10 @@ def _main(command: List[str]) -> None:
 
     strip_color = re.compile(r"\x1b\[[0-9;]{1,}[A-Za-z]")
     relative_diagnostic = re.compile(
-        r"^.+?:\d+(:\d+)?: (error|warning): ."
+        r"^.+?:\d+(:\d+)?: (fatal\s)?(error|warning): ."
+    )
+    fatal_error_diagnostic = re.compile(
+        r": fatal error: "
     )
     has_relative_diagnostic = False
 
@@ -54,6 +57,9 @@ def _main(command: List[str]) -> None:
 
         # Uppercase the first letter of the (actual) message
         message = message[:-1] + message[-1].upper()
+
+        # Replace 'fatal error:' with 'error:' to match Xcode's native build system
+        message = fatal_error_diagnostic.sub(': error: ', message)
 
         if message.startswith(execution_root):
             # VFS overlays can make paths absolute, so make them relative again


### PR DESCRIPTION
Fixes https://github.com/MobileNativeFoundation/rules_xcodeproj/issues/3203

## Demo

Before:

<img width="346" alt="Screenshot 2025-06-24 at 3 38 26 PM" src="https://github.com/user-attachments/assets/eb1584e0-d90e-45f2-8021-ecd97d0c6bc0" />

After:

<img width="333" alt="Screenshot 2025-06-24 at 4 09 42 PM" src="https://github.com/user-attachments/assets/75ce8785-36c7-425b-8d1e-b3a3d75d9d04" />
