### PR TITLE
Fix `generator_bazel_env` accidentally applying to Xcode builds as well

### DIFF
--- a/xcodeproj/internal/templates/runner.sh
+++ b/xcodeproj/internal/templates/runner.sh
@@ -238,7 +238,7 @@ bazel_cmd=(
   env -i
   "DEVELOPER_DIR=$developer_dir"
   "${passthrough_env[@]}"
-  "${envs[@]}"
+  "${generator_envs[@]}"
   "$bazel_path"
 
   # Restart Bazel server if `DEVELOPER_DIR` changes to clear `developerDirCache`

--- a/xcodeproj/internal/xcodeproj_runner.bzl
+++ b/xcodeproj/internal/xcodeproj_runner.bzl
@@ -290,7 +290,9 @@ def _write_runner(
 
     base_def_env_values = []
     base_envs_values = []
+    generator_envs_values = []
     collect_statements = []
+    generator_collect_statements = []
     for key, value in bazel_env.items():
         if value == _NULL_BAZEL_ENV_VALUE:
             base_def_env_values.append(
@@ -333,13 +335,13 @@ fi
 
     for key, value in generator_bazel_env.items():
         if value == _NULL_BAZEL_ENV_VALUE:
-            collect_statements.append("""\
+            generator_collect_statements.append("""\
 if [[ -n "${{{key}:-}}" ]]; then
-  envs+=("{key}=${key}")
+  generator_envs+=("{key}=${key}")
 fi
 """.format(key = key))
         else:
-            base_envs_values.append("  \"{}={}\"".format(
+            generator_envs_values.append("  \"{}={}\"".format(
                 key,
                 (
                     value.replace(
@@ -359,10 +361,17 @@ def_env="{{
 "
 
 {collect_statements}
+generator_envs=(
+  "${{envs[@]}}"
+{generator_envs_values}
+)
+{generator_collect_statements}
 def_env+='}}'""".format(
         base_def_env_values = "\n".join(base_def_env_values),
         base_envs_values = "\n".join(base_envs_values),
         collect_statements = "\n".join(collect_statements),
+        generator_collect_statements = "\n".join(generator_collect_statements),
+        generator_envs_values = "\n".join(generator_envs_values),
     )
 
     generator_package_name = paths.join("generator", package, name)


### PR DESCRIPTION
Missed in 07036157663284b8591ee6f3f82f1753490d10f7.