### PR TITLE
Omit plutil error

### DIFF
--- a/xcodeproj/internal/templates/installer.sh
+++ b/xcodeproj/internal/templates/installer.sh
@@ -188,7 +188,7 @@ if [[ $is_macos -eq 1 ]]; then
   plutil -replace IDEDidComputeMac32BitWarning -bool true "$workspace_checks"
 
   # - Configure the project to use Xcode's new build system.
-  plutil -remove BuildSystemType "$workspace_settings" > /dev/null || true
+  plutil -remove BuildSystemType "$workspace_settings" > /dev/null 2>&1 || true
 
   # - Prevent Xcode from prompting the user to autocreate schemes for all targets
   plutil -replace IDEWorkspaceSharedSettings_AutocreateContextsIfNeeded -bool false "$workspace_settings"


### PR DESCRIPTION
On macOS Tahoe, I get this log when generating the project:

```
Starting local Bazel server and connecting to it...
../Something.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings: No value to remove at key path BuildSystemType
```

Since we ignore errors with `|| true`, I imagine we don't care about this log either, which would only cause confusion for developers.