### PR TITLE
Fix incorrect SHA2 for rules_swift

### DIFF
--- a/xcodeproj/repositories.bzl
+++ b/xcodeproj/repositories.bzl
@@ -121,7 +121,7 @@ def xcodeproj_rules_dependencies(
         _maybe(
             http_archive,
             name = "build_bazel_rules_swift",
-            sha256 = "ae6673d27024914fa89e32fd1369e9563fb8ede463feac703aaec1ba6ca0358c",
+            sha256 = "b17bdad10f3996cffc1ae3634e426d5280848cdb25ae5351f39357599938f5c6",
             url = "https://github.com/bazelbuild/rules_swift/releases/download/3.0.2/rules_swift.3.0.2.tar.gz",
             ignore_version_differences = ignore_version_differences,
         )


### PR DESCRIPTION
The `rules_swift` release page shows the hash that is listed in this file, but that hash is incorrect. The actual hash from downloading the file, as well as what *GitHub* shows as the hash, is this one.

<img width="772" alt="Screenshot 2025-07-10 at 5 56 16 AM" src="https://github.com/user-attachments/assets/aceb8f83-315c-4e08-b48a-296c65d1e62d" />
