### PR TITLE
Use #!/usr/bin/env bash instead of #!/bin/bash in template scripts

### DIFF
--- a/xcodeproj/internal/templates/generate_bazel_dependencies.sh
+++ b/xcodeproj/internal/templates/generate_bazel_dependencies.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/xcodeproj/internal/templates/installer.sh
+++ b/xcodeproj/internal/templates/installer.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/xcodeproj/internal/templates/runner.sh
+++ b/xcodeproj/internal/templates/runner.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 


### PR DESCRIPTION
## Problem

macOS ships bash 3.2 at `/bin/bash`. Apple stopped updating it years ago due to GPLv3 licensing and has moved to zsh as the default shell. This means `/bin/bash` will likely remain at 3.2 indefinitely.

Some Bazel wrapper scripts (e.g. `tools/bazel`) now require bash 4.4+ for features like safe empty array expansion under `set -u`. When rules_xcodeproj's generated scripts use `#!/bin/bash`, they pick up the system bash 3.2, which then fails when invoking these wrapper scripts:

```
tools/bazel: requires bash 4.4+, found bash 3.2.57(1)-release at /bin/bash
```

## Fix

Change the shebang in the three template scripts from `#!/bin/bash` to `#!/usr/bin/env bash`:

- `xcodeproj/internal/templates/runner.sh`
- `xcodeproj/internal/templates/installer.sh`
- `xcodeproj/internal/templates/generate_bazel_dependencies.sh`

This picks up whichever `bash` is first on `$PATH`, which on macOS with Homebrew will be the modern bash 5.x at `/opt/homebrew/bin/bash`.

This is a standard practice — `#!/usr/bin/env bash` is the [recommended portable shebang](https://www.gnu.org/software/bash/manual/html_node/Invoking-Bash.html) and is already used by Bazel itself and many other tools in the ecosystem.