### PR TITLE
Fix `--remote_download_regex` matching all files unconditionally

### DIFF
--- a/xcodeproj/internal/bazel_integration_files/generate_index_build_bazel_dependencies.sh
+++ b/xcodeproj/internal/bazel_integration_files/generate_index_build_bazel_dependencies.sh
@@ -56,7 +56,7 @@ readonly build_pre_config_flags=(
   # This is brittle. If different file extensions are used for compilation
   # inputs, they will need to be added to this list. Ideally we can stop doing
   # this once Bazel adds support for a Remote Output Service.
-  "--remote_download_regex=${indexstores_regex}.*|.*\.(cfg|c|C|cc|cl|cpp|cu|cxx|c++|def|h|H|hh|hpp|hxx|h++|hmap|ilc|inc|inl|ipp|tcc|tlh|tli|tpp|m|modulemap|mm|pch|swift|swiftdoc|swiftmodule|swiftsourceinfo|yaml)$"
+  "--remote_download_regex=${indexstores_regex}.*\.(cfg|c|C|cc|cl|cpp|cu|cxx|c++|def|h|H|hh|hpp|hxx|h++|hmap|ilc|inc|inl|ipp|tcc|tlh|tli|tpp|m|modulemap|mm|pch|swift|swiftdoc|swiftmodule|swiftsourceinfo|yaml)$"
 )
 
 source "$BAZEL_INTEGRATION_DIR/bazel_build.sh"


### PR DESCRIPTION
#### Summary

Fix a bug in `generate_index_build_bazel_dependencies.sh` where the `--remote_download_regex` pattern matches all files unconditionally, defeating the purpose of selective downloads during Index Build.

#### Problem

The current regex:
```
--remote_download_regex=${indexstores_regex}.*|.*\.(cfg|c|C|cc|...)$
```

The `.*|` at the boundary acts as an unbounded wildcard. Due to regex OR semantics, it matches every file before the alternation is even evaluated. This means all remote cache outputs are downloaded locally during Index Build, regardless of file extension.

The intent was to download only indexstores (matched by `${indexstores_regex}`) and files with indexing-relevant extensions (`.swiftmodule`, `.swiftdoc`, `.swift`, headers, etc.). Instead, every output, including `.o` files, intermediate artifacts, and linked binaries, is downloaded.

#### Fix

Remove the erroneous `.*|` so the regex correctly constrains downloads to indexstores and listed extensions only:

```
--remote_download_regex=${indexstores_regex}.*\.(cfg|c|C|cc|...)$
```

#### Impact

In a large-scale monorepo, this bug caused Index Build's local storage to grow from an expected few GB to over 1TB, as all remote cache outputs were downloaded unconditionally. With the fix, only indexing-relevant files are downloaded.

#### Related

- #3078