### PR TITLE
Add lightweight `bi` output group to skip linking during Index Build

### DIFF
--- a/xcodeproj/internal/bazel_integration_files/generate_index_build_bazel_dependencies.sh
+++ b/xcodeproj/internal/bazel_integration_files/generate_index_build_bazel_dependencies.sh
@@ -10,11 +10,12 @@ readonly config="${BAZEL_CONFIG}_indexbuild"
 output_groups=(
   # Compile params
   "bc $BAZEL_TARGET_ID"
-  # Products (i.e. bundles) and index store data. The products themselves aren't
-  # used, they cause transitive files to be created. We use
-  # `--remote_download_regex` below to collect the files we care
+  # Indexstores and their filelist. Requesting indexstore directories triggers
+  # transitive Swift compilation (producing swiftmodules, indexstores, and
+  # generated headers) without linking, avoiding large product binaries. We use
+  # `--remote_download_regex` below to download the files we care
   # about.
-  "bp $BAZEL_TARGET_ID"
+  "bi $BAZEL_TARGET_ID"
 )
 
 indexstores_filelists=()

--- a/xcodeproj/internal/files/output_files.bzl
+++ b/xcodeproj/internal/files/output_files.bzl
@@ -262,8 +262,17 @@ def _collect_output_files(
         transitive = [transitive_products],
     )
 
+    # Indexing output group: contains indexstores (to trigger Swift compilation)
+    # and the indexstores filelist (for import_indexstores). Unlike `bp`, this
+    # does not include linked products, avoiding large binary materialization.
+    indexing_depset = memory_efficient_depset(
+        [indexstores_filelist],
+        transitive = [transitive_indexstores],
+    )
+
     direct_group_list = [
         ("bc {}".format(id), transitive_compile_params),
+        ("bi {}".format(id), indexing_depset),
         ("bl {}".format(id), transitive_link_params),
         (products_output_group_name, products_depset),
     ]


### PR DESCRIPTION
#### Summary

Introduce a new `bi` (build indexing) output group that contains only indexstores and their filelist, and switch Index Build to use `bi` instead of `bp`. This eliminates linking during Index Build, dramatically reducing local storage consumption and build time.

#### Problem

Index Build currently requests the `bp` (build products) output group, which includes linked product binaries (test bundles, app bundles). As noted in the existing comment:

> *"Products (i.e. bundles) and index store data. The products themselves aren't used, they cause transitive files to be created."*

The products are not used for indexing. They only serve as a trigger for transitive compilation. However, requesting linked products has significant side effects:

1. **Local builds**: Bazel's action graph is demand-driven. Requesting linked products forces the linker to run for every target, producing large binaries. In a large project with many test targets, this results in hundreds of GB of unnecessary linked output.

2. **Remote cache hits**: Even with `--remote_download_regex`, linked product binaries in the `bp` output group are subject to download via `--remote_download_outputs=toplevel` (configured in `xcodeproj.bazelrc`), further inflating local storage.

#### Solution

Add a new `bi` output group containing only:
- **`transitive_indexstores`**: indexstore directories that trigger Swift compilation
- **`indexstores_filelist`**: file list consumed by `import_indexstores`

Both are already collected in `output_files.bzl` but were not exposed as a separate output group.

##### Why `bi` correctly triggers all necessary compilation

Bazel's action graph is demand-driven: it executes only actions required to produce requested outputs. `SwiftCompile` is a single action that co-produces:
- `.indexstore` (requested via `bi`)
- `.swiftmodule`
- `.swiftdoc`
- `.swiftsourceinfo`
- `-Swift.h` (generated Objective-C header)
- `.o` (object file)

Since indexstores are a direct output of `SwiftCompile`, requesting them triggers the full compilation for every transitively depended Swift module, covering the same compilation scope as `bp`. The critical difference is that no linking action is triggered, because no linked product is in any requested output group.

The `--remote_download_regex` (already present in the script) then filters which compilation outputs to actually download from remote cache (`.swiftmodule`, `.swiftdoc`, headers, etc.), excluding unnecessary files like `.o`.

##### ObjC compatibility

ObjC module indexing is unaffected. In rules_xcodeproj, ObjC/C indexing is handled by Xcode's own clang compiler, and `-index-store-path` is explicitly stripped from CC flags passed to Bazel. ObjC compilation parameters are delivered through the `bc` output group, which remains unchanged.

#### Results

Tested in a large-scale production monorepo. Before the change, Index Build's `bazel-out` directory consumed over 1TB of local storage due to linked product binaries that were unnecessary for indexing. After switching to `bi`, storage dropped to a few GB. No test bundles or app binaries are materialized, and Index Build completes significantly faster since linking is entirely skipped.

#### Considerations

This is a behavioral change to Index Build's output group selection. Testing confirms it works correctly for both Swift and ObjC modules in a large production codebase, but if a more conservative rollout is preferred, this could be gated behind an `xcodeproj` rule attribute (e.g., `index_build_output_group`) to allow projects to opt in. Happy to add that if desired.