### PR TITLE
Use cache config when building release archive

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -51,7 +51,7 @@ jobs:
           BUILDBUDDY_RBE_API_KEY: ${{ secrets.BUILDBUDDY_RBE_API_KEY }}
         run: |
           bazel build \
-            --config=remote \
+            --config=cache \
             --remote_header="x-buildbuddy-api-key=${BUILDBUDDY_RBE_API_KEY}" \
             //distribution:release
 


### PR DESCRIPTION
We can't use RBE just yet.