### PR TITLE
Generate project-relative .lldbinit file

### DIFF
--- a/tools/generators/lib/XCScheme/src/BuildableReference.swift
+++ b/tools/generators/lib/XCScheme/src/BuildableReference.swift
@@ -2,7 +2,7 @@ public struct BuildableReference: Equatable, Hashable {
     public let blueprintIdentifier: String
     let buildableName: String
     public let blueprintName: String
-    let referencedContainer: String
+    public let referencedContainer: String
 
     public init(
         blueprintIdentifier: String,

--- a/tools/generators/lib/XCScheme/src/CreateLaunchAction.swift
+++ b/tools/generators/lib/XCScheme/src/CreateLaunchAction.swift
@@ -12,6 +12,7 @@ public struct CreateLaunchAction {
     public func callAsFunction(
         buildConfiguration: String,
         commandLineArguments: [CommandLineArgument],
+        customLLDBInitFile: String?,
         customWorkingDirectory: String?,
         enableAddressSanitizer: Bool,
         enableThreadSanitizer: Bool,
@@ -27,6 +28,7 @@ public struct CreateLaunchAction {
         return callable(
             /*buildConfiguration:*/ buildConfiguration,
             /*commandLineArguments:*/ commandLineArguments,
+            /*customLLDBInitFile:*/ customLLDBInitFile,
             /*customWorkingDirectory:*/ customWorkingDirectory,
             /*enableAddressSanitizer:*/ enableAddressSanitizer,
             /*enableThreadSanitizer:*/ enableThreadSanitizer,
@@ -48,6 +50,7 @@ extension CreateLaunchAction {
     public typealias Callable = (
         _ buildConfiguration: String,
         _ commandLineArguments: [CommandLineArgument],
+        _ customLLDBInitFile: String?,
         _ customWorkingDirectory: String?,
         _ enableAddressSanitizer: Bool,
         _ enableThreadSanitizer: Bool,
@@ -64,6 +67,7 @@ extension CreateLaunchAction {
     public static func defaultCallable(
         buildConfiguration: String,
         commandLineArguments: [CommandLineArgument],
+        customLLDBInitFile: String?,
         customWorkingDirectory: String?,
         enableAddressSanitizer: Bool,
         enableThreadSanitizer: Bool,
@@ -97,6 +101,12 @@ selectedDebuggerIdentifier = ""
 selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
 """#
+            )
+        }
+
+        if let customLLDBInitFile {
+            components.append(
+                #"customLLDBInitFile = "\#(customLLDBInitFile)""#
             )
         }
 

--- a/tools/generators/lib/XCScheme/src/CreateProfileAction.swift
+++ b/tools/generators/lib/XCScheme/src/CreateProfileAction.swift
@@ -12,6 +12,7 @@ public struct CreateProfileAction {
     public func callAsFunction(
         buildConfiguration: String,
         commandLineArguments: [CommandLineArgument],
+        customLLDBInitFile: String?,
         customWorkingDirectory: String?,
         environmentVariables: [EnvironmentVariable],
         postActions: [ExecutionAction],
@@ -22,6 +23,7 @@ public struct CreateProfileAction {
         return callable(
             /*buildConfiguration:*/ buildConfiguration,
             /*commandLineArguments:*/ commandLineArguments,
+            /*customLLDBInitFile:*/ customLLDBInitFile,
             /*customWorkingDirectory:*/ customWorkingDirectory,
             /*environmentVariables:*/ environmentVariables,
             /*postActions:*/ postActions,
@@ -38,6 +40,7 @@ extension CreateProfileAction {
     public typealias Callable = (
         _ buildConfiguration: String,
         _ commandLineArguments: [CommandLineArgument],
+        _ customLLDBInitFile: String?,
         _ customWorkingDirectory: String?,
         _ environmentVariables: [EnvironmentVariable],
         _ postActions: [ExecutionAction],
@@ -49,6 +52,7 @@ extension CreateProfileAction {
     public static func defaultCallable(
         buildConfiguration: String,
         commandLineArguments: [CommandLineArgument],
+        customLLDBInitFile: String?,
         customWorkingDirectory: String?,
         environmentVariables: [EnvironmentVariable],
         postActions: [ExecutionAction],
@@ -65,6 +69,12 @@ buildConfiguration = "\#(buildConfiguration)"
       savedToolIdentifier = ""
 """#,
         ]
+
+        if let customLLDBInitFile {
+            components.append(
+                #"customLLDBInitFile = "\#(customLLDBInitFile)""#
+            )
+        }
 
         if let customWorkingDirectory {
             components.append(

--- a/tools/generators/lib/XCScheme/src/CreateTestAction.swift
+++ b/tools/generators/lib/XCScheme/src/CreateTestAction.swift
@@ -15,6 +15,7 @@ public struct CreateTestAction {
         codeCoverage: Bool,
         buildConfiguration: String,
         commandLineArguments: [CommandLineArgument],
+        customLLDBInitFile: String?,
         enableAddressSanitizer: Bool,
         enableThreadSanitizer: Bool,
         enableUBSanitizer: Bool,
@@ -33,6 +34,7 @@ public struct CreateTestAction {
             /*codeCoverage:*/ codeCoverage,
             /*buildConfiguration:*/ buildConfiguration,
             /*commandLineArguments:*/ commandLineArguments,
+            /*customLLDBInitFile:*/ customLLDBInitFile,
             /*enableAddressSanitizer:*/ enableAddressSanitizer,
             /*enableThreadSanitizer:*/ enableThreadSanitizer,
             /*enableUBSanitizer:*/ enableUBSanitizer,
@@ -57,6 +59,7 @@ extension CreateTestAction {
         _ codeCoverage: Bool,
         _ buildConfiguration: String,
         _ commandLineArguments: [CommandLineArgument],
+        _ customLLDBInitFile: String?,
         _ enableAddressSanitizer: Bool,
         _ enableThreadSanitizer: Bool,
         _ enableUBSanitizer: Bool,
@@ -76,6 +79,7 @@ extension CreateTestAction {
         codeCoverage: Bool,
         buildConfiguration: String,
         commandLineArguments: [CommandLineArgument],
+        customLLDBInitFile: String?,
         enableAddressSanitizer: Bool,
         enableThreadSanitizer: Bool,
         enableUBSanitizer: Bool,
@@ -98,6 +102,12 @@ buildConfiguration = "\#(buildConfiguration)"
       shouldUseLaunchSchemeArgsEnv = "\#(useLaunchSchemeArgsEnv.xmlString)"
 """#,
         ]
+
+        if let customLLDBInitFile {
+            components.append(
+                #"customLLDBInitFile = "\#(customLLDBInitFile)""#
+            )
+        }
 
         if enableAddressSanitizer {
             components.append(#"enableAddressSanitizer = "YES""#)

--- a/tools/generators/lib/XCScheme/test/CreateLaunchActionTests.swift
+++ b/tools/generators/lib/XCScheme/test/CreateLaunchActionTests.swift
@@ -131,6 +131,33 @@ final class CreateLaunchActionTests: XCTestCase {
         XCTAssertNoDifference(action, expectedAction)
     }
 
+    func test_customLLDBInitFile() {
+        let buildConfiguration = "Release"
+        let customLLDBInitFile = "$(SRCROOT)/.lldbinit-rules_xcodeproj"
+
+        let expectedAction = #"""
+   <LaunchAction
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$(SRCROOT)/.lldbinit-rules_xcodeproj"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+"""#
+
+        let action = createLaunchActionWithDefaults(
+            buildConfiguration: buildConfiguration,
+            customLLDBInitFile: customLLDBInitFile
+        )
+
+        XCTAssertNoDifference(action, expectedAction)
+    }
+
     func test_disableMainThreadChecker() {
         // Arrange
 
@@ -585,6 +612,7 @@ final class CreateLaunchActionTests: XCTestCase {
 private func createLaunchActionWithDefaults(
     buildConfiguration: String,
     commandLineArguments: [CommandLineArgument] = [],
+    customLLDBInitFile: String? = nil,
     customWorkingDirectory: String? = nil,
     enableAddressSanitizer: Bool = false,
     enableThreadSanitizer: Bool = false,
@@ -600,6 +628,7 @@ private func createLaunchActionWithDefaults(
     return CreateLaunchAction.defaultCallable(
         buildConfiguration: buildConfiguration,
         commandLineArguments: commandLineArguments,
+        customLLDBInitFile: customLLDBInitFile,
         customWorkingDirectory: customWorkingDirectory,
         enableAddressSanitizer: enableAddressSanitizer,
         enableThreadSanitizer: enableThreadSanitizer,

--- a/tools/generators/lib/XCScheme/test/CreateProfileActionTests.swift
+++ b/tools/generators/lib/XCScheme/test/CreateProfileActionTests.swift
@@ -104,6 +104,29 @@ final class CreateProfileActionTests: XCTestCase {
         XCTAssertNoDifference(prefix, expectedPrefix)
     }
 
+    func test_customLLDBInitFile() {
+        let buildConfiguration = "Profile"
+        let customLLDBInitFile = "$(SRCROOT)/.lldbinit-rules_xcodeproj"
+
+        let expectedPrefix = #"""
+   <ProfileAction
+      buildConfiguration = "Profile"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      customLLDBInitFile = "$(SRCROOT)/.lldbinit-rules_xcodeproj"
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+"""#
+
+        let prefix = createProfileActionWithDefaults(
+            buildConfiguration: buildConfiguration,
+            customLLDBInitFile: customLLDBInitFile
+        )
+
+        XCTAssertNoDifference(prefix, expectedPrefix)
+    }
+
     func test_environmentVariables() {
         // Arrange
 
@@ -379,6 +402,7 @@ final class CreateProfileActionTests: XCTestCase {
 private func createProfileActionWithDefaults(
     buildConfiguration: String,
     commandLineArguments: [CommandLineArgument] = [],
+    customLLDBInitFile: String? = nil,
     customWorkingDirectory: String? = nil,
     environmentVariables: [EnvironmentVariable] = [],
     postActions: [ExecutionAction] = [],
@@ -389,6 +413,7 @@ private func createProfileActionWithDefaults(
     return CreateProfileAction.defaultCallable(
         buildConfiguration: buildConfiguration,
         commandLineArguments: commandLineArguments,
+        customLLDBInitFile: customLLDBInitFile,
         customWorkingDirectory: customWorkingDirectory,
         environmentVariables: environmentVariables,
         postActions: postActions,

--- a/tools/generators/lib/XCScheme/test/CreateTestActionTests.swift
+++ b/tools/generators/lib/XCScheme/test/CreateTestActionTests.swift
@@ -77,6 +77,30 @@ final class CreateTestActionTests: XCTestCase {
         XCTAssertNoDifference(action, expectedAction)
     }
 
+    func test_customLLDBInitFile() {
+        let buildConfiguration = "Debug"
+        let customLLDBInitFile = "$(SRCROOT)/.lldbinit-rules_xcodeproj"
+
+        let expectedAction = #"""
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      customLLDBInitFile = "$(SRCROOT)/.lldbinit-rules_xcodeproj">
+      <Testables>
+      </Testables>
+   </TestAction>
+"""#
+
+        let action = createTestActionWithDefaults(
+            buildConfiguration: buildConfiguration,
+            customLLDBInitFile: customLLDBInitFile
+        )
+
+        XCTAssertNoDifference(action, expectedAction)
+    }
+
     func test_disableMainThreadChecker() {
         // Arrange
 
@@ -458,6 +482,7 @@ private func createTestActionWithDefaults(
     codeCoverage: Bool = false,
     buildConfiguration: String,
     commandLineArguments: [CommandLineArgument] = [],
+    customLLDBInitFile: String? = nil,
     enableAddressSanitizer: Bool = false,
     enableThreadSanitizer: Bool = false,
     enableUBSanitizer: Bool = false,
@@ -476,6 +501,7 @@ private func createTestActionWithDefaults(
         codeCoverage: codeCoverage,
         buildConfiguration: buildConfiguration,
         commandLineArguments: commandLineArguments,
+        customLLDBInitFile: customLLDBInitFile,
         enableAddressSanitizer: enableAddressSanitizer,
         enableThreadSanitizer: enableThreadSanitizer,
         enableUBSanitizer: enableUBSanitizer,

--- a/tools/generators/pbxproj_prefix/README.md
+++ b/tools/generators/pbxproj_prefix/README.md
@@ -195,7 +195,7 @@ Here is an example output:
 				BAZEL_CONFIG = rules_xcodeproj;
 				BAZEL_EXTERNAL = "$(BAZEL_OUTPUT_BASE)/external";
 				BAZEL_INTEGRATION_DIR = "$(INTERNAL_DIR)/bazel";
-				BAZEL_LLDB_INIT = "$(HOME)/.lldbinit-rules_xcodeproj";
+				BAZEL_LLDB_INIT = "$(PROJECT_FILE_PATH)/rules_xcodeproj/bazel.lldbinit";
 				BAZEL_OUT = "$(PROJECT_DIR)/bazel-out";
 				BAZEL_OUTPUT_BASE = "$(_BAZEL_OUTPUT_BASE:standardizepath)";
 				BAZEL_WORKSPACE_ROOT = "$(SRCROOT)";
@@ -258,7 +258,7 @@ Here is an example output:
 				BAZEL_CONFIG = rules_xcodeproj;
 				BAZEL_EXTERNAL = "$(BAZEL_OUTPUT_BASE)/external";
 				BAZEL_INTEGRATION_DIR = "$(INTERNAL_DIR)/bazel";
-				BAZEL_LLDB_INIT = "$(HOME)/.lldbinit-rules_xcodeproj";
+				BAZEL_LLDB_INIT = "$(PROJECT_FILE_PATH)/rules_xcodeproj/bazel.lldbinit";
 				BAZEL_OUT = "$(PROJECT_DIR)/bazel-out";
 				BAZEL_OUTPUT_BASE = "$(_BAZEL_OUTPUT_BASE:standardizepath)";
 				BAZEL_WORKSPACE_ROOT = "$(SRCROOT)";

--- a/tools/generators/pbxproj_prefix/src/Generator/PBXProjectBuildSettings.swift
+++ b/tools/generators/pbxproj_prefix/src/Generator/PBXProjectBuildSettings.swift
@@ -49,7 +49,7 @@ extension Generator {
             ),
             .init(
                 key: "BAZEL_LLDB_INIT",
-                value: #""$(HOME)/.lldbinit-rules_xcodeproj""#
+                value: #""$(PROJECT_FILE_PATH)/rules_xcodeproj/bazel.lldbinit""#
             ),
             .init(
                 key: "BAZEL_OUT",

--- a/tools/generators/pbxproj_prefix/test/PBXProjectBuildSettingsTests.swift
+++ b/tools/generators/pbxproj_prefix/test/PBXProjectBuildSettingsTests.swift
@@ -26,7 +26,7 @@ class PBXProjectBuildSettingsTests: XCTestCase {
 				BAZEL_CONFIG = rxcp_custom_config;
 				BAZEL_EXTERNAL = "$(BAZEL_OUTPUT_BASE)/external";
 				BAZEL_INTEGRATION_DIR = "$(INTERNAL_DIR)/bazel";
-				BAZEL_LLDB_INIT = "$(HOME)/.lldbinit-rules_xcodeproj";
+				BAZEL_LLDB_INIT = "$(PROJECT_FILE_PATH)/rules_xcodeproj/bazel.lldbinit";
 				BAZEL_OUT = "$(PROJECT_DIR)/bazel-out";
 				BAZEL_OUTPUT_BASE = "$(_BAZEL_OUTPUT_BASE:standardizepath)";
 				BAZEL_WORKSPACE_ROOT = "$(SRCROOT)";
@@ -121,7 +121,7 @@ class PBXProjectBuildSettingsTests: XCTestCase {
 				BAZEL_CONFIG = rxcp_custom_config;
 				BAZEL_EXTERNAL = "$(BAZEL_OUTPUT_BASE)/external";
 				BAZEL_INTEGRATION_DIR = "$(INTERNAL_DIR)/bazel";
-				BAZEL_LLDB_INIT = "$(HOME)/.lldbinit-rules_xcodeproj";
+				BAZEL_LLDB_INIT = "$(PROJECT_FILE_PATH)/rules_xcodeproj/bazel.lldbinit";
 				BAZEL_OUT = "$(PROJECT_DIR)/bazel-out";
 				BAZEL_OUTPUT_BASE = "$(_BAZEL_OUTPUT_BASE:standardizepath)";
 				BAZEL_SUPPRESS_COVERAGE_BUILD = YES;
@@ -215,7 +215,7 @@ class PBXProjectBuildSettingsTests: XCTestCase {
 				BAZEL_CONFIG = rxcp_custom_config;
 				BAZEL_EXTERNAL = "$(BAZEL_OUTPUT_BASE)/external";
 				BAZEL_INTEGRATION_DIR = "$(INTERNAL_DIR)/bazel";
-				BAZEL_LLDB_INIT = "$(HOME)/.lldbinit-rules_xcodeproj";
+				BAZEL_LLDB_INIT = "$(PROJECT_FILE_PATH)/rules_xcodeproj/bazel.lldbinit";
 				BAZEL_OUT = "$(PROJECT_DIR)/bazel-out";
 				BAZEL_OUTPUT_BASE = "$(_BAZEL_OUTPUT_BASE:standardizepath)";
 				BAZEL_SEPARATE_INDEXBUILD_OUTPUT_BASE = YES;

--- a/tools/generators/xcschemes/README.md
+++ b/tools/generators/xcschemes/README.md
@@ -155,6 +155,7 @@ Here is an example output:
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
+      customLLDBInitFile = "/Users/brentley/Developer/rules_xcodeproj/tools/tools.xcodeproj/rules_xcodeproj/bazel.lldbinit"
       enableAddressSanitizer = "YES">
       <PreActions>
          <ExecutionAction
@@ -223,6 +224,7 @@ Here is an example output:
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "/Users/brentley/Developer/rules_xcodeproj/tools/tools.xcodeproj/rules_xcodeproj/bazel.lldbinit"
       enableAddressSanitizer = "YES"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
@@ -329,6 +331,7 @@ Here is an example output:
       buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
+      customLLDBInitFile = "/Users/brentley/Developer/rules_xcodeproj/tools/tools.xcodeproj/rules_xcodeproj/bazel.lldbinit"
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
       <PreActions>

--- a/tools/generators/xcschemes/src/Generator/CreateScheme.swift
+++ b/tools/generators/xcschemes/src/Generator/CreateScheme.swift
@@ -1,3 +1,4 @@
+import Foundation
 import OrderedCollections
 import PBXProj
 import XCScheme
@@ -157,6 +158,7 @@ extension Generator.CreateScheme {
             defaultXcodeConfiguration
 
         let launchRunnable: Runnable?
+        let launchBuildableReference: BuildableReference?
         let canUseLaunchSchemeArgsEnv: Bool
         let wasCreatedForAppExtension: Bool
         switch schemeInfo.run.launchTarget {
@@ -164,6 +166,7 @@ extension Generator.CreateScheme {
             canUseLaunchSchemeArgsEnv = true
 
             let buildableReference = primary.buildableReference
+            launchBuildableReference = buildableReference
 
             adjustBuildActionEntry(
                 for: buildableReference,
@@ -200,11 +203,13 @@ extension Generator.CreateScheme {
                 .appendUpdateLldbInitAndCopyDSYMs(for: buildableReference)
         case let .path(path):
             launchRunnable = .path(path: path)
+            launchBuildableReference = nil
             canUseLaunchSchemeArgsEnv = false
             wasCreatedForAppExtension = false
 
         case .none:
             launchRunnable = nil
+            launchBuildableReference = nil
             canUseLaunchSchemeArgsEnv = false
             wasCreatedForAppExtension = false
         }
@@ -219,9 +224,11 @@ extension Generator.CreateScheme {
         // MARK: Profile
 
         let profileRunnable: Runnable?
+        let profileBuildableReference: BuildableReference?
         switch schemeInfo.profile.launchTarget {
         case let .target(primary, extensionHost):
             let buildableReference = primary.buildableReference
+            profileBuildableReference = buildableReference
             adjustBuildActionEntry(for: buildableReference, include: .profiling)
 
             if let extensionHost {
@@ -255,9 +262,11 @@ extension Generator.CreateScheme {
 
         case let .path(path):
             profileRunnable = .path(path: path)
+            profileBuildableReference = nil
 
         case .none:
             profileRunnable = nil
+            profileBuildableReference = nil
         }
 
         for buildOnlyTarget in schemeInfo.profile.buildTargets {
@@ -366,6 +375,9 @@ extension Generator.CreateScheme {
                 buildConfiguration: schemeInfo.test.xcodeConfiguration ??
                     defaultXcodeConfiguration,
                 commandLineArguments: schemeInfo.test.commandLineArguments,
+                customLLDBInitFile: bazelLldbInitFile(
+                    for: testables.first?.buildableReference
+                ),
                 enableAddressSanitizer: schemeInfo.test.enableAddressSanitizer,
                 enableThreadSanitizer: schemeInfo.test.enableThreadSanitizer,
                 enableUBSanitizer: schemeInfo.test.enableUBSanitizer,
@@ -387,6 +399,9 @@ extension Generator.CreateScheme {
                 buildConfiguration: launchBuildConfiguration,
                 commandLineArguments: launchRunnable == nil ?
                     [] : schemeInfo.run.commandLineArguments,
+                customLLDBInitFile: bazelLldbInitFile(
+                    for: launchBuildableReference
+                ),
                 customWorkingDirectory: schemeInfo.run.customWorkingDirectory,
                 enableAddressSanitizer: schemeInfo.run.enableAddressSanitizer,
                 enableThreadSanitizer: schemeInfo.run.enableThreadSanitizer,
@@ -409,6 +424,9 @@ extension Generator.CreateScheme {
                     defaultXcodeConfiguration,
                 commandLineArguments: profileRunnable == nil ?
                     [] : schemeInfo.profile.commandLineArguments,
+                customLLDBInitFile: bazelLldbInitFile(
+                    for: profileBuildableReference
+                ),
                 customWorkingDirectory: schemeInfo.profile.customWorkingDirectory,
                 environmentVariables: profileRunnable == nil ?
                     [] : schemeInfo.profile.environmentVariables,
@@ -436,6 +454,26 @@ extension Generator.CreateScheme {
 
 private typealias OrderedExecutionAction =
     (action: ExecutionAction, order: Int?)
+
+private func bazelLldbInitFile(
+    for buildableReference: BuildableReference?
+) -> String? {
+    let containerPrefix = "container:"
+
+    guard
+        let referencedContainer = buildableReference?.referencedContainer,
+        referencedContainer.hasPrefix(containerPrefix)
+    else {
+        return nil
+    }
+
+    let projectFilePath = String(
+        referencedContainer.dropFirst(containerPrefix.count)
+    )
+    return (
+        projectFilePath as NSString
+    ).appendingPathComponent("rules_xcodeproj/bazel.lldbinit")
+}
 
 private func compareExecutionActions(
     lhs: OrderedExecutionAction,

--- a/tools/generators/xcschemes/test/CreateSchemeTests.swift
+++ b/tools/generators/xcschemes/test/CreateSchemeTests.swift
@@ -1,0 +1,262 @@
+import CustomDump
+import PBXProj
+import XCScheme
+import XCTest
+
+@testable import xcschemes
+
+final class CreateSchemeTests: XCTestCase {
+    func test_testAction_usesFirstTestableForCustomLLDBInitFile() throws {
+        // Arrange
+
+        let buildOnlyTarget = Target.mock(
+            key: "BuildOnly",
+            productType: .staticLibrary,
+            buildableReference: buildableReference(
+                name: "BuildOnly",
+                referencedContainer: "container:/tmp/BuildOnly.xcodeproj"
+            )
+        )
+        let testableTarget = Target.mock(
+            key: "Tests",
+            productType: .unitTestBundle,
+            buildableReference: buildableReference(
+                name: "Tests",
+                referencedContainer: "container:/tmp/Tests.xcodeproj"
+            )
+        )
+        let expectedTestAction = createExpectedTestAction(
+            buildableReference: testableTarget.buildableReference
+        )
+
+        // Act
+
+        let scheme = try createSchemeWithDefaults(
+            schemeInfo: .mock(
+                name: "Scheme",
+                test: .mock(
+                    buildTargets: [buildOnlyTarget],
+                    testTargets: [.init(target: testableTarget, isEnabled: true)]
+                )
+            )
+        )
+
+        let testAction = try XCTUnwrap(extractTestAction(from: scheme))
+
+        // Assert
+
+        XCTAssertNoDifference(testAction, expectedTestAction)
+    }
+
+    func test_profileAction_usesProfileTargetForCustomLLDBInitFile() throws {
+        // Arrange
+
+        let runTarget = Target.mock(
+            key: "Run",
+            productType: .application,
+            buildableReference: buildableReference(
+                name: "Run",
+                referencedContainer: "container:/tmp/Run.xcodeproj"
+            )
+        )
+        let profileTarget = Target.mock(
+            key: "Profile",
+            productType: .application,
+            buildableReference: buildableReference(
+                name: "Profile",
+                referencedContainer: "container:/tmp/Profile.xcodeproj"
+            )
+        )
+        let expectedProfileAction = createExpectedProfileAction(
+            buildableReference: profileTarget.buildableReference
+        )
+
+        // Act
+
+        let scheme = try createSchemeWithDefaults(
+            schemeInfo: .mock(
+                name: "Scheme",
+                run: .mock(
+                    launchTarget: .target(
+                        primary: runTarget,
+                        extensionHost: nil
+                    )
+                ),
+                profile: .mock(
+                    launchTarget: .target(
+                        primary: profileTarget,
+                        extensionHost: nil
+                    )
+                )
+            )
+        )
+
+        let profileAction = try XCTUnwrap(extractProfileAction(from: scheme))
+
+        // Assert
+
+        XCTAssertNoDifference(profileAction, expectedProfileAction)
+    }
+
+    func test_launchAction_pathRunnableDoesNotUseBuildEntryLLDBInitFile() throws {
+        // Arrange
+
+        let buildOnlyTarget = Target.mock(
+            key: "BuildOnly",
+            productType: .application,
+            buildableReference: buildableReference(
+                name: "BuildOnly",
+                referencedContainer: "container:/tmp/BuildOnly.xcodeproj"
+            )
+        )
+        let expectedLaunchAction = CreateLaunchAction.defaultCallable(
+            buildConfiguration: "Debug",
+            commandLineArguments: [],
+            customLLDBInitFile: nil,
+            customWorkingDirectory: nil,
+            enableAddressSanitizer: false,
+            enableThreadSanitizer: false,
+            enableUBSanitizer: false,
+            enableMainThreadChecker: false,
+            enableThreadPerformanceChecker: false,
+            environmentVariables: [],
+            postActions: [],
+            preActions: [],
+            runnable: .path(path: "/tmp/tool"),
+            storeKitConfiguration: nil
+        )
+
+        // Act
+
+        let scheme = try createSchemeWithDefaults(
+            schemeInfo: .mock(
+                name: "Scheme",
+                run: .mock(
+                    buildTargets: [buildOnlyTarget],
+                    launchTarget: .path("/tmp/tool")
+                )
+            )
+        )
+
+        let launchAction = try XCTUnwrap(extractLaunchAction(from: scheme))
+
+        // Assert
+
+        XCTAssertNoDifference(launchAction, expectedLaunchAction)
+    }
+}
+
+private func createSchemeWithDefaults(
+    schemeInfo: SchemeInfo
+) throws -> String {
+    try Generator.CreateScheme.defaultCallable(
+        defaultXcodeConfiguration: "Debug",
+        extensionPointIdentifiers: [:],
+        schemeInfo: schemeInfo,
+        createAnalyzeAction: CreateAnalyzeAction(),
+        createArchiveAction: CreateArchiveAction(),
+        createBuildAction: CreateBuildAction(),
+        createLaunchAction: CreateLaunchAction(),
+        createProfileAction: CreateProfileAction(),
+        createSchemeXML: XCScheme.CreateScheme(),
+        createTestAction: CreateTestAction()
+    ).scheme
+}
+
+private func extractTestAction(from scheme: String) -> String? {
+    extractElement(named: "TestAction", from: scheme)
+}
+
+private func extractProfileAction(from scheme: String) -> String? {
+    extractElement(named: "ProfileAction", from: scheme)
+}
+
+private func extractLaunchAction(from scheme: String) -> String? {
+    extractElement(named: "LaunchAction", from: scheme)
+}
+
+private func extractElement(named name: String, from scheme: String) -> String? {
+    guard
+        let start = scheme.range(of: "   <\(name)"),
+        let end = scheme.range(of: "</\(name)>")
+    else {
+        return nil
+    }
+
+    return String(scheme[start.lowerBound ..< end.upperBound])
+}
+
+private func buildableReference(
+    name: String,
+    referencedContainer: String
+) -> BuildableReference {
+    return .init(
+        blueprintIdentifier: "\(name)_blueprintIdentifier",
+        buildableName: "\(name)_buildableName",
+        blueprintName: name,
+        referencedContainer: referencedContainer
+    )
+}
+
+private func createExpectedProfileAction(
+    buildableReference: BuildableReference
+) -> String {
+    return CreateProfileAction.defaultCallable(
+        buildConfiguration: "Debug",
+        commandLineArguments: [],
+        customLLDBInitFile: "/tmp/Profile.xcodeproj/rules_xcodeproj/bazel.lldbinit",
+        customWorkingDirectory: nil,
+        environmentVariables: [],
+        postActions: [],
+        preActions: [updateLldbInitAndCopyDSYMsAction(
+            buildableReference: buildableReference
+        )],
+        useLaunchSchemeArgsEnv: true,
+        runnable: .plain(buildableReference: buildableReference)
+    )
+}
+
+private func createExpectedTestAction(
+    buildableReference: BuildableReference
+) -> String {
+    return CreateTestAction.defaultCallable(
+        appLanguage: nil,
+        appRegion: nil,
+        codeCoverage: false,
+        buildConfiguration: "Debug",
+        commandLineArguments: [],
+        customLLDBInitFile: "/tmp/Tests.xcodeproj/rules_xcodeproj/bazel.lldbinit",
+        enableAddressSanitizer: false,
+        enableThreadSanitizer: false,
+        enableUBSanitizer: false,
+        enableMainThreadChecker: false,
+        enableThreadPerformanceChecker: false,
+        environmentVariables: [],
+        expandVariablesBasedOn: buildableReference,
+        postActions: [],
+        preActions: [updateLldbInitAndCopyDSYMsAction(
+            buildableReference: buildableReference
+        )],
+        testables: [
+            .init(
+                buildableReference: buildableReference,
+                isSkipped: false
+            ),
+        ],
+        useLaunchSchemeArgsEnv: false
+    )
+}
+
+private func updateLldbInitAndCopyDSYMsAction(
+    buildableReference: BuildableReference
+) -> ExecutionAction {
+    return .init(
+        title: "Update .lldbinit and copy dSYMs",
+        escapedScriptText: #"""
+"$BAZEL_INTEGRATION_DIR/create_lldbinit.sh"
+"$BAZEL_INTEGRATION_DIR/copy_dsyms.sh"
+
+"""#.schemeXmlEscaped,
+        expandVariablesBasedOn: buildableReference
+    )
+}

--- a/xcodeproj/internal/bazel_integration_files/create_lldbinit.sh
+++ b/xcodeproj/internal/bazel_integration_files/create_lldbinit.sh
@@ -72,21 +72,3 @@ fi
 echo "command script import \"$OBJROOT/$CONFIGURATION/swift_debug_settings.py\""
 
 } > "$BAZEL_LLDB_INIT"
-
-if  [[ -f "$HOME/.lldbinit-Xcode" ]]; then
-  readonly lldbinit="$HOME/.lldbinit-Xcode"
-elif [[ -f "$HOME/.lldbinit" ]]; then
-  readonly lldbinit="$HOME/.lldbinit"
-else
-  readonly lldbinit="$HOME/.lldbinit-Xcode"
-fi
-
-touch "$lldbinit"
-
-readonly required_source='command source ~/.lldbinit-rules_xcodeproj'
-if ! grep -m 1 -q "^$required_source$" "$lldbinit"; then
-  # Add a newline if the file doesn't end with one
-  tail -c 1 "$lldbinit" | read || echo >> "$lldbinit"
-  # Update `$lldbinit to source `~/.lldbinit-rules_xcodeproj`
-  echo "$required_source" >> "$lldbinit"
-fi


### PR DESCRIPTION
We stop putting `.lldbinit` into user's home directory and instead generate it within the `.xcodeproj` bundle. This prevents debugging issues with plain Xcode projects that are not generated with `rules_xcodeproj`.

**NOTE:** I tested this with various targets including WatchOS, extensions and tests and it appears to be working fine.

Closes https://github.com/MobileNativeFoundation/rules_xcodeproj/issues/3134