### PR TITLE
Add max_compatibility_level = 3 for rules_swift dep

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -17,6 +17,7 @@ bazel_dep(name = "rules_cc", version = "0.2.17")
 bazel_dep(
     name = "rules_swift",
     version = "3.5.0",
+    max_compatibility_level = 3,
     repo_name = "build_bazel_rules_swift",
 )
 bazel_dep(


### PR DESCRIPTION
## Summary

* Add `max_compatibility_level = 3` to the `rules_swift` `bazel_dep` in `MODULE.bazel`
* The upcoming `rules_swift` release bumps `compatibility_level` from 2 to 3, which breaks Bzlmod resolution for downstream projects unless dependents declare `max_compatibility_level = 3`
* Other modules in the ecosystem (`rules_apple`, `rules_swift_package_manager`, `swift-syntax`, `swift-index-store`) already declare this

## Test plan

- [ ] Verify Bzlmod resolution succeeds with a `rules_swift` git override at a commit past the `compatibility_level = 3` bump (e.g. `00e74b8`)