### PR TITLE
Improve `compile_only_aspect`

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -58,6 +58,14 @@ bazel run //label/to:xcodeproj \
   'build --config=compile_only --remote_download_minimal $_GENERATOR_LABEL_'
 ```
 
+If you want to also cache resource processing (e.g. asset catalog compiles,
+`Info.plist` processing, entitlement processing, etc.), then you can also
+include the `resources` output group:
+
+```
+common:compile_only --output_groups=compiles,resources
+```
+
 # Bazel configs
 
 The way your project is generated, and the way Bazel builds it inside of Xcode,

--- a/xcodeproj/compile_only_aspect.bzl
+++ b/xcodeproj/compile_only_aspect.bzl
@@ -116,18 +116,11 @@ def _xcodeproj_cache_warm_aspect_impl(target, ctx):
             for action in target.actions
             if action.mnemonic in _COMPILE_MNEMONICS
         ]
-
-        if compile_outs:
-            # If this target compiled code, we don't need the transitive
-            # outputs, since they are implicitly compiled
-            deps = []
-        else:
-            # Otherwise collect the transitive outputs
-            deps = (
-                getattr(ctx.rule.attr, "deps", []) +
-                getattr(ctx.rule.attr, "implementation_deps", []) +
-                getattr(ctx.rule.attr, "private_deps", [])
-            )
+        deps = (
+            getattr(ctx.rule.attr, "deps", []) +
+            getattr(ctx.rule.attr, "implementation_deps", []) +
+            getattr(ctx.rule.attr, "private_deps", [])
+        )
     else:
         deps = getattr(ctx.rule.attr, "deps", [])
 


### PR DESCRIPTION
* Collect `CppCompile`
* Add a new `resources` output group, which will cause the resources that will be bundled to be processed (e.g. asset catalog compiles, `Info.plist` processing, entitlement processing, etc.)