### PR TITLE
Fix xcfilelists having duplicate items

### DIFF
--- a/test/internal/pbxproj_partials/BUILD
+++ b/test/internal/pbxproj_partials/BUILD
@@ -4,6 +4,10 @@ load(
     "write_files_and_groups_test_suite",
 )
 load(
+    ":write_generated_xcfilelist_tests.bzl",
+    "write_generated_xcfilelist_test_suite",
+)
+load(
     ":write_pbxproj_prefix_tests.bzl",
     "write_pbxproj_prefix_test_suite",
 )
@@ -21,6 +25,8 @@ load(
 )
 
 write_files_and_groups_test_suite(name = "write_files_and_groups")
+
+write_generated_xcfilelist_test_suite(name = "write_generated_xcfilelist")
 
 write_pbxproj_prefix_test_suite(name = "write_pbxproj_prefix")
 

--- a/test/internal/pbxproj_partials/write_generated_xcfilelist_tests.bzl
+++ b/test/internal/pbxproj_partials/write_generated_xcfilelist_tests.bzl
@@ -1,0 +1,149 @@
+"""Tests for `pbxproj_partials.write_generated_xcfilelist`."""
+
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("//test:mock_actions.bzl", "mock_actions")
+
+# buildifier: disable=bzl-visibility
+load("//xcodeproj/internal:pbxproj_partials.bzl", "pbxproj_partials")
+
+_GENERATED_XCFILELIST_DECLARED_FILE = mock_actions.mock_file(
+    "a_generator_name-generated.xcfilelist",
+)
+
+def _write_generated_xcfilelist_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    # Arrange
+
+    actions = mock_actions.create()
+    infoplists = [
+        mock_actions.mock_file(path)
+        for path in ctx.attr.infoplists
+    ]
+    srcs = [
+        struct(
+            path = path,
+            is_source = path in ctx.attr.source_srcs,
+        )
+        for path in ctx.attr.srcs
+    ]
+
+    # Act
+
+    generated_xcfilelist = pbxproj_partials.write_generated_xcfilelist(
+        actions = actions.mock,
+        generator_name = "a_generator_name",
+        infoplists = infoplists,
+        srcs = depset(srcs),
+    )
+
+    # Assert
+
+    asserts.equals(
+        env,
+        {
+            _GENERATED_XCFILELIST_DECLARED_FILE: None,
+        },
+        actions.declared_files,
+        "actions.declare_file",
+    )
+
+    asserts.equals(
+        env,
+        {
+            _GENERATED_XCFILELIST_DECLARED_FILE.path: ctx.attr.expected_content,
+        },
+        actions.writes,
+        "actions.write",
+    )
+
+    asserts.equals(
+        env,
+        "multiline",
+        actions.args_objects[0].captured.set_param_file_format_args["format"],
+        "args[0].param_file_format",
+    )
+
+    asserts.equals(
+        env,
+        _GENERATED_XCFILELIST_DECLARED_FILE,
+        generated_xcfilelist,
+        "generated_xcfilelist",
+    )
+
+    return unittest.end(env)
+
+write_generated_xcfilelist_test = unittest.make(
+    impl = _write_generated_xcfilelist_test_impl,
+    attrs = {
+        # Inputs
+        "infoplists": attr.string_list(mandatory = True),
+        "source_srcs": attr.string_list(mandatory = True),
+        "srcs": attr.string_list(mandatory = True),
+
+        # Expected
+        "expected_content": attr.string(mandatory = True),
+    },
+)
+
+def write_generated_xcfilelist_test_suite(name):
+    """Test suite for `pbxproj_partials.write_generated_xcfilelist`.
+
+    Args:
+        name: The base name to be used in things created by this macro. Also the
+            name of the test suite.
+    """
+    test_names = []
+
+    def _add_test(
+            *,
+            name,
+
+            # Inputs
+            infoplists = [],
+            source_srcs = [],
+            srcs = [],
+
+            # Expected
+            expected_content):
+        test_name = "{}_{}".format(name, len(test_names))
+        test_names.append(test_name)
+
+        write_generated_xcfilelist_test(
+            name = test_name,
+            infoplists = infoplists,
+            source_srcs = source_srcs,
+            srcs = srcs,
+            expected_content = expected_content,
+        )
+
+    _add_test(
+        name = "deduplicates_generated_paths",
+        infoplists = [
+            "bazel-out/ios-sim/bin/App/Info.plist",
+        ],
+        source_srcs = [
+            "Modules/App/Source.swift",
+        ],
+        srcs = [
+            "bazel-out/ios-sim/bin/Modules/App/Shared.generated.swift",
+            "Modules/App/Source.swift",
+            "bazel-out/ios-sim/bin/Modules/App/Shared.generated.swift",
+            "bazel-out/ios-sim/bin/Modules/App/Other.generated.swift",
+        ],
+        expected_content = """\
+$(BAZEL_OUT)/ios-sim/bin/App/Info.plist
+$(BAZEL_OUT)/ios-sim/bin/Modules/App/Shared.generated.swift
+$(BAZEL_OUT)/ios-sim/bin/Modules/App/Other.generated.swift
+""",
+    )
+
+    _add_test(
+        name = "empty",
+        expected_content = "\n",
+    )
+
+    native.test_suite(
+        name = name,
+        tests = test_names,
+    )

