### PR TITLE
Add --remote_download_outputs=toplevel to xcodeproj.bazelrc

### DIFF
--- a/xcodeproj/internal/templates/xcodeproj.bazelrc
+++ b/xcodeproj/internal/templates/xcodeproj.bazelrc
@@ -65,6 +65,9 @@ common:rules_xcodeproj --show_result=0
 common:rules_xcodeproj --noworker_sandboxing
 common:rules_xcodeproj --spawn_strategy=remote,worker,local
 
+# Output group outputs aren't downloaded with minimal, we need to use toplevel with Xcode
+build:rules_xcodeproj --remote_download=toplevel
+
 ### `--config=rules_xcodeproj_generator`
 #
 # Used when generating a project.


### PR DESCRIPTION
As titled. There's an issue when remote download minimal is generating empty app bundles when using Xcode.

```
error: Failed to read Info.plist of app /Users/ernesto/Library/Developer/Xcode/DerivedData/InstacartBazel-eqgbkfaxbhrobdfmvkzzkbbafnzs/Build/Products/Debug-iphonesimulator/bazel-out/ios_sim_arm64-dbg-ios-sim_arm64-min16.0-applebin_ios-ST-1de1fcec1e3b/bin/Instacart.app: The operation couldn't be completed. (SWBUtil.PropertyListConversionError error 1.) (in target 'InstacartDev' from project 'InstacartBazel')
```
