### PR TITLE
Add a versioned build proxy manifest

### DIFF
--- a/test/internal/build_proxy_manifest/BUILD
+++ b/test/internal/build_proxy_manifest/BUILD
@@ -1,0 +1,7 @@
+load("@rules_python//python:defs.bzl", "py_test")
+
+py_test(
+    name = "build_proxy_manifest_tests",
+    srcs = ["build_proxy_manifest_tests.py"],
+    deps = ["//xcodeproj/internal:build_proxy_manifest_lib"],
+)

--- a/test/internal/build_proxy_manifest/build_proxy_manifest_tests.py
+++ b/test/internal/build_proxy_manifest/build_proxy_manifest_tests.py
@@ -51,6 +51,10 @@ class BuildProxyManifestTests(unittest.TestCase):
         self.assertEqual(manifest["schemaVersion"], 1)
         self.assertEqual(manifest["capabilities"], {"actions": ["build"]})
         self.assertEqual(
+            manifest["ignoredXcodeTargetGUIDs"],
+            ["FF0100000000000000000001"],
+        )
+        self.assertEqual(
             manifest["invocation"],
             {
                 "bazelPath": "/usr/local/bin/bazel",

--- a/test/internal/build_proxy_manifest/build_proxy_manifest_tests.py
+++ b/test/internal/build_proxy_manifest/build_proxy_manifest_tests.py
@@ -1,0 +1,131 @@
+import json
+import unittest
+
+from xcodeproj.internal import build_proxy_manifest_lib
+
+
+def _entry(configuration="Debug", arch="arm64"):
+    return {
+        "action": "build",
+        "bazelLabel": "@@//app:app",
+        "configuration": configuration,
+        "outputGroup": f"bp @@//app:app {configuration}-{arch}",
+        "product": {
+            "basename": "App.app",
+            "name": "App",
+            "path": "bazel-out/App.app",
+            "type": "com.apple.product-type.application",
+        },
+        "targetID": f"@@//app:app {configuration}-{arch}",
+        "variant": {
+            "arch": arch,
+            "minimumOSVersion": "18.0",
+            "platform": "iphonesimulator",
+        },
+        "xcodeTargetGUID": "0000AAAAAAAA000000000001",
+    }
+
+
+def _line(entry):
+    return json.dumps(entry, separators=(",", ":"), sort_keys=True)
+
+
+class BuildProxyManifestTests(unittest.TestCase):
+    def test_assemble_is_versioned_and_byte_deterministic(self):
+        debug = _line(_entry())
+        release = _line(_entry(configuration="Release"))
+
+        forward = build_proxy_manifest_lib.assemble(
+            [("a", 1, release), ("b", 1, debug)],
+            bazel_path="/usr/local/bin/bazel",
+            generator_label="@@//app:project",
+        )
+        reverse = build_proxy_manifest_lib.assemble(
+            [("b", 1, debug), ("a", 1, release)],
+            bazel_path="/usr/local/bin/bazel",
+            generator_label="@@//app:project",
+        )
+
+        self.assertEqual(forward, reverse)
+        manifest = json.loads(forward)
+        self.assertEqual(manifest["schemaVersion"], 1)
+        self.assertEqual(manifest["capabilities"], {"actions": ["build"]})
+        self.assertEqual(
+            manifest["invocation"],
+            {
+                "bazelPath": "/usr/local/bin/bazel",
+                "bazelrcPath": "rules_xcodeproj/bazel/xcodeproj.bazelrc",
+                "generatorLabel": "@@//app:project",
+            },
+        )
+        self.assertEqual(
+            [entry["configuration"] for entry in manifest["targets"]],
+            ["Debug", "Release"],
+        )
+
+    def test_missing_required_key_is_rejected(self):
+        entry = _entry()
+        del entry["xcodeTargetGUID"]
+
+        with self.assertRaisesRegex(
+            build_proxy_manifest_lib.ManifestError,
+            "missing keys: xcodeTargetGUID",
+        ):
+            build_proxy_manifest_lib.assemble(
+                [("fragment", 1, _line(entry))],
+                bazel_path="bazel",
+                generator_label="@@//app:project",
+            )
+
+    def test_unsupported_action_is_rejected(self):
+        entry = _entry()
+        entry["action"] = "archive"
+
+        with self.assertRaisesRegex(
+            build_proxy_manifest_lib.ManifestError,
+            "unsupported action: 'archive'",
+        ):
+            build_proxy_manifest_lib.assemble(
+                [("fragment", 1, _line(entry))],
+                bazel_path="bazel",
+                generator_label="@@//app:project",
+            )
+
+    def test_duplicate_mapping_is_rejected(self):
+        entry = _line(_entry())
+
+        with self.assertRaisesRegex(
+            build_proxy_manifest_lib.ManifestError,
+            "duplicate target mapping",
+        ):
+            build_proxy_manifest_lib.assemble(
+                [("fragment", 1, entry), ("fragment", 2, entry)],
+                bazel_path="bazel",
+                generator_label="@@//app:project",
+            )
+
+    def test_missing_generator_label_is_rejected(self):
+        with self.assertRaisesRegex(
+            build_proxy_manifest_lib.ManifestError,
+            "generator label must not be empty",
+        ):
+            build_proxy_manifest_lib.assemble(
+                [],
+                bazel_path="bazel",
+                generator_label="",
+            )
+
+    def test_missing_bazel_path_is_rejected(self):
+        with self.assertRaisesRegex(
+            build_proxy_manifest_lib.ManifestError,
+            "Bazel path must not be empty",
+        ):
+            build_proxy_manifest_lib.assemble(
+                [],
+                bazel_path="",
+                generator_label="@@//app:project",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/generators/pbxnativetargets/BUILD
+++ b/tools/generators/pbxnativetargets/BUILD
@@ -62,12 +62,28 @@ apple_universal_binary(
 swift_library(
     name = "pbxnativetargets_tests.library",
     testonly = True,
-    srcs = glob(["test/**/*.swift"]),
+    srcs = glob(
+        ["test/**/*.swift"],
+        exclude = ["test/Generator/BuildProxyManifestEntryTests.swift"],
+    ),
     module_name = "pbxnativetargets_tests",
     deps = [
         ":pbxnativetargets.library",
         "@com_github_pointfreeco_swift_custom_dump//:CustomDump",
     ],
+)
+
+swift_library(
+    name = "build_proxy_manifest_tests.library",
+    testonly = True,
+    srcs = ["test/Generator/BuildProxyManifestEntryTests.swift"],
+    deps = [":pbxnativetargets.library"],
+)
+
+macos_unit_test(
+    name = "build_proxy_manifest_tests",
+    minimum_os_version = "13.0",
+    deps = [":build_proxy_manifest_tests.library"],
 )
 
 macos_unit_test(

--- a/tools/generators/pbxnativetargets/README.md
+++ b/tools/generators/pbxnativetargets/README.md
@@ -1,6 +1,6 @@
 # `PBXNativeTarget`s `PBXProj` partials generator
 
-The `pbxnativetargets` generator creates two or more files:
+The `pbxnativetargets` generator creates three or more files:
 
 - A `PBXProj` partial containing all of the `PBXNativeTarget` related objects:
   - `PBXNativeTarget`
@@ -8,6 +8,8 @@ The `pbxnativetargets` generator creates two or more files:
   - `XCBuildConfigurationList`
   - and various build phases
 - A file that maps `PBXBuildFile` identifiers to file paths
+- A JSON Lines fragment mapping generated target GUIDs and Xcode
+  configurations to Bazel build metadata
 
 Each `pbxnativetargets` invocation might process a subset of all targets. All
 targets that share the same name will be processed by the same invocation. This
@@ -22,6 +24,7 @@ The generator accepts the following command-line arguments (see
 
 - Positional `targets-output-path`
 - Positional `buildfile-map-output-path`
+- Positional `build-proxy-manifest-entries-output-path`
 - Positional `consolidation-map`
 - Positional `target-arguments-file
 - Positional `top-level-target-attributes-file`
@@ -35,6 +38,7 @@ Here is an example invocation:
 $ pbxnativetargets \
     /tmp/pbxproj_partials/pbxnativetargets/0 \
     /tmp/pbxproj_partials/buildfile_subidentifiers/0 \
+    /tmp/pbxproj_partials/build_proxy_manifest_entries/0 \
     /tmp/pbxproj_partials/consolidation_maps/0 \
     /tmp/pbxproj_partials/target_arguments_files/7 \
     /tmp/pbxproj_partials/top_level_target_attributes_files/7 \

--- a/tools/generators/pbxnativetargets/src/Generator/Arguments.swift
+++ b/tools/generators/pbxnativetargets/src/Generator/Arguments.swift
@@ -23,6 +23,14 @@ be written.
         var buildFileSubIdentifiersOutputPath: URL
 
         @Argument(
+            help: """
+Path to where build proxy manifest JSON Lines entries should be written.
+""",
+            transform: { URL(fileURLWithPath: $0, isDirectory: false) }
+        )
+        var buildProxyManifestEntriesOutputPath: URL
+
+        @Argument(
             help: "Path to the consolidation map.",
             transform: { URL(fileURLWithPath: $0, isDirectory: false) }
         )

--- a/tools/generators/pbxnativetargets/src/Generator/BuildProxyManifestEntry.swift
+++ b/tools/generators/pbxnativetargets/src/Generator/BuildProxyManifestEntry.swift
@@ -1,0 +1,122 @@
+import Foundation
+import PBXProj
+import ToolCommon
+
+/// One deterministic build mapping consumed by the build-service proxy.
+///
+/// The complete manifest is assembled from generator-shard JSON Lines files by
+/// `build_proxy_manifest_generator`. Keeping the PBX target GUID calculation in
+/// this generator ensures that the manifest and `project.pbxproj` use the same
+/// identifier source of truth.
+struct BuildProxyManifestEntry: Codable, Equatable {
+    struct Product: Codable, Equatable {
+        let basename: String
+        let name: String
+        let path: String?
+        let type: String
+    }
+
+    struct Variant: Codable, Equatable {
+        let arch: String
+        let minimumOSVersion: String
+        let platform: String
+    }
+
+    let action: String
+    let bazelLabel: String
+    let configuration: String
+    let outputGroup: String
+    let product: Product
+    let targetID: String
+    let variant: Variant
+    let xcodeTargetGUID: String
+}
+
+extension BuildProxyManifestEntry {
+    static func calculate(
+        consolidationMapEntries: [ConsolidationMapEntry],
+        targetArguments: [TargetID: TargetArguments],
+        topLevelTargetAttributes: [TargetID: TopLevelTargetAttributes]
+    ) throws -> [Self] {
+        var entries: [Self] = []
+
+        for consolidationMapEntry in consolidationMapEntries {
+            let xcodeTargetGUID = Identifiers.Targets.id(
+                subIdentifier: consolidationMapEntry.subIdentifier,
+                name: consolidationMapEntry.name
+            ).withoutComment
+
+            for targetID in consolidationMapEntry.key.sortedIds {
+                guard let arguments = targetArguments[targetID] else {
+                    throw PreconditionError(message: """
+Missing target arguments for build proxy manifest target ID \(targetID).
+""")
+                }
+
+                let topLevelAttributes = topLevelTargetAttributes[targetID]
+                let product = Product(
+                    basename: arguments.productBasename,
+                    name: arguments.productName,
+                    path: topLevelAttributes?.outputsProductPath,
+                    type: arguments.productType.identifier
+                )
+                let variant = Variant(
+                    arch: arguments.arch,
+                    minimumOSVersion: arguments.osVersion.description,
+                    platform: arguments.platform.rawValue
+                )
+
+                for configuration in Set(arguments.xcodeConfigurations).sorted() {
+                    entries.append(
+                        Self(
+                            action: "build",
+                            bazelLabel: consolidationMapEntry.label.description,
+                            configuration: configuration,
+                            outputGroup: "bp \(targetID.rawValue)",
+                            product: product,
+                            targetID: targetID.rawValue,
+                            variant: variant,
+                            xcodeTargetGUID: xcodeTargetGUID
+                        )
+                    )
+                }
+            }
+        }
+
+        return entries.sorted(by: stableLessThan)
+    }
+
+    static func encodeJSONLines(_ entries: [Self]) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+
+        var data = Data()
+        for entry in entries.sorted(by: stableLessThan) {
+            try data.append(encoder.encode(entry))
+            data.append(0x0A)
+        }
+        return data
+    }
+
+    private static func stableLessThan(_ lhs: Self, _ rhs: Self) -> Bool {
+        let lhsValues = [
+            lhs.xcodeTargetGUID,
+            lhs.configuration,
+            lhs.action,
+            lhs.variant.platform,
+            lhs.variant.arch,
+            lhs.variant.minimumOSVersion,
+            lhs.targetID,
+        ]
+        let rhsValues = [
+            rhs.xcodeTargetGUID,
+            rhs.configuration,
+            rhs.action,
+            rhs.variant.platform,
+            rhs.variant.arch,
+            rhs.variant.minimumOSVersion,
+            rhs.targetID,
+        ]
+        return lhsValues.lexicographicallyPrecedes(rhsValues)
+    }
+}

--- a/tools/generators/pbxnativetargets/src/Generator/Generator.swift
+++ b/tools/generators/pbxnativetargets/src/Generator/Generator.swift
@@ -41,6 +41,14 @@ struct Generator {
                     .formUnion(targetArguments.xcodeConfigurations)
             }
 
+        let buildProxyManifestEntries = try BuildProxyManifestEntry.calculate(
+            consolidationMapEntries: consolidationMapEntries,
+            targetArguments: targetArguments,
+            topLevelTargetAttributes: topLevelTargetAttributes
+        )
+        let buildProxyManifestEntriesData = try BuildProxyManifestEntry
+            .encodeJSONLines(buildProxyManifestEntries)
+
         guard
             let shard = UInt8(arguments.consolidationMap.lastPathComponent)
         else {
@@ -86,9 +94,16 @@ correctly
                 to: arguments.buildFileSubIdentifiersOutputPath
             )
         }
+        let writeBuildProxyManifestEntriesTask = Task {
+            try buildProxyManifestEntriesData.write(
+                to: arguments.buildProxyManifestEntriesOutputPath,
+                options: .atomic
+            )
+        }
 
         // Wait for all of the writes to complete
         try await writeTargetsTask.value
         try await writeBuildFileSubIdentifiersTask.value
+        try await writeBuildProxyManifestEntriesTask.value
     }
 }

--- a/tools/generators/pbxnativetargets/test/Generator/BuildProxyManifestEntryTests.swift
+++ b/tools/generators/pbxnativetargets/test/Generator/BuildProxyManifestEntryTests.swift
@@ -1,0 +1,86 @@
+import Foundation
+import XCTest
+@testable import pbxnativetargets
+
+class BuildProxyManifestEntryTests: XCTestCase {
+    func test_encodeJSONLines_isByteDeterministicAndSorted() throws {
+        let first = BuildProxyManifestEntry(
+            action: "build",
+            bazelLabel: "@@//app:app",
+            configuration: "Release",
+            outputGroup: "bp @@//app:app ios-opt",
+            product: .init(
+                basename: "App.app",
+                name: "App",
+                path: "bazel-out/App.app",
+                type: "com.apple.product-type.application"
+            ),
+            targetID: "@@//app:app ios-opt",
+            variant: .init(
+                arch: "arm64",
+                minimumOSVersion: "18.0",
+                platform: "iphoneos"
+            ),
+            xcodeTargetGUID: "0000AAAAAAAA000000000001"
+        )
+        let second = BuildProxyManifestEntry(
+            action: "build",
+            bazelLabel: "@@//app:app",
+            configuration: "Debug",
+            outputGroup: "bp @@//app:app ios-sim-dbg",
+            product: .init(
+                basename: "App.app",
+                name: "App",
+                path: "bazel-out/App.app",
+                type: "com.apple.product-type.application"
+            ),
+            targetID: "@@//app:app ios-sim-dbg",
+            variant: .init(
+                arch: "arm64",
+                minimumOSVersion: "18.0",
+                platform: "iphonesimulator"
+            ),
+            xcodeTargetGUID: "0000AAAAAAAA000000000001"
+        )
+
+        let forward = try BuildProxyManifestEntry.encodeJSONLines([first, second])
+        let reverse = try BuildProxyManifestEntry.encodeJSONLines([second, first])
+
+        XCTAssertEqual(forward, reverse)
+        XCTAssertEqual(
+            String(decoding: forward, as: UTF8.self),
+            #"{"action":"build","bazelLabel":"@@//app:app","configuration":"Debug","outputGroup":"bp @@//app:app ios-sim-dbg","product":{"basename":"App.app","name":"App","path":"bazel-out/App.app","type":"com.apple.product-type.application"},"targetID":"@@//app:app ios-sim-dbg","variant":{"arch":"arm64","minimumOSVersion":"18.0","platform":"iphonesimulator"},"xcodeTargetGUID":"0000AAAAAAAA000000000001"}"# + "\n" +
+                #"{"action":"build","bazelLabel":"@@//app:app","configuration":"Release","outputGroup":"bp @@//app:app ios-opt","product":{"basename":"App.app","name":"App","path":"bazel-out/App.app","type":"com.apple.product-type.application"},"targetID":"@@//app:app ios-opt","variant":{"arch":"arm64","minimumOSVersion":"18.0","platform":"iphoneos"},"xcodeTargetGUID":"0000AAAAAAAA000000000001"}"# + "\n"
+        )
+    }
+
+    func test_encodeJSONLines_omitsAbsentProductPath() throws {
+        let entry = BuildProxyManifestEntry(
+            action: "build",
+            bazelLabel: "@@//lib",
+            configuration: "Debug",
+            outputGroup: "bp @@//lib macos-dbg",
+            product: .init(
+                basename: "libLib.a",
+                name: "Lib",
+                path: nil,
+                type: "com.apple.product-type.library.static"
+            ),
+            targetID: "@@//lib macos-dbg",
+            variant: .init(
+                arch: "arm64",
+                minimumOSVersion: "14.0",
+                platform: "macosx"
+            ),
+            xcodeTargetGUID: "0000BBBBBBBB000000000001"
+        )
+
+        let data = try BuildProxyManifestEntry.encodeJSONLines([entry])
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
+        let product = try XCTUnwrap(object["product"] as? [String: Any])
+
+        XCTAssertNil(product["path"])
+    }
+}

--- a/xcodeproj/internal/BUILD
+++ b/xcodeproj/internal/BUILD
@@ -1,4 +1,17 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+
+py_library(
+    name = "build_proxy_manifest_lib",
+    srcs = ["build_proxy_manifest_lib.py"],
+    visibility = ["//test/internal/build_proxy_manifest:__pkg__"],
+)
+
+py_binary(
+    name = "build_proxy_manifest",
+    srcs = ["build_proxy_manifest.py"],
+    deps = [":build_proxy_manifest_lib"],
+)
 
 bzl_library(
     name = "bazel_tools",

--- a/xcodeproj/internal/BUILD
+++ b/xcodeproj/internal/BUILD
@@ -11,6 +11,9 @@ py_binary(
     name = "build_proxy_manifest",
     srcs = ["build_proxy_manifest.py"],
     deps = [":build_proxy_manifest_lib"],
+    # The xcodeproj rule is instantiated from a generated extension repository,
+    # so its implicit executable tool must be visible across repository bounds.
+    visibility = ["//visibility:public"],
 )
 
 bzl_library(

--- a/xcodeproj/internal/BUILD
+++ b/xcodeproj/internal/BUILD
@@ -10,10 +10,10 @@ py_library(
 py_binary(
     name = "build_proxy_manifest",
     srcs = ["build_proxy_manifest.py"],
-    deps = [":build_proxy_manifest_lib"],
     # The xcodeproj rule is instantiated from a generated extension repository,
     # so its implicit executable tool must be visible across repository bounds.
     visibility = ["//visibility:public"],
+    deps = [":build_proxy_manifest_lib"],
 )
 
 bzl_library(

--- a/xcodeproj/internal/build_proxy_manifest.bzl
+++ b/xcodeproj/internal/build_proxy_manifest.bzl
@@ -1,0 +1,43 @@
+"""Actions for creating the versioned build-proxy manifest."""
+
+def write_build_proxy_manifest(
+        *,
+        actions,
+        bazel_path,
+        entries_files,
+        generator_label,
+        name,
+        tool):
+    """Assembles deterministic shard entries into the v1 proxy manifest.
+
+    Args:
+        actions: `ctx.actions`.
+        bazel_path: The Bazel executable path recorded for proxy invocation.
+        entries_files: JSON Lines manifest fragments from target shards.
+        generator_label: The `xcodeproj` generator label the proxy must build.
+        name: The generator target name.
+        tool: The executable that validates and assembles the manifest.
+
+    Returns:
+        The generated build proxy manifest `File`.
+    """
+    output = actions.declare_file(
+        "{}_bazel_integration_files/build_proxy_manifest.json".format(name),
+    )
+
+    args = actions.args()
+    args.add(output)
+    args.add(str(generator_label))
+    args.add(bazel_path)
+    args.add_all(entries_files)
+
+    actions.run(
+        arguments = [args],
+        executable = tool,
+        inputs = entries_files,
+        outputs = [output],
+        mnemonic = "WriteBuildProxyManifest",
+        progress_message = "Generating %{output}",
+    )
+
+    return output

--- a/xcodeproj/internal/build_proxy_manifest.py
+++ b/xcodeproj/internal/build_proxy_manifest.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""Builds a canonical build-proxy manifest from generator shard entries."""
+
+import argparse
+from pathlib import Path
+
+from xcodeproj.internal import build_proxy_manifest_lib
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("output", type=Path)
+    parser.add_argument("generator_label")
+    parser.add_argument("bazel_path")
+    parser.add_argument("fragments", nargs="*", type=Path)
+    args = parser.parse_args()
+    build_proxy_manifest_lib.write(
+        args.output,
+        args.fragments,
+        bazel_path=args.bazel_path,
+        generator_label=args.generator_label,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/xcodeproj/internal/build_proxy_manifest_lib.py
+++ b/xcodeproj/internal/build_proxy_manifest_lib.py
@@ -1,0 +1,169 @@
+"""Deterministically assembles version 1 build-proxy manifest fragments."""
+
+import json
+from pathlib import Path
+from typing import Iterable, Mapping, Sequence
+
+
+SCHEMA_VERSION = 1
+CAPABILITIES = {"actions": ["build"]}
+BAZELRC_PATH = "rules_xcodeproj/bazel/xcodeproj.bazelrc"
+
+_REQUIRED_ENTRY_KEYS = {
+    "action",
+    "bazelLabel",
+    "configuration",
+    "outputGroup",
+    "product",
+    "targetID",
+    "variant",
+    "xcodeTargetGUID",
+}
+_REQUIRED_PRODUCT_KEYS = {"basename", "name", "type"}
+_REQUIRED_VARIANT_KEYS = {"arch", "minimumOSVersion", "platform"}
+
+
+class ManifestError(ValueError):
+    """Raised when a generated manifest fragment violates the v1 contract."""
+
+
+def _validate_entry(entry: object, source: str, line_number: int) -> Mapping:
+    if not isinstance(entry, dict):
+        raise ManifestError(f"{source}:{line_number}: entry must be an object")
+
+    missing = _REQUIRED_ENTRY_KEYS - entry.keys()
+    if missing:
+        raise ManifestError(
+            f"{source}:{line_number}: missing keys: {', '.join(sorted(missing))}"
+        )
+    if entry["action"] != "build":
+        raise ManifestError(
+            f"{source}:{line_number}: unsupported action: {entry['action']!r}"
+        )
+
+    product = entry["product"]
+    if not isinstance(product, dict):
+        raise ManifestError(f"{source}:{line_number}: product must be an object")
+    missing_product = _REQUIRED_PRODUCT_KEYS - product.keys()
+    if missing_product:
+        raise ManifestError(
+            f"{source}:{line_number}: product missing keys: "
+            f"{', '.join(sorted(missing_product))}"
+        )
+
+    variant = entry["variant"]
+    if not isinstance(variant, dict):
+        raise ManifestError(f"{source}:{line_number}: variant must be an object")
+    missing_variant = _REQUIRED_VARIANT_KEYS - variant.keys()
+    if missing_variant:
+        raise ManifestError(
+            f"{source}:{line_number}: variant missing keys: "
+            f"{', '.join(sorted(missing_variant))}"
+        )
+
+    return entry
+
+
+def _entry_sort_key(entry: Mapping) -> tuple:
+    variant = entry["variant"]
+    return (
+        entry["xcodeTargetGUID"],
+        entry["configuration"],
+        entry["action"],
+        variant["platform"],
+        variant["arch"],
+        variant["minimumOSVersion"],
+        entry["targetID"],
+    )
+
+
+def assemble(
+    fragment_lines: Iterable[tuple[str, int, str]],
+    *,
+    bazel_path: str,
+    generator_label: str,
+) -> bytes:
+    """Returns canonical v1 JSON bytes for named JSON Lines input."""
+    if not generator_label:
+        raise ManifestError("generator label must not be empty")
+    if not bazel_path:
+        raise ManifestError("Bazel path must not be empty")
+
+    entries = []
+    for source, line_number, line in fragment_lines:
+        if not line.strip():
+            continue
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError as error:
+            raise ManifestError(f"{source}:{line_number}: invalid JSON: {error}") from error
+        entries.append(_validate_entry(entry, source, line_number))
+
+    entries.sort(key=_entry_sort_key)
+    for previous, current in zip(entries, entries[1:]):
+        if _entry_sort_key(previous) == _entry_sort_key(current):
+            raise ManifestError(
+                "duplicate target mapping for "
+                f"{current['xcodeTargetGUID']}/"
+                f"{current['configuration']}/"
+                f"{current['action']}/"
+                f"{current['variant']['platform']}/"
+                f"{current['variant']['arch']}/"
+                f"{current['variant']['minimumOSVersion']}"
+            )
+
+    manifest = {
+        "capabilities": CAPABILITIES,
+        "invocation": {
+            "bazelPath": bazel_path,
+            "bazelrcPath": BAZELRC_PATH,
+            "generatorLabel": generator_label,
+        },
+        "schemaVersion": SCHEMA_VERSION,
+        "targets": entries,
+    }
+    return (
+        json.dumps(
+            manifest,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        + "\n"
+    ).encode("utf-8")
+
+
+def assemble_files(
+    paths: Sequence[Path],
+    *,
+    bazel_path: str,
+    generator_label: str,
+) -> bytes:
+    lines = []
+    for path in paths:
+        with path.open(encoding="utf-8") as file:
+            lines.extend(
+                (str(path), line_number, line)
+                for line_number, line in enumerate(file, start=1)
+            )
+    return assemble(
+        lines,
+        bazel_path=bazel_path,
+        generator_label=generator_label,
+    )
+
+
+def write(
+    output: Path,
+    fragments: Sequence[Path],
+    *,
+    bazel_path: str,
+    generator_label: str,
+) -> None:
+    output.write_bytes(
+        assemble_files(
+            fragments,
+            bazel_path=bazel_path,
+            generator_label=generator_label,
+        )
+    )

--- a/xcodeproj/internal/build_proxy_manifest_lib.py
+++ b/xcodeproj/internal/build_proxy_manifest_lib.py
@@ -8,6 +8,7 @@ from typing import Iterable, Mapping, Sequence
 SCHEMA_VERSION = 1
 CAPABILITIES = {"actions": ["build"]}
 BAZELRC_PATH = "rules_xcodeproj/bazel/xcodeproj.bazelrc"
+BAZEL_DEPENDENCIES_TARGET_GUID = "FF0100000000000000000001"
 
 _REQUIRED_ENTRY_KEYS = {
     "action",
@@ -114,6 +115,7 @@ def assemble(
 
     manifest = {
         "capabilities": CAPABILITIES,
+        "ignoredXcodeTargetGUIDs": [BAZEL_DEPENDENCIES_TARGET_GUID],
         "invocation": {
             "bazelPath": bazel_path,
             "bazelrcPath": BAZELRC_PATH,

--- a/xcodeproj/internal/pbxproj_partials.bzl
+++ b/xcodeproj/internal/pbxproj_partials.bzl
@@ -170,12 +170,14 @@ def _write_consolidation_map_targets(
             `dict` mapping `xcode_target.id` to `xcode_target`s.
 
     Returns:
-        A tuple with two elements:
+        A tuple with three elements:
 
         *   `pbxnativetargets`: A `File` for the `PBNativeTarget` `PBXProj`
             partial.
         *   `buildfile_subidentifiers`: A `File` that contain serialized
             `[Identifiers.BuildFile.SubIdentifier]`.
+        *   `build_proxy_manifest_entries`: A `File` that contains
+            deterministic JSON Lines manifest entries.
     """
     pbxnativetargets = actions.declare_file(
         "{}_pbxproj_partials/pbxnativetargets/{}".format(
@@ -185,6 +187,12 @@ def _write_consolidation_map_targets(
     )
     buildfile_subidentifiers = actions.declare_file(
         "{}_pbxproj_partials/buildfile_subidentifiers/{}".format(
+            generator_name,
+            idx,
+        ),
+    )
+    build_proxy_manifest_entries = actions.declare_file(
+        "{}_pbxproj_partials/build_proxy_manifest_entries/{}".format(
             generator_name,
             idx,
         ),
@@ -218,6 +226,9 @@ def _write_consolidation_map_targets(
 
     # buildFileSubIdentifiersOutputPath
     args.add(buildfile_subidentifiers)
+
+    # buildProxyManifestEntriesOutputPath
+    args.add(build_proxy_manifest_entries)
 
     # consolidationMap
     args.add(consolidation_map)
@@ -380,6 +391,7 @@ Target ID for unit test host '{}' not found in xcode_targets
         outputs = [
             pbxnativetargets,
             buildfile_subidentifiers,
+            build_proxy_manifest_entries,
         ],
         progress_message = message,
         mnemonic = "WritePBXNativeTargets",
@@ -392,6 +404,7 @@ Target ID for unit test host '{}' not found in xcode_targets
     return (
         pbxnativetargets,
         buildfile_subidentifiers,
+        build_proxy_manifest_entries,
     )
 
 def _write_files_and_groups(
@@ -1347,19 +1360,23 @@ def _write_targets(
             `dict` mapping `xcode_target.id` to `xcode_target`s.
 
     Returns:
-        A tuple with two elements:
+        A tuple with three elements:
 
         *   `pbxnativetargets`: A `list` of `File`s for the `PBNativeTarget`
             `PBXProj` partials.
         *   `buildfile_subidentifiers_files`: A `list` of `File`s that contain
             serialized `[Identifiers.BuildFile.SubIdentifier]`s.
+        *   `build_proxy_manifest_entries_files`: A `list` of `File`s that
+            contain deterministic JSON Lines manifest entries.
     """
     pbxnativetargets = []
     buildfile_subidentifiers_files = []
+    build_proxy_manifest_entries_files = []
     for consolidation_map, labels in consolidation_maps.items():
         (
             label_pbxnativetargets,
             label_buildfile_subidentifiers,
+            label_build_proxy_manifest_entries,
         ) = _write_consolidation_map_targets(
             actions = actions,
             colorize = colorize,
@@ -1377,10 +1394,14 @@ def _write_targets(
 
         pbxnativetargets.append(label_pbxnativetargets)
         buildfile_subidentifiers_files.append(label_buildfile_subidentifiers)
+        build_proxy_manifest_entries_files.append(
+            label_build_proxy_manifest_entries,
+        )
 
     return (
         pbxnativetargets,
         buildfile_subidentifiers_files,
+        build_proxy_manifest_entries_files,
     )
 
 # `project.pbxproj`

--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -2,6 +2,10 @@
 
 load("@bazel_skylib//lib:shell.bzl", "shell")
 load("//xcodeproj:xcodeprojinfo.bzl", "XcodeProjInfo")
+load(
+    "//xcodeproj/internal:build_proxy_manifest.bzl",
+    "write_build_proxy_manifest",
+)
 load("//xcodeproj/internal:pbxproj_partials.bzl", "pbxproj_partials")
 load(
     "//xcodeproj/internal/bazel_integration_files:actions.bzl",
@@ -209,6 +213,7 @@ def _write_bazel_integration_files(
         bazel_build_script_template,
         bazel_dependencies_script_template,
         bazel_path,
+        build_proxy_manifest,
         colorize,
         infos_per_xcode_configuration,
         install_path,
@@ -241,7 +246,11 @@ def _write_bazel_integration_files(
     )
 
     return (
-        [bazel_build_script, generate_bazel_dependencies_script] +
+        [
+            bazel_build_script,
+            build_proxy_manifest,
+            generate_bazel_dependencies_script,
+        ] +
         swift_debug_settings +
         static_files
     )
@@ -301,12 +310,15 @@ def _write_installer(
 def _write_project_contents(
         *,
         actions,
+        bazel_path,
         bin_dir_path,
+        build_proxy_manifest_generator,
         colorize,
         config,
         default_xcode_configuration,
         files_and_groups_generator,
         generation_shard_count,
+        generator_label,
         import_index_build_indexstores,
         legacy_index_import,
         index_import,
@@ -392,6 +404,7 @@ def _write_project_contents(
     (
         target_partials,
         buildfile_subidentifiers_files,
+        build_proxy_manifest_entries_files,
     ) = pbxproj_partials.write_targets(
         actions = actions,
         colorize = colorize,
@@ -403,6 +416,15 @@ def _write_project_contents(
         xcode_target_configurations = xcode_target_configurations,
         xcode_targets = xcode_targets,
         xcode_targets_by_label = xcode_targets_by_label,
+    )
+
+    build_proxy_manifest = write_build_proxy_manifest(
+        actions = actions,
+        bazel_path = bazel_path,
+        entries_files = build_proxy_manifest_entries_files,
+        generator_label = generator_label,
+        name = name,
+        tool = build_proxy_manifest_generator,
     )
 
     (
@@ -486,6 +508,7 @@ def _write_project_contents(
 
     return (
         project_pbxproj,
+        build_proxy_manifest,
         generated_directories_filelist,
         generated_xcfilelist,
         consolidation_maps.keys(),
@@ -626,18 +649,24 @@ Are you using an `alias`? `xcodeproj.focused_targets` and \
 
     (
         project_pbxproj,
+        build_proxy_manifest,
         generated_directories_filelist,
         generated_xcfilelist,
         consolidation_maps,
         target_ids_list,
     ) = _write_project_contents(
         actions = actions,
+        bazel_path = ctx.attr.bazel_path,
         bin_dir_path = ctx.bin_dir.path,
+        build_proxy_manifest_generator = (
+            ctx.executable._build_proxy_manifest_generator
+        ),
         colorize = colorize,
         config = config,
         default_xcode_configuration = default_xcode_configuration,
         files_and_groups_generator = ctx.executable._files_and_groups_generator,
         generation_shard_count = ctx.attr.generation_shard_count,
+        generator_label = ctx.label,
         import_index_build_indexstores = (
             ctx.attr.import_index_build_indexstores
         ),
@@ -724,6 +753,7 @@ Are you using an `alias`? `xcodeproj.focused_targets` and \
             ctx.file._generate_bazel_dependencies_script_template
         ),
         bazel_path = ctx.attr.bazel_path,
+        build_proxy_manifest = build_proxy_manifest,
         colorize = colorize,
         infos_per_xcode_configuration = infos_per_xcode_configuration,
         install_path = install_path,
@@ -845,6 +875,11 @@ A dict mapping of Labels for StoreKit Testing configuration files to their File 
             default = Label(
                 "//xcodeproj/internal/bazel_integration_files",
             ),
+        ),
+        "_build_proxy_manifest_generator": attr.label(
+            cfg = "exec",
+            default = Label("//xcodeproj/internal:build_proxy_manifest"),
+            executable = True,
         ),
         "_contents_xcworkspacedata": attr.label(
             allow_single_file = True,

--- a/xcodeproj/repositories.bzl
+++ b/xcodeproj/repositories.bzl
@@ -230,7 +230,7 @@ swift_library(
 """,
         sha256 = "1ebde9c9403d5befb6956556e26f9308000722f7da9e87fed2e770d3918d647c",
         strip_prefix = "swift-issue-reporting-0.2.1",
-        url = "https://github.com/pointfreeco/xctest-dynamic-overlay/archive/refs/tags/0.2.1.tar.gz",
+        url = "https://github.com/pointfreeco/swift-issue-reporting/archive/refs/tags/0.2.1.tar.gz",
     )
 
     http_archive(


### PR DESCRIPTION
# Summary

- Add a deterministic schema-v2 build-proxy manifest to generated Xcode projects.
- Bind project identity, target GUIDs, Bazel labels, target IDs, variants, operation capabilities, and output groups.
- Keep projects without proxy configuration unchanged.

# Stack

- Part of #1953.
- 1 of 5 in the rules_xcodeproj build-proxy stack.
- Parent: `main`.
- Next: the generated Bazel adapter layer.

# Validation

- `git diff --check` passes at this exact endpoint.
- The combined stack passes the repository test matrix; exact-layer CI is expected on this draft.

# Testing

Run the manifest analysis and generation tests, regenerate the Sanitizers fixture twice, and verify byte-identical schema-v2 output plus unchanged generation when proxy attributes are absent.
