### PR TITLE
Support new convention for WMO module deps artifacts naming in Xcode 26 beta 3

### DIFF
--- a/tools/swiftc_stub/main.swift
+++ b/tools/swiftc_stub/main.swift
@@ -80,12 +80,14 @@ func touchDepsFiles(isWMO: Bool, paths: [PathKey: URL]) throws {
     guard let outputFileMapPath = paths[PathKey.outputFileMap] else { return }
 
     if isWMO {
-        let dPath = String(
-            outputFileMapPath.path.dropLast("-OutputFileMap.json".count) +
-            "-master.d"
-        )
-        var url = URL(fileURLWithPath: dPath)
-        try url.touch()
+        // Xcode 26 beta 3 changed the naming convention for .d files of WMO modules to
+        // use a suffix of "-primary" instead of "-master". Support both for now.
+        let basePath = outputFileMapPath.path.dropLast("-OutputFileMap.json".count)
+        for suffix in ["-master", "-primary"] {
+            let dPath = "\(basePath)\(suffix).d"
+            var url = URL(fileURLWithPath: dPath)
+            try url.touch()
+        }
     } else {
         let data = try Data(contentsOf: outputFileMapPath)
         let outputFileMapRaw = try JSONSerialization.jsonObject(


### PR DESCRIPTION
Xcode 26 beta 3 [seems to have changed a convention](https://github.com/swiftlang/swift-build/blob/release/6.2/Sources/SWBCore/SpecImplementations/Tools/SwiftCompiler.swift#L2249) around the naming of various dependencies files when belonging to a WMO module, from using a `-master` suffix to `-primary`. 

As an aside, it's not clear to me why we can't use the fallback case in this method, since it appears as though it would help. Maybe @brentleyjones can weigh in. 