### PR TITLE
Update call to _uppercase_first_letter in process_bazel_build_log.py

### DIFF
--- a/xcodeproj/internal/bazel_integration_files/process_bazel_build_log.py
+++ b/xcodeproj/internal/bazel_integration_files/process_bazel_build_log.py
@@ -62,7 +62,7 @@ def _main(command: List[str]) -> None:
 
     def _replacement(match: re.Match) -> str:
         message = f"""\
-{match.group("loc")}{match.group("sev")}{uppercase_first_letter(match.group("msg"))}\
+{match.group("loc")}{match.group("sev")}{_uppercase_first_letter(match.group("msg"))}\
 """
 
         if message.startswith(execution_root):


### PR DESCRIPTION
Fixes this error when running builds in Xcode
```
  File "/Users/x/build/Project.xcodeproj/rules_xcodeproj/bazel/process_bazel_build_log.py", line 124, in <module>
    _main(sys.argv[1:])
  File "/Users/x/build/Project.xcodeproj/rules_xcodeproj/bazel/process_bazel_build_log.py", line 108, in _main
    _process_log_line(process.stderr.readline())
  File "/Users/x/build/Project.xcodeproj/rules_xcodeproj/bazel/process_bazel_build_log.py", line 99, in _process_log_line
    output_line = RELATIVE_DIAGNOSTICS_RE.sub(_replacement, input_line)
  File "/Users/x/build/Project.xcodeproj/rules_xcodeproj/bazel/process_bazel_build_log.py", line 65, in _replacement
    {match.group("loc")}{match.group("sev")}{uppercase_first_letter(match.group("msg"))}\
  NameError: name 'uppercase_first_letter' is not defined
```