--- a/test/mock_actions.bzl
+++ b/test/mock_actions.bzl
@@ -53,9 +53,8 @@ def _create():
                 format_each = None,
                 map_each = None,
                 omit_if_empty = True,
-                terminate_with = None):
-            inner_args = []
-
+                terminate_with = None,
+                uniquify = False):
             if values != None:
                 flag = flag_or_values
             else:
@@ -65,31 +64,38 @@ def _create():
             if type(values) == "depset":
                 values = values.to_list()
 
-            if omit_if_empty and not values:
-                return inner_args
-
-            if flag:
-                inner_args.append(flag)
-
+            value_args = []
             if map_each:
                 for value in values:
                     mapped_value = map_each(value)
                     if type(mapped_value) == "list":
                         if format_each:
-                            inner_args.extend(
+                            value_args.extend(
                                 [format_each % v for v in mapped_value],
                             )
                         else:
-                            inner_args.extend(
+                            value_args.extend(
                                 [str(v) for v in mapped_value],
                             )
                     elif mapped_value:
                         if format_each:
-                            inner_args.append(format_each % mapped_value)
+                            value_args.append(format_each % mapped_value)
                         else:
-                            inner_args.append(str(mapped_value))
+                            value_args.append(str(mapped_value))
             else:
-                inner_args.extend([_path_or_str(value) for value in values])
+                value_args.extend([_path_or_str(value) for value in values])
+
+            if uniquify:
+                value_args = _uniq(value_args)
+
+            if omit_if_empty and not value_args:
+                return []
+
+            inner_args = []
+            if flag:
+                inner_args.append(flag)
+
+            inner_args.extend(value_args)
 
             if terminate_with != None:
                 inner_args.append(terminate_with)
@@ -105,7 +111,8 @@ def _create():
                 format_each = None,
                 map_each = None,
                 omit_if_empty = True,
-                terminate_with = None):
+                terminate_with = None,
+                uniquify = False):
             args.extend(
                 _inner_add_all(
                     flag_or_values,
@@ -114,6 +121,7 @@ def _create():
                     map_each = map_each,
                     omit_if_empty = omit_if_empty,
                     terminate_with = terminate_with,
+                    uniquify = uniquify,
                 ),
             )
 
@@ -125,7 +133,8 @@ def _create():
                 join_with,
                 map_each = None,
                 omit_if_empty = True,
-                terminate_with = None):
+                terminate_with = None,
+                uniquify = False):
             args.append(
                 join_with.join(
                     _inner_add_all(
@@ -135,6 +144,7 @@ def _create():
                         map_each = map_each,
                         omit_if_empty = omit_if_empty,
                         terminate_with = terminate_with,
+                        uniquify = uniquify,
                     ),
                 ),
             )
@@ -218,3 +228,15 @@ mock_actions = struct(
     mock_file = _mock_file,
     mock_label = _mock_label,
 )
+
+def _uniq(values):
+    unique_values = []
+    seen = {}
+    for value in values:
+        if value in seen:
+            continue
+
+        seen[value] = None
+        unique_values.append(value)
+
+    return unique_values

--- a/xcodeproj/internal/pbxproj_partials.bzl
+++ b/xcodeproj/internal/pbxproj_partials.bzl
@@ -641,7 +641,11 @@ def _write_generated_xcfilelist(
     # Source files are tracked as build files by Xcode, so building targets that
     # directly use generated source files will fail the first time they are
     # built if we don't track them
-    args.add_all(srcs, map_each = _xcfilelist_generated_file_path)
+    args.add_all(
+        srcs,
+        map_each = _xcfilelist_generated_file_path,
+        uniquify = True,
+    )
 
     xcfilelist = actions.declare_file(
         "{}-generated.xcfilelist".format(generator_name),


### PR DESCRIPTION
Fixes this:

```
Multiple commands produce 'bazel_output_base/rules_xcodeproj.noindex/build_output_base/execroot/_main/bazel-out/ios_sim_arm64-dbg-ios-sim_arm64-min16.0-ST-738c16325277/bin/Some.generated.swift'
```

when multiple targets depend on the same generated file.