### PR TITLE
Fix issues with `xcodeproj_cache_warm_aspect` aspect

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -38,7 +38,7 @@ To use the aspect, you apply it at the command line:
 
 ```
 bazel build //some:target \
-  --aspects=@rules_xcodeproj//xcodeproj:compile_only_aspect.bzl%compile_only_aspect \
+  --aspects=@rules_xcodeproj//xcodeproj:compile_only_aspect.bzl%xcodeproj_cache_warm_aspect \
   --output_groups=compiles
 ```
 
@@ -46,7 +46,7 @@ You can also create a Bazel configuration in a `.bazelrc` file to reuse the
 aspect easily:
 
 ```
-common:compile_only --aspects=@rules_xcodeproj//xcodeproj:compile_only_aspect.bzl%compile_only_aspect
+common:compile_only --aspects=@rules_xcodeproj//xcodeproj:compile_only_aspect.bzl%xcodeproj_cache_warm_aspect
 common:compile_only --output_groups=compiles
 ```
 

--- a/xcodeproj/compile_only_aspect.bzl
+++ b/xcodeproj/compile_only_aspect.bzl
@@ -12,19 +12,14 @@ load("@build_bazel_rules_swift//swift:providers.bzl", "SwiftInfo")
 _BUNDLING_RULE_KINDS = set([
     "ios_app_clip",
     "ios_application",
-    "ios_build_test",
     "ios_extension",
     "macos_application",
-    "macos_build_test",
     "macos_extension",
     "tvos_application",
-    "tvos_build_test",
     "tvos_extension",
     "visionos_application",
-    "visionos_build_test",
     "visionos_extension",
     "watchos_application",
-    "watchos_build_test",
     "watchos_extension",
     "_ios_internal_ui_test_bundle",
     "_ios_internal_unit_test_bundle",
@@ -36,6 +31,14 @@ _BUNDLING_RULE_KINDS = set([
     "_visionos_internal_unit_test_bundle",
     "_watchos_internal_ui_test_bundle",
     "_watchos_internal_unit_test_bundle",
+])
+
+_BUILD_TEST_RULE_KINDS = set([
+    "ios_build_test",
+    "macos_build_test",
+    "tvos_build_test",
+    "visionos_build_test",
+    "watchos_build_test",
 ])
 
 _COMPILE_MNEMONICS = set([
@@ -106,7 +109,7 @@ def _xcodeproj_cache_warm_aspect_impl(target, ctx):
         ]
     elif ctx.rule.kind == "test_suite":
         deps = ctx.rule.attr.tests
-    elif ctx.rule.kind == "ios_build_test":
+    elif ctx.rule.kind in _BUILD_TEST_RULE_KINDS:
         deps = ctx.rule.attr.targets
     elif ctx.rule.kind == "xcodeproj":
         deps = (


### PR DESCRIPTION
- `*_build_test` rules does not have `deps` attr it has `targets`
- `*_build_test` does not have `AppleResourceInfo`
- Remove special case for `ios_build_test`, already handled by being added to the bundling rules list.