### PR TITLE
Fix XCTestDynamicOverlay archive URL

### DIFF
--- a/xcodeproj/repositories.bzl
+++ b/xcodeproj/repositories.bzl
@@ -230,7 +230,7 @@ swift_library(
 """,
         sha256 = "1ebde9c9403d5befb6956556e26f9308000722f7da9e87fed2e770d3918d647c",
         strip_prefix = "swift-issue-reporting-0.2.1",
-        url = "https://github.com/pointfreeco/xctest-dynamic-overlay/archive/refs/tags/0.2.1.tar.gz",
+        url = "https://github.com/pointfreeco/swift-issue-reporting/archive/refs/tags/0.2.1.tar.gz",
     )
 
     http_archive(


### PR DESCRIPTION
## Summary

- point the pinned XCTestDynamicOverlay archive at its canonical renamed repository, `pointfreeco/swift-issue-reporting`
- preserve version `0.2.1`, `strip_prefix`, and SHA-256 unchanged
- unblock repository materialization used by the Xcode Preview integration fixture

## Validation

- verified the renamed archive extracts to the expected `swift-issue-reporting-0.2.1` tree
- ran the focused generator, output-group, archive, linker-parameter, and Preview-staging test matrix as part of the dependent Preview validation
- regenerated and built the Integration project successfully with the pinned dependency

## Stack

This is the prerequisite for the separate Xcode 26.5 shared-JIT Previews draft. Keeping it separate makes the dependency-source correction independently reviewable.

## Kill switch

N/A
