### PR TITLE
Integrate Samba rsync from BCR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ END_UNRELEASED_TEMPLATE
 ### Adjusted
 
 * Added support for Bazel 9: [#3286](https://github.com/MobileNativeFoundation/rules_xcodeproj/pull/3286)
+* Integrated [Samba rsync](https://rsync.samba.org) from BCR so that users no longer need to install it via homebrew: [#3265](https://github.com/MobileNativeFoundation/rules_xcodeproj/pull/3265)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ END_UNRELEASED_TEMPLATE
 ### Adjusted
 
 * We now resolve `bazel_env` earlier to reduce analysis cache invalidation when environment values are resolved dynamically: [#3305](https://github.com/MobileNativeFoundation/rules_xcodeproj/pull/3305)
+* Integrated [Samba rsync](https://rsync.samba.org) from BCR so that users no longer need to install it via homebrew: [#3265](https://github.com/MobileNativeFoundation/rules_xcodeproj/pull/3265)
 
 ### Fixed
 
@@ -88,7 +89,6 @@ END_UNRELEASED_TEMPLATE
 ### Adjusted
 
 * Added support for Bazel 9: [#3286](https://github.com/MobileNativeFoundation/rules_xcodeproj/pull/3286)
-* Integrated [Samba rsync](https://rsync.samba.org) from BCR so that users no longer need to install it via homebrew: [#3265](https://github.com/MobileNativeFoundation/rules_xcodeproj/pull/3265)
 
 ### Fixed
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -25,6 +25,7 @@ bazel_dep(
     repo_name = "build_bazel_rules_apple",
 )
 bazel_dep(name = "rules_python", version = "1.7.0")
+bazel_dep(name = "rsync", version = "3.4.1")
 
 repos = use_extension("//xcodeproj:extensions.bzl", "rules_repos")
 use_repo(
@@ -44,11 +45,6 @@ use_repo(
 bazel_dep(
     name = "buildifier_prebuilt",
     version = "6.3.3",
-    dev_dependency = True,
-)
-bazel_dep(
-    name = "rsync",
-    version = "3.4.1",
     dev_dependency = True,
 )
 bazel_dep(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -47,6 +47,11 @@ bazel_dep(
     dev_dependency = True,
 )
 bazel_dep(
+    name = "rsync",
+    version = "3.4.1",
+    dev_dependency = True,
+)
+bazel_dep(
     name = "rules_pkg",
     version = "1.0.1",
     dev_dependency = True,

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -25,7 +25,7 @@ bazel_dep(
     repo_name = "build_bazel_rules_apple",
 )
 bazel_dep(name = "rules_python", version = "1.7.0")
-bazel_dep(name = "rsync", version = "3.4.1")
+bazel_dep(name = "rsync", version = "3.4.2")
 
 repos = use_extension("//xcodeproj:extensions.bzl", "rules_repos")
 use_repo(

--- a/xcodeproj/internal/bazel_integration_files/BUILD
+++ b/xcodeproj/internal/bazel_integration_files/BUILD
@@ -9,6 +9,7 @@ _BASE_FILES = [
 filegroup(
     name = "bazel_integration_files",
     srcs = _BASE_FILES + [
+        ":renamed_rsync",
         ":renamed_swiftc_stub",
         ":rsync_excludes",
     ] + glob(
@@ -123,6 +124,27 @@ fi
         "manual",
         "no-sandbox",
     ],
+)
+
+genrule(
+    name = "renamed_rsync",
+    srcs = ["@rsync"],
+    outs = ["rsync"],
+    # Make `rsync` have the right name
+    cmd = """\
+readonly output="$@"
+if [[ $$(stat -f '%d' "$<") == $$(stat -f '%d' "$${output%/*}") ]]; then
+  cp -c "$<" "$@"
+else
+  cp "$<" "$@"
+fi
+""",
+    message = "Renaming rsync",
+    tags = [
+        "manual",
+        "no-sandbox",
+    ],
+    visibility = ["//visibility:public"],
 )
 
 # Release

--- a/xcodeproj/internal/bazel_integration_files/copy_dsyms.sh
+++ b/xcodeproj/internal/bazel_integration_files/copy_dsyms.sh
@@ -46,16 +46,13 @@ function patch_dsym() {
 EOF
 }
 
+readonly rsync="$BAZEL_INTEGRATION_DIR/rsync"
+
 if [[ -n "${BAZEL_OUTPUTS_DSYM:-}" ]]; then
   cd "${BAZEL_OUT%/*}"
 
-  # NOTE: use `which` to find the path to `rsync`.
-  # In macOS 15.4, the system `rsync` is using `openrsync` which contains some permission issues.
-  # This allows users to workaround the issue by overriding the system `rsync` with a working version.
-  # Remove this once we no longer support macOS versions with broken `rsync`.
   # shellcheck disable=SC2046
-  PATH="/opt/homebrew/bin:/usr/local/bin:$PATH" \
-    rsync \
+  "$rsync" \
     --copy-links \
     --recursive \
     --times \

--- a/xcodeproj/internal/bazel_integration_files/copy_outputs.sh
+++ b/xcodeproj/internal/bazel_integration_files/copy_outputs.sh
@@ -21,6 +21,8 @@ readonly test_frameworks=(
   "XCUnit.framework"
 )
 
+readonly rsync="$BAZEL_INTEGRATION_DIR/rsync"
+
 if [[ "$ACTION" != indexbuild ]]; then
   # Copy product
   if [[ -n ${BAZEL_OUTPUTS_PRODUCT:-} ]]; then
@@ -32,12 +34,7 @@ if [[ "$ACTION" != indexbuild ]]; then
       ln -sfh "$PWD/$BAZEL_OUTPUTS_PRODUCT_BASENAME" "$TARGET_BUILD_DIR/$PRODUCT_NAME"
     else
       # Product is a bundle
-      # NOTE: use `which` to find the path to `rsync`.
-      # In macOS 15.4, the system `rsync` is using `openrsync` which contains some permission issues.
-      # This allows users to workaround the issue by overriding the system `rsync` with a working version.
-      # Remove this once we no longer support macOS versions with broken `rsync`.
-      PATH="/opt/homebrew/bin:/usr/local/bin:$PATH" \
-        rsync \
+      "$rsync" \
         --copy-links \
         --recursive \
         --times \

--- a/xcodeproj/internal/templates/installer.sh
+++ b/xcodeproj/internal/templates/installer.sh
@@ -70,6 +70,7 @@ fi
 readonly src_generated_xcfilelist="$PWD/%generated_xcfilelist%"
 readonly src_generated_directories_filelist="$PWD/%generated_directories_filelist%"
 readonly src_project_pbxproj="$PWD/%project_pbxproj%"
+readonly src_rsync="$PWD/%rsync%"
 readonly src_xcschememanagement="$PWD/%xcschememanagement%"
 readonly src_xcschemes="$PWD/%xcschemes%/"
 readonly src_xcworkspacedata="$PWD/%contents_xcworkspacedata%"
@@ -89,13 +90,7 @@ readonly dest_xcschemes="$dest/xcshareddata/xcschemes"
 
 mkdir -p "$dest_xcschemes"
 
-# NOTE: use `which` to find the path to `rsync`.
-# In macOS 15.4, the system `rsync` is using `openrsync` which contains some permission issues.
-# This allows users to workaround the issue by overriding the system `rsync` with a working version.
-# Remove this once we no longer support macOS versions with broken `rsync`.
-# shellcheck disable=SC2046
-PATH="/opt/homebrew/bin:/usr/local/bin:$PATH" \
-  rsync \
+"$src_rsync" \
   --archive \
   --perms \
   --chmod=u+w,F-x \
@@ -132,6 +127,7 @@ rm -rf "$dest/rules_xcodeproj/bazel"/*
 $cp_cmd "${bazel_integration_files[@]}" "$dest/rules_xcodeproj/bazel"
 $cp_cmd "$bazel_env" "$dest/rules_xcodeproj/bazel/bazel_env.sh"
 $cp_cmd "$xcodeproj_bazelrc" "$dest/rules_xcodeproj/bazel/xcodeproj.bazelrc"
+chmod u+rx "$dest/rules_xcodeproj/bazel/rsync"
 
 if [[ -s "${extra_flags_bazelrc:-}" ]]; then
   $cp_cmd "$extra_flags_bazelrc" "$dest/rules_xcodeproj/bazel/xcodeproj_extra_flags.bazelrc"
@@ -149,10 +145,10 @@ chmod u+w "$dest_generated_xcfilelist"
 
 # - Keep only scripts as runnable
 find "$dest/rules_xcodeproj/bazel" \
-  -type f \( -name "*.sh" -o -name "*.py" -o -name "ld" -o -name "libtool" \) \
+  -type f \( -name "*.sh" -o -name "*.py" -o -name "ld" -o -name "libtool" -o -name "rsync" \) \
   -print0 | xargs -0 chmod u+x
 find "$dest/rules_xcodeproj/bazel" \
-  -type f ! \( -name "swiftc" -o -name "ld" -o -name "libtool" -o -name "import_indexstores" -o -name "*.sh" -o -name "*.py" \) \
+  -type f ! \( -name "swiftc" -o -name "ld" -o -name "libtool" -o -name "import_indexstores" -o -name "rsync" -o -name "*.sh" -o -name "*.py" \) \
   -print0 | xargs -0 chmod -x
 
 # Copy over `project.xcworkspace/contents.xcworkspacedata` if needed

--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -257,6 +257,7 @@ def _write_installer(
         install_path,
         name,
         project_pbxproj,
+        rsync,
         template,
         xcschememanagement,
         xcschemes):
@@ -280,6 +281,7 @@ def _write_installer(
             "%generated_xcfilelist%": generated_xcfilelist.short_path,
             "%output_path%": install_path,
             "%project_pbxproj%": project_pbxproj.short_path,
+            "%rsync%": rsync.short_path,
             "%xcschememanagement%": xcschememanagement.short_path,
             "%xcschemes%": xcschemes.short_path,
         },
@@ -746,6 +748,7 @@ Are you using an `alias`? `xcodeproj.focused_targets` and \
         install_path = install_path,
         name = name,
         project_pbxproj = project_pbxproj,
+        rsync = ctx.file._rsync,
         template = ctx.file._installer_template,
         xcschememanagement = xcschememanagement,
         xcschemes = xcschemes,
@@ -877,6 +880,11 @@ A dict mapping of Labels for StoreKit Testing configuration files to their File 
             default = Label(
                 "//xcodeproj/internal/templates:installer.sh",
             ),
+        ),
+        "_rsync": attr.label(
+            allow_single_file = True,
+            cfg = "exec",
+            default = Label("//xcodeproj/internal/bazel_integration_files:renamed_rsync"),
         ),
         # TODO: Remove 5.8 when support for Xcode 16.x is dropped.
         "_legacy_index_import": attr.label(

--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -881,11 +881,6 @@ A dict mapping of Labels for StoreKit Testing configuration files to their File 
                 "//xcodeproj/internal/templates:installer.sh",
             ),
         ),
-        "_rsync": attr.label(
-            allow_single_file = True,
-            cfg = "exec",
-            default = Label("//xcodeproj/internal/bazel_integration_files:renamed_rsync"),
-        ),
         # TODO: Remove 5.8 when support for Xcode 16.x is dropped.
         "_legacy_index_import": attr.label(
             cfg = "exec",
@@ -912,6 +907,11 @@ A dict mapping of Labels for StoreKit Testing configuration files to their File 
                 "//tools/generators/pbxtargetdependencies:universal_pbxtargetdependencies",
             ),
             executable = True,
+        ),
+        "_rsync": attr.label(
+            allow_single_file = True,
+            cfg = "exec",
+            default = Label("//xcodeproj/internal/bazel_integration_files:renamed_rsync"),
         ),
         "_selected_model_versions_generator": attr.label(
             cfg = "exec",


### PR DESCRIPTION
Integrating [rsync](https://registry.bazel.build/modules/rsync) from BCR to stop relying on system `rsync` / homebrew `rsync`. We allow users to rely on homebrew `rsync` ever since the issue with `openrsync` on maCOS popped up. This fixes that.