### PR TITLE
Fix Metal toolchains in Xcode 26 betas

### DIFF
--- a/xcodeproj/internal/templates/bazel_build.sh
+++ b/xcodeproj/internal/templates/bazel_build.sh
@@ -97,9 +97,20 @@ readonly base_pre_config_flags=(
 # Custom Swift toolchains
 
 if [[ -n "${TOOLCHAINS-}" ]]; then
-  toolchain="${TOOLCHAINS%% *}"
-  if [[ "$toolchain" == "com.apple.dt.toolchain.XcodeDefault" ]]; then
-    unset toolchain
+  # We remove all Metal toolchains from the list first
+  toolchains_array=($TOOLCHAINS)
+  filtered_toolchains=()
+  for tc in "${toolchains_array[@]}"; do
+    if [[ "$tc" != "com.apple.dt.toolchain.Metal"* ]]; then
+      filtered_toolchains+=("$tc")
+    fi
+  done
+
+  if [[ ${#filtered_toolchains[@]} -gt 0 ]]; then
+    toolchain="${filtered_toolchains[0]}"
+    if [[ "$toolchain" == "com.apple.dt.toolchain.XcodeDefault" ]]; then
+      unset toolchain
+    fi
   fi
 fi
 


### PR DESCRIPTION
Fixes:

```
Error: TOOLCHAINS was set to 'com.apple.dt.toolchain.Metal.32023' but the default toolchain was found, that likely means a matching toolchain isn't installed
```

Apparently `$toolchain` either was never set for Metal toolchains in earlier Xcode versions or Xcode didn't complain when it was set in `action_env`. I tested on Xcode 16 and it was never there while it definitely shows up in Xcode 26 Beta 3.

I think version check may not be needed here at all. If yes, please do let me know what would be suggested way of performing the check. I tried calling `xcodebuild -version` but that seem to randomly fail for some people so I removed it.