### PR TITLE
Work around stale Xcode version from outer Bazel invocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ END_UNRELEASED_TEMPLATE
 
 ### Fixed
 
-* TBD
+* Fixed potential stale `--xcode_version` in `runner.sh`: [#3232](https://github.com/MobileNativeFoundation/rules_xcodeproj/pull/3232)
 
 ### Ruleset Development Changes
 


### PR DESCRIPTION
We were potentially setting a stale `--version` in `runner.sh`, because not everyone (including the local dev environment of this ruleset) has code in `tools/bazel` to force Bazel to re-evaluate its Xcode cache when `xcode-select -p` changes. Now we follow more of https://github.com/bazelbuild/rules_apple/blob/master/doc/common_info.md#xcode-version-selection-and-invalidation.