### PR TITLE
Fix `AppleResourceInfo` value extraction in `compile_only_aspect`

### DIFF
--- a/xcodeproj/compile_only_aspect.bzl
+++ b/xcodeproj/compile_only_aspect.bzl
@@ -83,8 +83,8 @@ def _xcodeproj_cache_warm_aspect_impl(target, ctx):
         dep_resources = [
             resources
             for (_, _, resources) in (
-                resource_info.processed +
-                resource_info.unprocessed
+                getattr(resource_info, "processed", []) +
+                getattr(resource_info, "unprocessed", [])
             )
         ]
 


### PR DESCRIPTION
In some cases `AppleResourceInfo` won’t have all of its attributes, so we need to use `getattr`.