### PR TITLE
Add Testing.framework to testing frameworks

### DIFF
--- a/xcodeproj/internal/bazel_integration_files/BUILD
+++ b/xcodeproj/internal/bazel_integration_files/BUILD
@@ -50,6 +50,7 @@ frameworks=(
   'libclang_rt.ubsan*.dylib'
   'libXCTestBundleInject.dylib'
   'libXCTestSwiftSupport.dylib'
+  'Testing.framework',
   'XCTAutomationSupport.framework'
   'XCTest.framework'
   'XCTestCore.framework'

--- a/xcodeproj/internal/bazel_integration_files/copy_outputs.sh
+++ b/xcodeproj/internal/bazel_integration_files/copy_outputs.sh
@@ -13,6 +13,7 @@ readonly test_frameworks=(
   "libXCTestSwiftSupport.dylib"
   "IDEBundleInjection.framework"
   "XCTAutomationSupport.framework"
+  "Testing.framework"
   "XCTest.framework"
   "XCTestCore.framework"
   "XCTestSupport.framework"


### PR DESCRIPTION
Resolves issues signing tests for execution on device. Adding to original fix: https://github.com/MobileNativeFoundation/rules_xcodeproj/issues/2395

<img width="968" height="480" alt="Xcode 2025-07-14 14 36 03" src="https://github.com/user-attachments/assets/c8a760bb-57fa-453f-9f49-491945f440a9" />
