### PR TITLE
Fix issues building swift_test/macos_unit_test in Bazel

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -10,7 +10,7 @@ bazel_dep(name = "bazel_features", version = "1.3.0")
 bazel_dep(name = "bazel_skylib", version = "1.3.0")
 bazel_dep(
     name = "rules_swift",
-    version = "3.0.2",
+    version = "3.1.1",
     repo_name = "build_bazel_rules_swift",
 )
 bazel_dep(

--- a/examples/integration/.bazelrc
+++ b/examples/integration/.bazelrc
@@ -22,7 +22,8 @@ build:rules_xcodeproj --@build_bazel_rules_swift//swift:universal_tools
 build:rules_xcodeproj --apple_generate_dsym
 
 # To force swift_test to a specific OS version
-build:rules_xcodeproj --macos_minimum_os=12.0
+build:rules_xcodeproj --macos_minimum_os=13.0
+build:rules_xcodeproj --host_macos_minimum_os=13.0
 
 build --test_env=INTEGRATION_TEST_ENV_VAR=TRUE
 

--- a/examples/integration/CommandLine/Tests/BUILD
+++ b/examples/integration/CommandLine/Tests/BUILD
@@ -17,7 +17,7 @@ swift_library(
 
 macos_unit_test(
     name = "CommandLineToolTests",
-    minimum_os_version = "11.0",
+    minimum_os_version = "13.0",
     visibility = ["@rules_xcodeproj//xcodeproj:generated"],
     deps = [
         ":CommandLineLibSwiftTestsLib",

--- a/examples/integration/MODULE.bazel
+++ b/examples/integration/MODULE.bazel
@@ -15,7 +15,7 @@ bazel_dep(
 )
 bazel_dep(
     name = "rules_swift",
-    version = "3.0.2",
+    version = "3.1.1",
     repo_name = "build_bazel_rules_swift",
 )
 bazel_dep(name = "bazel_skylib", version = "1.5.0")


### PR DESCRIPTION
Couple of fixes as macOS 13.0 is now required for Swift test targets.