### PR TITLE
Fix Testing.framework rsync exclusion

### DIFF
--- a/xcodeproj/internal/bazel_integration_files/BUILD
+++ b/xcodeproj/internal/bazel_integration_files/BUILD
@@ -51,7 +51,7 @@ frameworks=(
   'libclang_rt.ubsan*.dylib'
   'libXCTestBundleInject.dylib'
   'libXCTestSwiftSupport.dylib'
-  'Testing.framework',
+  'Testing.framework'
   'XCTAutomationSupport.framework'
   'XCTest.framework'
   'XCTestCore.framework'


### PR DESCRIPTION
This seems like a real issue. See the diff, it's a small patch.

GPT 5.6 wrote the text below.

> 
> ## What does this change?
> 
> Remove the trailing comma from the `Testing.framework` entry in the Bash array used to generate rsync exclusions.
> 
> The comma is currently emitted as part of the filename:
> 
> ```text
> /*.app/Frameworks/Testing.framework,
> ```
> 
> That pattern does not exclude the real `Testing.framework`. The Bazel output-copy script can consequently run `rsync --delete` against the framework while Xcode is copying it into a test host, causing timing-dependent build failures.
> 
> Observed failures include a missing `Testing.framework/Info.plist` and `unlinkat: Directory not empty`:
> 
> https://github.com/maplibre/maplibre-native/actions/runs/29261436369/job/86881585165?pr=4146
> 
> Downstream workaround PR: https://github.com/maplibre/maplibre-native/pull/4402
> 
> ## Validation
> 
> - `bazel run //:buildifier.check`
> - `bazel build //xcodeproj/internal/bazel_integration_files:rsync_excludes`
> - Confirmed the generated app exclusions contain `Testing.framework` without a trailing comma for both framework locations
