### PR TITLE
fix TOCTOU race when reading xcbuilddata bundle

### DIFF
--- a/xcodeproj/internal/bazel_integration_files/calculate_output_groups.py
+++ b/xcodeproj/internal/bazel_integration_files/calculate_output_groups.py
@@ -113,28 +113,34 @@ https://github.com/MobileNativeFoundation/rules_xcodeproj/issues/new?template=bu
         )
 
     def wait_for_build_request():
-        xcbuilddata = max(
-            glob.iglob(f"{objroot}/XCBuildData/*.xcbuilddata"),
-            key = os.path.getctime,
-        )
-        if os.path.getctime(xcbuilddata) >= build_request_min_ctime:
-            build_request_file = f"{xcbuilddata}/build-request.json"
-            if os.path.exists(build_request_file):
-                with open(build_request_file, encoding = "utf-8") as f:
-                    # Parse the build-request.json file
-                    try:
-                        return json.load(f)
-                    except Exception as error:
-                        print(
-                            f"""\
+        try:
+            xcbuilddata = max(
+                glob.iglob(f"{objroot}/XCBuildData/*.xcbuilddata"),
+                key = os.path.getctime,
+            )
+            if os.path.getctime(xcbuilddata) < build_request_min_ctime:
+                return None
+        except (ValueError, FileNotFoundError, OSError):
+            # ValueError: no .xcbuilddata files yet (empty glob)
+            # FileNotFoundError/OSError: TOCTOU race - file deleted between glob and getctime
+            return None
+        build_request_file = f"{xcbuilddata}/build-request.json"
+        if os.path.exists(build_request_file):
+            with open(build_request_file, encoding = "utf-8") as f:
+                # Parse the build-request.json file
+                try:
+                    return json.load(f)
+                except Exception as error:
+                    print(
+                        f"""\
 error: Failed to parse '{build_request_file}':
 {type(error).__name__}: {error}.
 
 Please file a bug report here: \
 https://github.com/MobileNativeFoundation/rules_xcodeproj/issues/new?template=bug.md""",
-                            file = sys.stderr,
-                        )
-                        exit(1)
+                        file = sys.stderr,
+                    )
+                    sys.exit(1)
         return None
 
     return _wait_for_value(


### PR DESCRIPTION
## Summary

Fixes a race condition in `calculate_output_groups.py` that causes intermittent build failures when Xcode deletes `.xcbuilddata` bundles concurrently with the pre-build script.

## Problem

The `wait_for_build_request()` function uses `glob.iglob()` (a lazy generator) with `os.path.getctime()` as the key for `max()`. Because the generator yields paths lazily, there's a window between when a path is yielded and when `getctime()` is called during which Xcode's build system can delete or replace the `.xcbuilddata` bundle. This results in a `FileNotFoundError` that bypasses the `_wait_for_value()` retry loop and fails the build.

This particularly affects CI environments where DerivedData is reused across builds—stale `.xcbuilddata` bundles from previous runs are present when a new build starts, and Xcode begins replacing them concurrently with the pre-build script.

Example failure:

```
Build description signature: 8999db0ef50cb36294751fc27f4dc82e
Build description path: /Users/ec2-user/Library/Developer/Xcode/DerivedData/MyApp-bqspktvzncwdrrfbzlfbtjjpxguv/Build/Intermediates.noindex/XCBuildData/8999db0ef50cb36294751fc27f4dc82e.xcbuilddata
note: Run script build phase 'Generate Bazel Dependencies' will be run during every build because the option to run the script phase "Based on dependency analysis" is unchecked. (in target 'BazelDependencies' from project 'MyApp')
PhaseScriptExecution Generate\ Bazel\ Dependencies /Users/ec2-user/Library/Developer/Xcode/DerivedData/MyApp-bqspktvzncwdrrfbzlfbtjjpxguv/Build/Intermediates.noindex/MyApp.build/rules_xcodeproj/Script-FF0100000000000000000004.sh (in target 'BazelDependencies' from project 'MyApp')
cd /var/lib/buildkite-agent/bazel-v8/a23a3d7f05a33a445e382baf0a41d6e8/rules_xcodeproj.noindex/build_output_base/execroot/_main
/bin/sh -c /Users/ec2-user/Library/Developer/Xcode/DerivedData/MyApp-bqspktvzncwdrrfbzlfbtjjpxguv/Build/Intermediates.noindex/MyApp.build/rules_xcodeproj/Script-FF0100000000000000000004.sh
error: Failed to calculate labels and target ids from PIFCache:
Traceback (most recent call last):
File "/path/to/MyApp.xcodeproj/rules_xcodeproj/bazel/calculate_output_groups.py", line 383, in _main
build_request = _get_build_request(
File "/path/to/MyApp.xcodeproj/rules_xcodeproj/bazel/calculate_output_groups.py", line 140, in _get_build_request
return _wait_for_value(
File "/path/to/MyApp.xcodeproj/rules_xcodeproj/bazel/calculate_output_groups.py", line 30, in _wait_for_value
value = calculate_value()
File "/path/to/MyApp.xcodeproj/rules_xcodeproj/bazel/calculate_output_groups.py", line 116, in wait_for_build_request
xcbuilddata = max(
File "/Applications/Xcode.app/Contents/Developer/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/genericpath.py", line 65, in getctime
return os.stat(filename).st_ctime
FileNotFoundError: [Errno 2] No such file or directory: '/Users/ec2-user/Library/Developer/Xcode/DerivedData/MyApp-bqspktvzncwdrrfbzlfbtjjpxguv/Build/Intermediates.noindex/XCBuildData/6b62e9ec6732598a060e57bdb109a782.xcbuilddata'
Please file a bug report here: https://github.com/MobileNativeFoundation/rules_xcodeproj/issues/new?template=bug.md
** BUILD FAILED **
```

## Solution

Wrap both `getctime()` call sites in try/except blocks that catch:
- `ValueError` (empty glob, no `.xcbuilddata` files yet)
- `FileNotFoundError`/`OSError` (TOCTOU race—file deleted between glob and getctime)

When these exceptions occur, return `None` to allow `_wait_for_value()` to retry properly instead of crashing.

## Testing

- Validated in our CI environment -- no more flakes with this change
