### PR TITLE
Expose configured Bazel actions to the build proxy

### DIFF
--- a/test/internal/build_proxy_launcher/BUILD
+++ b/test/internal/build_proxy_launcher/BUILD
@@ -44,6 +44,7 @@ sh_test(
     data = [
         ":configured_runner",
         "//xcodeproj/internal/templates:build_proxy_launcher.sh",
+        "//xcodeproj/internal/templates:generate_bazel_dependencies.sh",
         "//xcodeproj/internal/templates:install_build_proxy.sh",
     ],
     deps = ["@bazel_tools//tools/bash/runfiles"],

--- a/test/internal/build_proxy_launcher/build_proxy_launcher_tests.sh
+++ b/test/internal/build_proxy_launcher/build_proxy_launcher_tests.sh
@@ -55,6 +55,29 @@ expected_bep_flag="--build_event_json_file=\$SWIFTBUILD_BAZEL_PROXY_BEP_PATH"
 readonly expected_bep_flag
 [[ "$(grep -Fc -- "$expected_bep_flag" <<< "$proxy_bep_block")" == 1 ]]
 
+proxy_action_graph_block="$(sed -n '/SWIFTBUILD_BAZEL_PROXY_ACTION_GRAPH_PATH:-/,/^fi$/p' "$adapter_source")"
+readonly proxy_action_graph_block
+# These are literal source fragments whose dollar expressions must not expand in this test shell.
+# shellcheck disable=SC2016
+for expected_action_graph_flag in \
+  'aquery' \
+  'action_graph_query="deps(${labels[0]})"' \
+  'action_graph_query="deps(set(${labels[*]}))"' \
+  'action_graph_toolchain_flags+=("--action_env=TOOLCHAINS=$toolchain")' \
+  '"--config=$config"' \
+  '--color=no' \
+  '--output=jsonproto' \
+  '--noinclude_commandline' \
+  '--include_artifacts' \
+  '--consistent_labels' \
+  '--output_file=$SWIFTBUILD_BAZEL_PROXY_ACTION_GRAPH_PATH'; do
+  [[ "$(grep -Fc -- "$expected_action_graph_flag" <<< "$proxy_action_graph_block")" == 1 ]]
+done
+# shellcheck disable=SC2016
+[[ "$(grep -Fc -- '"$option" != --build_event_json_file=*' <<< "$proxy_action_graph_block")" == 1 ]]
+# shellcheck disable=SC2016
+[[ "$(grep -Fc -- 'chmod 600 "$SWIFTBUILD_BAZEL_PROXY_ACTION_GRAPH_PATH"' <<< "$proxy_action_graph_block")" == 1 ]]
+
 sha256_file() {
   if command -v sha256sum > /dev/null 2>&1; then
     sha256sum -- "$1" | awk '{print $1}'

--- a/test/internal/build_proxy_launcher/build_proxy_launcher_tests.sh
+++ b/test/internal/build_proxy_launcher/build_proxy_launcher_tests.sh
@@ -29,6 +29,8 @@ installer="$(rlocation "$TEST_WORKSPACE/xcodeproj/internal/templates/install_bui
 readonly installer
 launcher_source="$(rlocation "$TEST_WORKSPACE/xcodeproj/internal/templates/build_proxy_launcher.sh")"
 readonly launcher_source
+adapter_source="$(rlocation "$TEST_WORKSPACE/xcodeproj/internal/templates/generate_bazel_dependencies.sh")"
+readonly adapter_source
 configured_runner="$(rlocation "$TEST_WORKSPACE/test/internal/build_proxy_launcher/configured_runner-runner.sh")"
 readonly configured_runner
 test_root="$(mktemp -d "$TEST_TMPDIR/build-proxy-launcher.XXXXXX")"
@@ -45,6 +47,13 @@ readonly capture="$test_root/capture"
 project_identity_flag="$(grep -F -- '--build_proxy_project_identity ' "$configured_runner")"
 readonly project_identity_flag
 [[ "$project_identity_flag" == *'//generator/test/internal/build_proxy_launcher/configured_runner:configured_runner' ]]
+
+proxy_bep_block="$(sed -n '/SWIFTBUILD_BAZEL_PROXY_BEP_PATH:-/,/^fi$/p' "$adapter_source")"
+readonly proxy_bep_block
+[[ "$(grep -Fc -- '--build_event_publish_all_actions' <<< "$proxy_bep_block")" == 1 ]]
+expected_bep_flag="--build_event_json_file=\$SWIFTBUILD_BAZEL_PROXY_BEP_PATH"
+readonly expected_bep_flag
+[[ "$(grep -Fc -- "$expected_bep_flag" <<< "$proxy_bep_block")" == 1 ]]
 
 sha256_file() {
   if command -v sha256sum > /dev/null 2>&1; then

--- a/xcodeproj/internal/templates/generate_bazel_dependencies.sh
+++ b/xcodeproj/internal/templates/generate_bazel_dependencies.sh
@@ -156,6 +156,7 @@ build_pre_config_flags=(
 )
 if [[ -n "${SWIFTBUILD_BAZEL_PROXY_BEP_PATH:-}" ]]; then
   build_pre_config_flags+=(
+    "--build_event_publish_all_actions"
     "--build_event_json_file=$SWIFTBUILD_BAZEL_PROXY_BEP_PATH"
   )
 fi

--- a/xcodeproj/internal/templates/generate_bazel_dependencies.sh
+++ b/xcodeproj/internal/templates/generate_bazel_dependencies.sh
@@ -226,7 +226,44 @@ fi
 readonly build_pre_config_flags
 
 # `bazel_build.sh` sets `output_path`
+# shellcheck disable=SC1091
 source "$BAZEL_INTEGRATION_DIR/bazel_build.sh"
+
+# A successful Bazel build can execute zero product actions when every output is already current.
+# BEP remains the execution source of truth; this private aquery snapshot is bounded to the exact
+# target labels requested by the selected build service and lets it distinguish configured product
+# prerequisites that were up-to-date from actions that actually executed.
+if [[ -n "${SWIFTBUILD_BAZEL_PROXY_ACTION_GRAPH_PATH:-}" ]]; then
+  action_graph_pre_config_flags=()
+  for option in "${build_pre_config_flags[@]}"; do
+    if [[ "$option" != --build_event_publish_all_actions && "$option" != --build_event_json_file=* ]]; then
+      action_graph_pre_config_flags+=("$option")
+    fi
+  done
+  action_graph_query="deps(${labels[0]})"
+  if ((${#labels[@]} > 1)); then
+    action_graph_query="deps(set(${labels[*]}))"
+  fi
+  action_graph_toolchain_flags=()
+  if [[ -n "${toolchain:-}" ]]; then
+    action_graph_toolchain_flags+=("--action_env=TOOLCHAINS=$toolchain")
+  fi
+  # Both arrays are assigned by the generated `bazel_build.sh` sourced above.
+  # shellcheck disable=SC2154
+  "${bazel_cmd[@]}" aquery \
+    "${base_pre_config_flags[@]}" \
+    "${action_graph_pre_config_flags[@]}" \
+    "${action_graph_toolchain_flags[@]}" \
+    "--config=$config" \
+    --color=no \
+    --output=jsonproto \
+    --noinclude_commandline \
+    --include_artifacts \
+    --consistent_labels \
+    "--output_file=$SWIFTBUILD_BAZEL_PROXY_ACTION_GRAPH_PATH" \
+    "$action_graph_query"
+  chmod 600 "$SWIFTBUILD_BAZEL_PROXY_ACTION_GRAPH_PATH"
+fi
 
 # Async actions
 #


### PR DESCRIPTION
# Summary

- Publish all proxy-owned BEP action completion events.
- Capture the exact configured product-action closure after a successful build.
- Keep the feature opt-in and exclude proxy metadata destinations from publishable receipts.

# Stack

- Part of #1953.
- 4 of 5 in the rules_xcodeproj build-proxy stack.
- Parent: the opt-in launcher PR.
- Next: action commands and cache provenance.

# Validation

- Repository CI is green at this exact head.
- Live Xcode verifies configured and completed action reconciliation without duplicate rows.

# Testing

Build a mapped target after a source change and on a no-change rebuild; verify configured plus completed product actions form one mutually exclusive union in the Xcode report.
