### PR TITLE
Set --remote_download_outputs=toplevel when building release archive

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -53,6 +53,7 @@ jobs:
           bazel build \
             --config=cache \
             --remote_header="x-buildbuddy-api-key=${BUILDBUDDY_RBE_API_KEY}" \
+            --remote_download_outputs=toplevel \
             //distribution:release
 
       - name: Compute integrity


### PR DESCRIPTION
Step that computes integrity was failing since the files weren't being downloaded. Tested it with https://github.com/MobileNativeFoundation/rules_xcodeproj/actions/runs/21839909776/job/63021128417