### PR TITLE
Use `--@rules_swift//swift:copt` instead of `--swiftcopt`

### DIFF
--- a/xcodeproj/internal/bazel_integration_files/BUILD
+++ b/xcodeproj/internal/bazel_integration_files/BUILD
@@ -2,7 +2,6 @@ _BASE_FILES = [
     "calculate_output_groups.py",
     "copy_dsyms.sh",
     "create_lldbinit.sh",
-    "generate_bazel_dependencies.sh",
     ":renamed_import_indexstores",
     "process_bazel_build_log.py",
 ]

--- a/xcodeproj/internal/bazel_integration_files/actions.bzl
+++ b/xcodeproj/internal/bazel_integration_files/actions.bzl
@@ -54,3 +54,35 @@ def write_bazel_build_script(
     )
 
     return output
+
+def write_generate_bazel_dependencies_script(
+        *,
+        actions,
+        generator_label,
+        template):
+    """Writes the `generate_bazel_dependencies.sh` script.
+
+    Args:
+        actions: `ctx.actions`.
+        generator_label: The `Label` of the `xcodeproj` generator target.
+        template: `xcodeproj/internal/templates/generate_bazel_dependencies.sh`.
+
+    Returns:
+        The `File` for `generate_bazel_dependencies.sh`.
+    """
+    output = actions.declare_file(
+        "{}_bazel_integration_files/generate_bazel_dependencies.sh".format(
+            generator_label.name,
+        ),
+    )
+
+    actions.expand_template(
+        template = template,
+        output = output,
+        is_executable = True,
+        substitutions = {
+            "%swiftcopt%": str(Label("@build_bazel_rules_swift//swift:copt")),
+        },
+    )
+
+    return output

--- a/xcodeproj/internal/templates/generate_bazel_dependencies.sh
+++ b/xcodeproj/internal/templates/generate_bazel_dependencies.sh
@@ -141,7 +141,7 @@ if [[ $apply_sanitizers -eq 1 ]]; then
       --copt=-fno-sanitize-recover=all
       --copt=-fsanitize=address
       --linkopt=-fsanitize=address
-      --swiftcopt=-sanitize=address
+      --%swiftcopt%=-sanitize=address
       --copt=-Wno-macro-redefined
       --copt=-D_FORTIFY_SOURCE=0
     )
@@ -152,7 +152,7 @@ if [[ $apply_sanitizers -eq 1 ]]; then
       --copt=-fno-sanitize-recover=all
       --copt=-fsanitize=thread
       --linkopt=-fsanitize=thread
-      --swiftcopt=-sanitize=thread
+      --%swiftcopt%=-sanitize=thread
       )
   fi
   if [ "${ENABLE_UNDEFINED_BEHAVIOR_SANITIZER:-}" == "YES" ]; then

--- a/xcodeproj/internal/templates/xcodeproj.bazelrc
+++ b/xcodeproj/internal/templates/xcodeproj.bazelrc
@@ -94,9 +94,9 @@ common:rules_xcodeproj_swiftuipreviews --config=rules_xcodeproj
 common:rules_xcodeproj_swiftuipreviews --linkopt="-Wl,-rpath,@loader_path/SwiftUIPreviewsFrameworks"
 
 # `swiftc` flags needed for SwiftUI Previews
-common:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-implicit-dynamic
-common:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-private-imports
-common:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-dynamic-replacement-chaining
+common:rules_xcodeproj_swiftuipreviews --%swiftcopt%=-Xfrontend --%swiftcopt%=-enable-implicit-dynamic
+common:rules_xcodeproj_swiftuipreviews --%swiftcopt%=-Xfrontend --%swiftcopt%=-enable-private-imports
+common:rules_xcodeproj_swiftuipreviews --%swiftcopt%=-Xfrontend --%swiftcopt%=-enable-dynamic-replacement-chaining
 
 ### `--config=_rules_xcodeproj_build`
 #

--- a/xcodeproj/internal/xcodeproj_runner.bzl
+++ b/xcodeproj/internal/xcodeproj_runner.bzl
@@ -69,6 +69,7 @@ common:_{config}_build --config={config}
         output = output,
         substitutions = {
             "%project_configs%": project_configs,
+            "%swiftcopt%": str(Label("@build_bazel_rules_swift//swift:copt")),
         },
     )
 


### PR DESCRIPTION
Old way is no longer supported as of Bazel 8.