### PR TITLE
Update load statement in bazel.md for xcodeproj (#1)

### DIFF
--- a/docs/bazel.md
+++ b/docs/bazel.md
@@ -9,7 +9,7 @@ For example, to use the [`xcodeproj`](#xcodeproj) rule, you would need to use
 this `load` statement:
 
 ```starlark
-load("@rules_xcodeproj//xcodeproj:xcodeproj.bzl", "xcodeproj")
+load("@rules_xcodeproj//xcodeproj:defs.bzl", "xcodeproj")
 ```
 
 ### Index


### PR DESCRIPTION

# Summary
This pull request updates the documentation to reflect a change in the import path for the `xcodeproj` rule in Bazel. The `load` statement now references `defs.bzl` instead of `xcodeproj.bzl`.

Documentation update:

* Updated the Bazel documentation to load `xcodeproj` from `defs.bzl` instead of `xcodeproj.bzl` in the example `load` statement.

# Discussion

Isn't it more intuitive to use `defz.bzl` when presenting the core rules? 

:xcodeproj.bzl gets useless fast when trying to use top_level_target.bzl