### PR TITLE
Use DEVELOPER_DIR as an --xcode_version

### DIFF
--- a/xcodeproj/internal/templates/bazel_build.sh
+++ b/xcodeproj/internal/templates/bazel_build.sh
@@ -79,7 +79,7 @@ readonly bazel_cmd
 
 readonly base_pre_config_flags=(
   # Be explicit about our desired Xcode version
-  "--xcode_version=$XCODE_PRODUCT_BUILD_VERSION"
+  "--xcode_version=$DEVELOPER_DIR"
 
   # Set `DEVELOPER_DIR` in case a bazel wrapper filters it
   "--repo_env=DEVELOPER_DIR=$DEVELOPER_DIR"


### PR DESCRIPTION
In the exceptional case where the user has multiple versions of Xcode on his system with the same Xcode version, we want to make sure that Xcode is invoking bazel by referring to itself.

As bazel supports passing DEVELOPER_DIR to --xcode_version, we're using that variable when invoked through Xcode instead.