### PR TITLE
Add Bazel action command and cache metadata

### DIFF
--- a/test/internal/build_proxy_launcher/BUILD
+++ b/test/internal/build_proxy_launcher/BUILD
@@ -43,6 +43,7 @@ sh_test(
     srcs = ["build_proxy_launcher_tests.sh"],
     data = [
         ":configured_runner",
+        "//xcodeproj/internal/bazel_integration_files:actions_bzl_test_data",
         "//xcodeproj/internal/templates:bazel_build.sh",
         "//xcodeproj/internal/templates:build_proxy_launcher.sh",
         "//xcodeproj/internal/templates:generate_bazel_dependencies.sh",

--- a/test/internal/build_proxy_launcher/BUILD
+++ b/test/internal/build_proxy_launcher/BUILD
@@ -43,6 +43,7 @@ sh_test(
     srcs = ["build_proxy_launcher_tests.sh"],
     data = [
         ":configured_runner",
+        "//xcodeproj/internal/templates:bazel_build.sh",
         "//xcodeproj/internal/templates:build_proxy_launcher.sh",
         "//xcodeproj/internal/templates:generate_bazel_dependencies.sh",
         "//xcodeproj/internal/templates:install_build_proxy.sh",

--- a/test/internal/build_proxy_launcher/build_proxy_launcher_tests.sh
+++ b/test/internal/build_proxy_launcher/build_proxy_launcher_tests.sh
@@ -106,6 +106,35 @@ eval "$proxy_receipt_command_options_block"
 [[ "${receipt_args[0]}" == "--command-option=--base-build-flag" ]]
 [[ "${receipt_args[1]}" == "--command-option=--kept-build-flag" ]]
 
+# A proxied adapter is already the inner Xcode invocation. Preserve the generated hermetic Bazel
+# executable (or an explicitly inherited one), and tell workspace wrappers not to regenerate their
+# outer rules release inside Xcode's restricted PATH.
+proxy_bazel_environment_block="$(sed -n '/readonly build_proxy_bazel_real=/,/^fi$/p' "$bazel_build_source")"
+readonly proxy_bazel_environment_block
+readonly synthetic_integration="$test_root/synthetic-integration"
+mkdir -p "$synthetic_integration"
+cat > "$synthetic_integration/bazel_env.sh" <<'EOF'
+envs=(LANG=C BAZEL_REAL=/generated/bazel)
+EOF
+BAZEL_INTEGRATION_DIR="$synthetic_integration"
+SWIFTBUILD_BAZEL_PROXY_REQUEST_DIR="$test_root/request"
+(
+  unset BAZEL_REAL
+  eval "$proxy_bazel_environment_block"
+  [[ "${envs[*]}" == "LANG=C BAZEL_REAL=/generated/bazel BUILD_WORKSPACE_DIRECTORY=$PWD" ]]
+)
+(
+  BAZEL_REAL=/inherited/bazel
+  eval "$proxy_bazel_environment_block"
+  [[ "${envs[*]}" == "LANG=C BAZEL_REAL=/inherited/bazel BUILD_WORKSPACE_DIRECTORY=$PWD" ]]
+)
+(
+  unset BAZEL_REAL SWIFTBUILD_BAZEL_PROXY_REQUEST_DIR
+  eval "$proxy_bazel_environment_block"
+  [[ "${envs[*]}" == "LANG=C BAZEL_REAL=/generated/bazel" ]]
+)
+unset SWIFTBUILD_BAZEL_PROXY_REQUEST_DIR
+
 # The build must finish before the adapter makes the exact expected execution-log path private.
 proxy_execution_log_permissions_block="$(sed -n '/# Bazel has successfully returned/,/^fi$/p' "$adapter_source")"
 readonly proxy_execution_log_permissions_block

--- a/test/internal/build_proxy_launcher/build_proxy_launcher_tests.sh
+++ b/test/internal/build_proxy_launcher/build_proxy_launcher_tests.sh
@@ -31,6 +31,8 @@ launcher_source="$(rlocation "$TEST_WORKSPACE/xcodeproj/internal/templates/build
 readonly launcher_source
 adapter_source="$(rlocation "$TEST_WORKSPACE/xcodeproj/internal/templates/generate_bazel_dependencies.sh")"
 readonly adapter_source
+adapter_expansion_source="$(rlocation "$TEST_WORKSPACE/xcodeproj/internal/bazel_integration_files/actions.bzl")"
+readonly adapter_expansion_source
 bazel_build_source="$(rlocation "$TEST_WORKSPACE/xcodeproj/internal/templates/bazel_build.sh")"
 readonly bazel_build_source
 configured_runner="$(rlocation "$TEST_WORKSPACE/test/internal/build_proxy_launcher/configured_runner-runner.sh")"
@@ -49,6 +51,11 @@ readonly capture="$test_root/capture"
 project_identity_flag="$(grep -F -- '--build_proxy_project_identity ' "$configured_runner")"
 readonly project_identity_flag
 [[ "$project_identity_flag" == *'//generator/test/internal/build_proxy_launcher/configured_runner:configured_runner' ]]
+
+# The installed adapter must contain the configured generator label, never its template token.
+# Keep this guard next to the template assertion below so adding a placeholder requires wiring its
+# Starlark expansion in the same review.
+[[ "$(grep -Fc -- '"%generator_label%": str(generator_label)' "$adapter_expansion_source")" == 1 ]]
 
 proxy_bep_block="$(sed -n '/SWIFTBUILD_BAZEL_PROXY_BEP_PATH:-/,/^fi$/p' "$adapter_source")"
 readonly proxy_bep_block

--- a/test/internal/build_proxy_launcher/build_proxy_launcher_tests.sh
+++ b/test/internal/build_proxy_launcher/build_proxy_launcher_tests.sh
@@ -161,10 +161,10 @@ readonly proxy_action_graph_block
 # shellcheck disable=SC2016
 for expected_action_graph_flag in \
   'aquery' \
-  'action_graph_query="deps(${labels[0]})"' \
-  'action_graph_query="deps(set(${labels[*]}))"' \
+  'action_graph_query="deps(%generator_label%)"' \
   'action_graph_flags+=("--action_env=TOOLCHAINS=$toolchain")' \
   '"--config=$config"' \
+  '"$output_groups_flag"' \
   '--color=no' \
   '--output=jsonproto' \
   '--include_commandline' \
@@ -175,6 +175,10 @@ for expected_action_graph_flag in \
   '--output_file=$SWIFTBUILD_BAZEL_PROXY_ACTION_GRAPH_PATH'; do
   [[ "$(grep -Fc -- "$expected_action_graph_flag" <<< "$proxy_action_graph_block")" == 1 ]]
 done
+# The follow-up aquery must not re-resolve user labels in a potentially different top-level
+# configuration from the generated output-group target that the successful build used.
+# shellcheck disable=SC2016
+[[ "$(grep -Fc -- 'action_graph_query="deps(${labels[0]})"' <<< "$proxy_action_graph_block")" == 0 ]]
 # shellcheck disable=SC2016
 [[ "$(grep -Fc -- '"$option" != --build_event_json_file=*' <<< "$proxy_action_graph_block")" == 1 ]]
 # shellcheck disable=SC2016

--- a/test/internal/build_proxy_launcher/build_proxy_launcher_tests.sh
+++ b/test/internal/build_proxy_launcher/build_proxy_launcher_tests.sh
@@ -31,6 +31,8 @@ launcher_source="$(rlocation "$TEST_WORKSPACE/xcodeproj/internal/templates/build
 readonly launcher_source
 adapter_source="$(rlocation "$TEST_WORKSPACE/xcodeproj/internal/templates/generate_bazel_dependencies.sh")"
 readonly adapter_source
+bazel_build_source="$(rlocation "$TEST_WORKSPACE/xcodeproj/internal/templates/bazel_build.sh")"
+readonly bazel_build_source
 configured_runner="$(rlocation "$TEST_WORKSPACE/test/internal/build_proxy_launcher/configured_runner-runner.sh")"
 readonly configured_runner
 test_root="$(mktemp -d "$TEST_TMPDIR/build-proxy-launcher.XXXXXX")"
@@ -55,6 +57,75 @@ expected_bep_flag="--build_event_json_file=\$SWIFTBUILD_BAZEL_PROXY_BEP_PATH"
 readonly expected_bep_flag
 [[ "$(grep -Fc -- "$expected_bep_flag" <<< "$proxy_bep_block")" == 1 ]]
 
+proxy_execution_log_flags_block="$(sed -n '/# The build service gives every operation/,/^fi$/p' "$adapter_source")"
+readonly proxy_execution_log_flags_block
+# These are literal source fragments whose dollar expressions must not expand in this test shell.
+# shellcheck disable=SC2016
+for expected_execution_log_flag in \
+  '--execution_log_json_file=$SWIFTBUILD_BAZEL_PROXY_EXECUTION_LOG_PATH' \
+  '--noexecution_log_sort'; do
+  [[ "$(grep -Fc -- "$expected_execution_log_flag" <<< "$proxy_execution_log_flags_block")" == 1 ]]
+done
+
+# With no proxy path, the adapter must pass exactly the pre-existing build flags to Bazel.
+build_pre_config_flags=(--existing-build-flag)
+unset SWIFTBUILD_BAZEL_PROXY_EXECUTION_LOG_PATH
+eval "$proxy_execution_log_flags_block"
+[[ "${build_pre_config_flags[*]}" == "--existing-build-flag" ]]
+
+# With a proxy path, the two execution-log flags are appended to the actual build flags verbatim.
+readonly expected_execution_log_path="$test_root/execution log.jsonl"
+SWIFTBUILD_BAZEL_PROXY_EXECUTION_LOG_PATH="$expected_execution_log_path"
+export SWIFTBUILD_BAZEL_PROXY_EXECUTION_LOG_PATH
+eval "$proxy_execution_log_flags_block"
+[[ "${#build_pre_config_flags[@]}" == 3 ]]
+[[ "${build_pre_config_flags[0]}" == "--existing-build-flag" ]]
+[[ "${build_pre_config_flags[1]}" == "--execution_log_json_file=$expected_execution_log_path" ]]
+[[ "${build_pre_config_flags[2]}" == "--noexecution_log_sort" ]]
+unset SWIFTBUILD_BAZEL_PROXY_EXECUTION_LOG_PATH
+
+# Execution-log paths and sorting are proxy-owned evidence plumbing, not invocation policy. Keep
+# the volatile absolute path and its companion option out of the publishable invocation receipt.
+proxy_receipt_command_options_block="$(sed -n '/for option in .*build_pre_config_flags/,/^  done$/p' "$bazel_build_source")"
+readonly proxy_receipt_command_options_block
+# shellcheck disable=SC2016
+[[ "$(grep -Fc -- '"$option" != --execution_log_json_file=*' <<< "$proxy_receipt_command_options_block")" == 1 ]]
+# shellcheck disable=SC2016
+[[ "$(grep -Fc -- '"$option" != --noexecution_log_sort' <<< "$proxy_receipt_command_options_block")" == 1 ]]
+# The extracted source fragment consumes this array through `eval` below.
+# shellcheck disable=SC2034
+base_pre_config_flags=(--base-build-flag)
+build_pre_config_flags=(
+  "--execution_log_json_file=$expected_execution_log_path"
+  --noexecution_log_sort
+  --kept-build-flag
+)
+receipt_args=()
+eval "$proxy_receipt_command_options_block"
+[[ "${#receipt_args[@]}" == 2 ]]
+[[ "${receipt_args[0]}" == "--command-option=--base-build-flag" ]]
+[[ "${receipt_args[1]}" == "--command-option=--kept-build-flag" ]]
+
+# The build must finish before the adapter makes the exact expected execution-log path private.
+proxy_execution_log_permissions_block="$(sed -n '/# Bazel has successfully returned/,/^fi$/p' "$adapter_source")"
+readonly proxy_execution_log_permissions_block
+# shellcheck disable=SC2016
+[[ "$(grep -Fc -- 'chmod 600 "$SWIFTBUILD_BAZEL_PROXY_EXECUTION_LOG_PATH"' <<< "$proxy_execution_log_permissions_block")" == 1 ]]
+SWIFTBUILD_BAZEL_PROXY_EXECUTION_LOG_PATH="$expected_execution_log_path"
+export SWIFTBUILD_BAZEL_PROXY_EXECUTION_LOG_PATH
+printf 'private command metadata\n' > "$expected_execution_log_path"
+chmod 666 "$expected_execution_log_path"
+eval "$proxy_execution_log_permissions_block"
+# This is a generated private file with a controlled name; the permission string is portable.
+# shellcheck disable=SC2012
+[[ "$(LC_ALL=C ls -l "$expected_execution_log_path" | cut -c 1-10)" == "-rw-------" ]]
+rm "$expected_execution_log_path"
+if (eval "$proxy_execution_log_permissions_block") 2> /dev/null; then
+  echo >&2 "Expected missing execution log to fail closed"
+  exit 1
+fi
+unset SWIFTBUILD_BAZEL_PROXY_EXECUTION_LOG_PATH
+
 proxy_action_graph_block="$(sed -n '/SWIFTBUILD_BAZEL_PROXY_ACTION_GRAPH_PATH:-/,/^fi$/p' "$adapter_source")"
 readonly proxy_action_graph_block
 # These are literal source fragments whose dollar expressions must not expand in this test shell.
@@ -67,7 +138,9 @@ for expected_action_graph_flag in \
   '"--config=$config"' \
   '--color=no' \
   '--output=jsonproto' \
-  '--noinclude_commandline' \
+  '--include_commandline' \
+  '--noinclude_param_files' \
+  '--noinclude_file_write_contents' \
   '--include_artifacts' \
   '--consistent_labels' \
   '--output_file=$SWIFTBUILD_BAZEL_PROXY_ACTION_GRAPH_PATH'; do
@@ -75,6 +148,10 @@ for expected_action_graph_flag in \
 done
 # shellcheck disable=SC2016
 [[ "$(grep -Fc -- '"$option" != --build_event_json_file=*' <<< "$proxy_action_graph_block")" == 1 ]]
+# shellcheck disable=SC2016
+[[ "$(grep -Fc -- '"$option" != --execution_log_json_file=*' <<< "$proxy_action_graph_block")" == 1 ]]
+# shellcheck disable=SC2016
+[[ "$(grep -Fc -- '"$option" != --noexecution_log_sort' <<< "$proxy_action_graph_block")" == 1 ]]
 # shellcheck disable=SC2016
 [[ "$(grep -Fc -- 'chmod 600 "$SWIFTBUILD_BAZEL_PROXY_ACTION_GRAPH_PATH"' <<< "$proxy_action_graph_block")" == 1 ]]
 

--- a/test/internal/build_proxy_launcher/build_proxy_launcher_tests.sh
+++ b/test/internal/build_proxy_launcher/build_proxy_launcher_tests.sh
@@ -163,7 +163,7 @@ for expected_action_graph_flag in \
   'aquery' \
   'action_graph_query="deps(${labels[0]})"' \
   'action_graph_query="deps(set(${labels[*]}))"' \
-  'action_graph_toolchain_flags+=("--action_env=TOOLCHAINS=$toolchain")' \
+  'action_graph_flags+=("--action_env=TOOLCHAINS=$toolchain")' \
   '"--config=$config"' \
   '--color=no' \
   '--output=jsonproto' \
@@ -183,6 +183,25 @@ done
 [[ "$(grep -Fc -- '"$option" != --noexecution_log_sort' <<< "$proxy_action_graph_block")" == 1 ]]
 # shellcheck disable=SC2016
 [[ "$(grep -Fc -- 'chmod 600 "$SWIFTBUILD_BAZEL_PROXY_ACTION_GRAPH_PATH"' <<< "$proxy_action_graph_block")" == 1 ]]
+
+proxy_action_graph_flags_block="$(sed -n '/# Collect optional arrays before expansion/,/^  readonly action_graph_flags$/p' "$adapter_source")"
+readonly proxy_action_graph_flags_block
+(
+  set -u
+  base_pre_config_flags=(--base-flag)
+  action_graph_pre_config_flags=()
+  toolchain=
+  eval "$proxy_action_graph_flags_block"
+  [[ "${action_graph_flags[*]}" == "--base-flag" ]]
+)
+(
+  set -u
+  base_pre_config_flags=(--base-flag)
+  action_graph_pre_config_flags=(--configured-flag)
+  toolchain=com.example.toolchain
+  eval "$proxy_action_graph_flags_block"
+  [[ "${action_graph_flags[*]}" == "--base-flag --configured-flag --action_env=TOOLCHAINS=com.example.toolchain" ]]
+)
 
 sha256_file() {
   if command -v sha256sum > /dev/null 2>&1; then

--- a/xcodeproj/internal/bazel_integration_files/BUILD
+++ b/xcodeproj/internal/bazel_integration_files/BUILD
@@ -13,6 +13,13 @@ _TEST_FILES = [
     "write_build_proxy_invocation_receipt_tests.py",
 ]
 
+filegroup(
+    name = "actions_bzl_test_data",
+    testonly = True,
+    srcs = ["actions.bzl"],
+    visibility = ["//test/internal/build_proxy_launcher:__pkg__"],
+)
+
 py_library(
     name = "write_build_proxy_invocation_receipt_lib",
     srcs = ["write_build_proxy_invocation_receipt.py"],

--- a/xcodeproj/internal/bazel_integration_files/actions.bzl
+++ b/xcodeproj/internal/bazel_integration_files/actions.bzl
@@ -66,6 +66,7 @@ def write_generate_bazel_dependencies_script(
         output = output,
         is_executable = True,
         substitutions = {
+            "%generator_label%": str(generator_label),
             "%swiftcopt%": str(Label("@build_bazel_rules_swift//swift:copt")),
         },
     )

--- a/xcodeproj/internal/templates/bazel_build.sh
+++ b/xcodeproj/internal/templates/bazel_build.sh
@@ -88,15 +88,22 @@ done
 
 readonly build_proxy_bazel_real="${BAZEL_REAL:-}"
 source "$BAZEL_INTEGRATION_DIR/bazel_env.sh"
-if [[
-  -n "${SWIFTBUILD_BAZEL_PROXY_REQUEST_DIR:-}" &&
-  -n "$build_proxy_bazel_real"
-]]; then
+if [[ -n "${SWIFTBUILD_BAZEL_PROXY_REQUEST_DIR:-}" ]]; then
   build_proxy_envs=()
   for item in "${envs[@]}"; do
-    [[ "$item" != BAZEL_REAL=* ]] && build_proxy_envs+=("$item")
+    [[ "$item" != BUILD_WORKSPACE_DIRECTORY=* ]] || continue
+    if [[ -n "$build_proxy_bazel_real" && "$item" == BAZEL_REAL=* ]]; then
+      continue
+    fi
+    build_proxy_envs+=("$item")
   done
-  envs=("${build_proxy_envs[@]}" "BAZEL_REAL=$build_proxy_bazel_real")
+  envs=("${build_proxy_envs[@]}")
+  if [[ -n "$build_proxy_bazel_real" ]]; then
+    envs+=("BAZEL_REAL=$build_proxy_bazel_real")
+  fi
+  # Workspace wrappers use this standard Bazel marker to distinguish an Xcode inner invocation
+  # from a developer asking the wrapper to regenerate its outer rules release.
+  envs+=("BUILD_WORKSPACE_DIRECTORY=$PWD")
 fi
 
 bazel_cmd=(

--- a/xcodeproj/internal/templates/bazel_build.sh
+++ b/xcodeproj/internal/templates/bazel_build.sh
@@ -186,7 +186,11 @@ if [[ -n "${SWIFTBUILD_BAZEL_PROXY_INVOCATION_RECEIPT:-}" ]]; then
     receipt_args+=("--bazelrc=${bazelrc#--bazelrc=}")
   done
   for option in "${base_pre_config_flags[@]}" "${build_pre_config_flags[@]}"; do
-    if [[ "$option" != --build_event_json_file=* ]]; then
+    if [[
+      "$option" != --build_event_json_file=* &&
+      "$option" != --execution_log_json_file=* &&
+      "$option" != --noexecution_log_sort
+    ]]; then
       receipt_args+=("--command-option=$option")
     fi
   done

--- a/xcodeproj/internal/templates/generate_bazel_dependencies.sh
+++ b/xcodeproj/internal/templates/generate_bazel_dependencies.sh
@@ -262,16 +262,20 @@ if [[ -n "${SWIFTBUILD_BAZEL_PROXY_ACTION_GRAPH_PATH:-}" ]]; then
   if ((${#labels[@]} > 1)); then
     action_graph_query="deps(set(${labels[*]}))"
   fi
-  action_graph_toolchain_flags=()
-  if [[ -n "${toolchain:-}" ]]; then
-    action_graph_toolchain_flags+=("--action_env=TOOLCHAINS=$toolchain")
+  # Collect optional arrays before expansion. macOS Bash 3.2 treats "${empty[@]}" as unbound
+  # under `set -u`, even when the array was explicitly initialized.
+  action_graph_flags=("${base_pre_config_flags[@]}")
+  if ((${#action_graph_pre_config_flags[@]})); then
+    action_graph_flags+=("${action_graph_pre_config_flags[@]}")
   fi
+  if [[ -n "${toolchain:-}" ]]; then
+    action_graph_flags+=("--action_env=TOOLCHAINS=$toolchain")
+  fi
+  readonly action_graph_flags
   # Both arrays are assigned by the generated `bazel_build.sh` sourced above.
   # shellcheck disable=SC2154
   "${bazel_cmd[@]}" aquery \
-    "${base_pre_config_flags[@]}" \
-    "${action_graph_pre_config_flags[@]}" \
-    "${action_graph_toolchain_flags[@]}" \
+    "${action_graph_flags[@]}" \
     "--config=$config" \
     --color=no \
     --output=jsonproto \

--- a/xcodeproj/internal/templates/generate_bazel_dependencies.sh
+++ b/xcodeproj/internal/templates/generate_bazel_dependencies.sh
@@ -160,6 +160,14 @@ if [[ -n "${SWIFTBUILD_BAZEL_PROXY_BEP_PATH:-}" ]]; then
     "--build_event_json_file=$SWIFTBUILD_BAZEL_PROXY_BEP_PATH"
   )
 fi
+# The build service gives every operation its own private path. Keep execution metadata attached
+# to the build itself; the follow-up aquery is configuration evidence and must not replace it.
+if [[ -n "${SWIFTBUILD_BAZEL_PROXY_EXECUTION_LOG_PATH:-}" ]]; then
+  build_pre_config_flags+=(
+    "--execution_log_json_file=$SWIFTBUILD_BAZEL_PROXY_EXECUTION_LOG_PATH"
+    "--noexecution_log_sort"
+  )
+fi
 
 apply_sanitizers=1
 if [ "$ACTION" == "indexbuild" ]; then
@@ -229,6 +237,11 @@ readonly build_pre_config_flags
 # shellcheck disable=SC1091
 source "$BAZEL_INTEGRATION_DIR/bazel_build.sh"
 
+# Bazel has successfully returned; make its command/cache metadata private before parsing it.
+if [[ -n "${SWIFTBUILD_BAZEL_PROXY_EXECUTION_LOG_PATH:-}" ]]; then
+  chmod 600 "$SWIFTBUILD_BAZEL_PROXY_EXECUTION_LOG_PATH"
+fi
+
 # A successful Bazel build can execute zero product actions when every output is already current.
 # BEP remains the execution source of truth; this private aquery snapshot is bounded to the exact
 # target labels requested by the selected build service and lets it distinguish configured product
@@ -236,7 +249,12 @@ source "$BAZEL_INTEGRATION_DIR/bazel_build.sh"
 if [[ -n "${SWIFTBUILD_BAZEL_PROXY_ACTION_GRAPH_PATH:-}" ]]; then
   action_graph_pre_config_flags=()
   for option in "${build_pre_config_flags[@]}"; do
-    if [[ "$option" != --build_event_publish_all_actions && "$option" != --build_event_json_file=* ]]; then
+    if [[
+      "$option" != --build_event_publish_all_actions &&
+      "$option" != --build_event_json_file=* &&
+      "$option" != --execution_log_json_file=* &&
+      "$option" != --noexecution_log_sort
+    ]]; then
       action_graph_pre_config_flags+=("$option")
     fi
   done
@@ -257,7 +275,9 @@ if [[ -n "${SWIFTBUILD_BAZEL_PROXY_ACTION_GRAPH_PATH:-}" ]]; then
     "--config=$config" \
     --color=no \
     --output=jsonproto \
-    --noinclude_commandline \
+    --include_commandline \
+    --noinclude_param_files \
+    --noinclude_file_write_contents \
     --include_artifacts \
     --consistent_labels \
     "--output_file=$SWIFTBUILD_BAZEL_PROXY_ACTION_GRAPH_PATH" \

--- a/xcodeproj/internal/templates/generate_bazel_dependencies.sh
+++ b/xcodeproj/internal/templates/generate_bazel_dependencies.sh
@@ -243,9 +243,10 @@ if [[ -n "${SWIFTBUILD_BAZEL_PROXY_EXECUTION_LOG_PATH:-}" ]]; then
 fi
 
 # A successful Bazel build can execute zero product actions when every output is already current.
-# BEP remains the execution source of truth; this private aquery snapshot is bounded to the exact
-# target labels requested by the selected build service and lets it distinguish configured product
-# prerequisites that were up-to-date from actions that actually executed.
+# BEP remains the execution source of truth. Query the same generated target and exact output groups
+# as the successful build so split-transition products keep the configuration identity recorded in
+# the project manifest. Querying the user label directly can select only its top-level configuration
+# in a fresh output base and omit the requested transitioned product.
 if [[ -n "${SWIFTBUILD_BAZEL_PROXY_ACTION_GRAPH_PATH:-}" ]]; then
   action_graph_pre_config_flags=()
   for option in "${build_pre_config_flags[@]}"; do
@@ -258,10 +259,7 @@ if [[ -n "${SWIFTBUILD_BAZEL_PROXY_ACTION_GRAPH_PATH:-}" ]]; then
       action_graph_pre_config_flags+=("$option")
     fi
   done
-  action_graph_query="deps(${labels[0]})"
-  if ((${#labels[@]} > 1)); then
-    action_graph_query="deps(set(${labels[*]}))"
-  fi
+  action_graph_query="deps(%generator_label%)"
   # Collect optional arrays before expansion. macOS Bash 3.2 treats "${empty[@]}" as unbound
   # under `set -u`, even when the array was explicitly initialized.
   action_graph_flags=("${base_pre_config_flags[@]}")
@@ -277,6 +275,7 @@ if [[ -n "${SWIFTBUILD_BAZEL_PROXY_ACTION_GRAPH_PATH:-}" ]]; then
   "${bazel_cmd[@]}" aquery \
     "${action_graph_flags[@]}" \
     "--config=$config" \
+    "$output_groups_flag" \
     --color=no \
     --output=jsonproto \
     --include_commandline \


### PR DESCRIPTION
# Summary

- Add private per-operation command, runner, and cache metadata for proxy-owned builds.
- Query the exact generated target and output groups to preserve split-transition product identity.
- Preserve workspace-wrapper context and macOS Bash 3.2 compatibility; keep raw metadata owner-only and out of publishable receipts.

# Stack

- Part of #1953.
- 5 of 5 in the rules_xcodeproj build-proxy stack.
- Parent: configured Bazel action inventory.
- Companion proxy rollup: MobileNativeFoundation/XCBBuildServiceProxyKit#19.

# Validation

- Repository CI is green at this exact head.
- Focused launcher tests pass normally and with `--ignore_all_rc_files`; shell syntax, ShellCheck, and Buildifier pass.
- Live Xcode source-changing acceptance displayed 18 truthful action rows.
- Live Xcode disk-cache acceptance displayed 32 execution-log-proven cache-hit rows.

# Testing

Build after a source change, then populate a disk cache and build from a fresh correctly shaped output base. Verify only execution-log-proven rows say `Disk cache hit`, commands are sanitized, and persistent action-cache omissions remain `Up to date`.

# Remaining risk

The current JSON execution stream is a functional baseline. Compact-log adoption and production-graph latency/CPU/RSS comparison remain follow-up release gates.
