### PR TITLE
Capture compact Bazel execution logs

### DIFF
--- a/test/internal/build_proxy_launcher/build_proxy_launcher_tests.sh
+++ b/test/internal/build_proxy_launcher/build_proxy_launcher_tests.sh
@@ -59,10 +59,11 @@ readonly expected_bep_flag
 
 proxy_execution_log_flags_block="$(sed -n '/# The build service gives every operation/,/^fi$/p' "$adapter_source")"
 readonly proxy_execution_log_flags_block
-# This is a literal source fragment whose dollar expression must not expand in this test shell.
+# These are literal source fragments whose dollar expressions must not expand in this test shell.
 # shellcheck disable=SC2016
 [[ "$(grep -Fc -- '--execution_log_compact_file=$SWIFTBUILD_BAZEL_PROXY_EXECUTION_LOG_PATH' <<< "$proxy_execution_log_flags_block")" == 1 ]]
-[[ "$(grep -Fc -- '--execution_log_json_file=' <<< "$proxy_execution_log_flags_block")" == 0 ]]
+[[ "$(grep -Fc -- '"--execution_log_binary_file="' <<< "$proxy_execution_log_flags_block")" == 1 ]]
+[[ "$(grep -Fc -- '"--execution_log_json_file="' <<< "$proxy_execution_log_flags_block")" == 1 ]]
 [[ "$(grep -Fc -- '--noexecution_log_sort' <<< "$proxy_execution_log_flags_block")" == 0 ]]
 
 # With no proxy path, the adapter must pass exactly the pre-existing build flags to Bazel.
@@ -75,15 +76,17 @@ eval "$proxy_execution_log_flags_block"
 [[ "${build_pre_config_flags[0]}" == "--existing-build-flag" ]]
 [[ "${build_pre_config_flags[1]}" == "--define=ordinary=value with spaces" ]]
 
-# With a proxy path, the compact execution-log flag is appended to the actual build flags verbatim.
+# With a proxy path, conflicting formats are cleared and the private compact path wins verbatim.
 build_pre_config_flags=(--existing-build-flag)
 readonly expected_execution_log_path="$test_root/execution log.compact"
 SWIFTBUILD_BAZEL_PROXY_EXECUTION_LOG_PATH="$expected_execution_log_path"
 export SWIFTBUILD_BAZEL_PROXY_EXECUTION_LOG_PATH
 eval "$proxy_execution_log_flags_block"
-[[ "${#build_pre_config_flags[@]}" == 2 ]]
+[[ "${#build_pre_config_flags[@]}" == 4 ]]
 [[ "${build_pre_config_flags[0]}" == "--existing-build-flag" ]]
-[[ "${build_pre_config_flags[1]}" == "--execution_log_compact_file=$expected_execution_log_path" ]]
+[[ "${build_pre_config_flags[1]}" == "--execution_log_binary_file=" ]]
+[[ "${build_pre_config_flags[2]}" == "--execution_log_compact_file=$expected_execution_log_path" ]]
+[[ "${build_pre_config_flags[3]}" == "--execution_log_json_file=" ]]
 unset SWIFTBUILD_BAZEL_PROXY_EXECUTION_LOG_PATH
 
 # Execution-log paths and sorting are proxy-owned evidence plumbing, not invocation policy. Keep
@@ -197,6 +200,15 @@ done
 [[ "$(grep -Fc -- '"$option" != --execution_log_binary_file=*' <<< "$proxy_action_graph_block")" == 1 ]]
 # shellcheck disable=SC2016
 [[ "$(grep -Fc -- '"$option" != --noexecution_log_sort' <<< "$proxy_action_graph_block")" == 1 ]]
+# Command-line clears come after the named config, so execution-log settings inherited directly
+# from common/build/config bazelrc sections cannot leak into the metadata-only aquery.
+for cleared_execution_log_flag in \
+  '--execution_log_binary_file=' \
+  '--execution_log_compact_file=' \
+  '--execution_log_json_file='; do
+  expected_clear_line="    $cleared_execution_log_flag \\"
+  [[ "$(grep -Fxc -- "$expected_clear_line" <<< "$proxy_action_graph_block")" == 1 ]]
+done
 # shellcheck disable=SC2016
 [[ "$(grep -Fc -- 'chmod 600 "$SWIFTBUILD_BAZEL_PROXY_ACTION_GRAPH_PATH"' <<< "$proxy_action_graph_block")" == 1 ]]
 

--- a/test/internal/build_proxy_launcher/build_proxy_launcher_tests.sh
+++ b/test/internal/build_proxy_launcher/build_proxy_launcher_tests.sh
@@ -59,44 +59,52 @@ readonly expected_bep_flag
 
 proxy_execution_log_flags_block="$(sed -n '/# The build service gives every operation/,/^fi$/p' "$adapter_source")"
 readonly proxy_execution_log_flags_block
-# These are literal source fragments whose dollar expressions must not expand in this test shell.
+# This is a literal source fragment whose dollar expression must not expand in this test shell.
 # shellcheck disable=SC2016
-for expected_execution_log_flag in \
-  '--execution_log_json_file=$SWIFTBUILD_BAZEL_PROXY_EXECUTION_LOG_PATH' \
-  '--noexecution_log_sort'; do
-  [[ "$(grep -Fc -- "$expected_execution_log_flag" <<< "$proxy_execution_log_flags_block")" == 1 ]]
-done
+[[ "$(grep -Fc -- '--execution_log_compact_file=$SWIFTBUILD_BAZEL_PROXY_EXECUTION_LOG_PATH' <<< "$proxy_execution_log_flags_block")" == 1 ]]
+[[ "$(grep -Fc -- '--execution_log_json_file=' <<< "$proxy_execution_log_flags_block")" == 0 ]]
+[[ "$(grep -Fc -- '--noexecution_log_sort' <<< "$proxy_execution_log_flags_block")" == 0 ]]
 
 # With no proxy path, the adapter must pass exactly the pre-existing build flags to Bazel.
-build_pre_config_flags=(--existing-build-flag)
+build_pre_config_flags=(--existing-build-flag "--define=ordinary=value with spaces")
+ordinary_build_flags_before="$(declare -p build_pre_config_flags)"
 unset SWIFTBUILD_BAZEL_PROXY_EXECUTION_LOG_PATH
 eval "$proxy_execution_log_flags_block"
-[[ "${build_pre_config_flags[*]}" == "--existing-build-flag" ]]
+[[ "$(declare -p build_pre_config_flags)" == "$ordinary_build_flags_before" ]]
+[[ "${#build_pre_config_flags[@]}" == 2 ]]
+[[ "${build_pre_config_flags[0]}" == "--existing-build-flag" ]]
+[[ "${build_pre_config_flags[1]}" == "--define=ordinary=value with spaces" ]]
 
-# With a proxy path, the two execution-log flags are appended to the actual build flags verbatim.
-readonly expected_execution_log_path="$test_root/execution log.jsonl"
+# With a proxy path, the compact execution-log flag is appended to the actual build flags verbatim.
+build_pre_config_flags=(--existing-build-flag)
+readonly expected_execution_log_path="$test_root/execution log.compact"
 SWIFTBUILD_BAZEL_PROXY_EXECUTION_LOG_PATH="$expected_execution_log_path"
 export SWIFTBUILD_BAZEL_PROXY_EXECUTION_LOG_PATH
 eval "$proxy_execution_log_flags_block"
-[[ "${#build_pre_config_flags[@]}" == 3 ]]
+[[ "${#build_pre_config_flags[@]}" == 2 ]]
 [[ "${build_pre_config_flags[0]}" == "--existing-build-flag" ]]
-[[ "${build_pre_config_flags[1]}" == "--execution_log_json_file=$expected_execution_log_path" ]]
-[[ "${build_pre_config_flags[2]}" == "--noexecution_log_sort" ]]
+[[ "${build_pre_config_flags[1]}" == "--execution_log_compact_file=$expected_execution_log_path" ]]
 unset SWIFTBUILD_BAZEL_PROXY_EXECUTION_LOG_PATH
 
 # Execution-log paths and sorting are proxy-owned evidence plumbing, not invocation policy. Keep
-# the volatile absolute path and its companion option out of the publishable invocation receipt.
+# current and legacy metadata options out of the publishable invocation receipt.
 proxy_receipt_command_options_block="$(sed -n '/for option in .*build_pre_config_flags/,/^  done$/p' "$bazel_build_source")"
 readonly proxy_receipt_command_options_block
 # shellcheck disable=SC2016
+[[ "$(grep -Fc -- '"$option" != --execution_log_compact_file=*' <<< "$proxy_receipt_command_options_block")" == 1 ]]
+# shellcheck disable=SC2016
 [[ "$(grep -Fc -- '"$option" != --execution_log_json_file=*' <<< "$proxy_receipt_command_options_block")" == 1 ]]
+# shellcheck disable=SC2016
+[[ "$(grep -Fc -- '"$option" != --execution_log_binary_file=*' <<< "$proxy_receipt_command_options_block")" == 1 ]]
 # shellcheck disable=SC2016
 [[ "$(grep -Fc -- '"$option" != --noexecution_log_sort' <<< "$proxy_receipt_command_options_block")" == 1 ]]
 # The extracted source fragment consumes this array through `eval` below.
 # shellcheck disable=SC2034
 base_pre_config_flags=(--base-build-flag)
 build_pre_config_flags=(
+  "--execution_log_compact_file=$expected_execution_log_path"
   "--execution_log_json_file=$expected_execution_log_path"
+  "--execution_log_binary_file=$expected_execution_log_path"
   --noexecution_log_sort
   --kept-build-flag
 )
@@ -182,26 +190,49 @@ done
 # shellcheck disable=SC2016
 [[ "$(grep -Fc -- '"$option" != --build_event_json_file=*' <<< "$proxy_action_graph_block")" == 1 ]]
 # shellcheck disable=SC2016
+[[ "$(grep -Fc -- '"$option" != --execution_log_compact_file=*' <<< "$proxy_action_graph_block")" == 1 ]]
+# shellcheck disable=SC2016
 [[ "$(grep -Fc -- '"$option" != --execution_log_json_file=*' <<< "$proxy_action_graph_block")" == 1 ]]
+# shellcheck disable=SC2016
+[[ "$(grep -Fc -- '"$option" != --execution_log_binary_file=*' <<< "$proxy_action_graph_block")" == 1 ]]
 # shellcheck disable=SC2016
 [[ "$(grep -Fc -- '"$option" != --noexecution_log_sort' <<< "$proxy_action_graph_block")" == 1 ]]
 # shellcheck disable=SC2016
 [[ "$(grep -Fc -- 'chmod 600 "$SWIFTBUILD_BAZEL_PROXY_ACTION_GRAPH_PATH"' <<< "$proxy_action_graph_block")" == 1 ]]
 
-proxy_action_graph_flags_block="$(sed -n '/# Collect optional arrays before expansion/,/^  readonly action_graph_flags$/p' "$adapter_source")"
+proxy_action_graph_filter_block="$(sed -n '/  action_graph_pre_config_flags=()/,/^  done$/p' "$adapter_source")"
+readonly proxy_action_graph_filter_block
+base_pre_config_flags=(
+  "--execution_log_compact_file=$expected_execution_log_path"
+  "--execution_log_json_file=$expected_execution_log_path"
+  "--execution_log_binary_file=$expected_execution_log_path"
+  --noexecution_log_sort
+  --kept-base-action-graph-flag
+)
+build_pre_config_flags=(
+  "--execution_log_compact_file=$expected_execution_log_path"
+  "--execution_log_json_file=$expected_execution_log_path"
+  "--execution_log_binary_file=$expected_execution_log_path"
+  --noexecution_log_sort
+  --kept-action-graph-flag
+)
+eval "$proxy_action_graph_filter_block"
+[[ "${#action_graph_pre_config_flags[@]}" == 2 ]]
+[[ "${action_graph_pre_config_flags[0]}" == "--kept-base-action-graph-flag" ]]
+[[ "${action_graph_pre_config_flags[1]}" == "--kept-action-graph-flag" ]]
+
+proxy_action_graph_flags_block="$(sed -n '/  action_graph_flags=(/,/^  readonly action_graph_flags$/p' "$adapter_source")"
 readonly proxy_action_graph_flags_block
 (
   set -u
-  base_pre_config_flags=(--base-flag)
-  action_graph_pre_config_flags=()
+  action_graph_pre_config_flags=(--base-flag)
   toolchain=
   eval "$proxy_action_graph_flags_block"
   [[ "${action_graph_flags[*]}" == "--base-flag" ]]
 )
 (
   set -u
-  base_pre_config_flags=(--base-flag)
-  action_graph_pre_config_flags=(--configured-flag)
+  action_graph_pre_config_flags=(--base-flag --configured-flag)
   toolchain=com.example.toolchain
   eval "$proxy_action_graph_flags_block"
   [[ "${action_graph_flags[*]}" == "--base-flag --configured-flag --action_env=TOOLCHAINS=com.example.toolchain" ]]

--- a/test/internal/build_proxy_launcher/build_proxy_launcher_tests.sh
+++ b/test/internal/build_proxy_launcher/build_proxy_launcher_tests.sh
@@ -66,10 +66,11 @@ readonly expected_bep_flag
 
 proxy_execution_log_flags_block="$(sed -n '/# The build service gives every operation/,/^fi$/p' "$adapter_source")"
 readonly proxy_execution_log_flags_block
-# This is a literal source fragment whose dollar expression must not expand in this test shell.
+# These are literal source fragments whose dollar expressions must not expand in this test shell.
 # shellcheck disable=SC2016
 [[ "$(grep -Fc -- '--execution_log_compact_file=$SWIFTBUILD_BAZEL_PROXY_EXECUTION_LOG_PATH' <<< "$proxy_execution_log_flags_block")" == 1 ]]
-[[ "$(grep -Fc -- '--execution_log_json_file=' <<< "$proxy_execution_log_flags_block")" == 0 ]]
+[[ "$(grep -Fc -- '"--execution_log_binary_file="' <<< "$proxy_execution_log_flags_block")" == 1 ]]
+[[ "$(grep -Fc -- '"--execution_log_json_file="' <<< "$proxy_execution_log_flags_block")" == 1 ]]
 [[ "$(grep -Fc -- '--noexecution_log_sort' <<< "$proxy_execution_log_flags_block")" == 0 ]]
 
 # With no proxy path, the adapter must pass exactly the pre-existing build flags to Bazel.
@@ -82,15 +83,17 @@ eval "$proxy_execution_log_flags_block"
 [[ "${build_pre_config_flags[0]}" == "--existing-build-flag" ]]
 [[ "${build_pre_config_flags[1]}" == "--define=ordinary=value with spaces" ]]
 
-# With a proxy path, the compact execution-log flag is appended to the actual build flags verbatim.
+# With a proxy path, conflicting formats are cleared and the private compact path wins verbatim.
 build_pre_config_flags=(--existing-build-flag)
 readonly expected_execution_log_path="$test_root/execution log.compact"
 SWIFTBUILD_BAZEL_PROXY_EXECUTION_LOG_PATH="$expected_execution_log_path"
 export SWIFTBUILD_BAZEL_PROXY_EXECUTION_LOG_PATH
 eval "$proxy_execution_log_flags_block"
-[[ "${#build_pre_config_flags[@]}" == 2 ]]
+[[ "${#build_pre_config_flags[@]}" == 4 ]]
 [[ "${build_pre_config_flags[0]}" == "--existing-build-flag" ]]
-[[ "${build_pre_config_flags[1]}" == "--execution_log_compact_file=$expected_execution_log_path" ]]
+[[ "${build_pre_config_flags[1]}" == "--execution_log_binary_file=" ]]
+[[ "${build_pre_config_flags[2]}" == "--execution_log_compact_file=$expected_execution_log_path" ]]
+[[ "${build_pre_config_flags[3]}" == "--execution_log_json_file=" ]]
 unset SWIFTBUILD_BAZEL_PROXY_EXECUTION_LOG_PATH
 
 # Execution-log paths and sorting are proxy-owned evidence plumbing, not invocation policy. Keep
@@ -204,6 +207,15 @@ done
 [[ "$(grep -Fc -- '"$option" != --execution_log_binary_file=*' <<< "$proxy_action_graph_block")" == 1 ]]
 # shellcheck disable=SC2016
 [[ "$(grep -Fc -- '"$option" != --noexecution_log_sort' <<< "$proxy_action_graph_block")" == 1 ]]
+# Command-line clears come after the named config, so execution-log settings inherited directly
+# from common/build/config bazelrc sections cannot leak into the metadata-only aquery.
+for cleared_execution_log_flag in \
+  '--execution_log_binary_file=' \
+  '--execution_log_compact_file=' \
+  '--execution_log_json_file='; do
+  expected_clear_line="    $cleared_execution_log_flag \\"
+  [[ "$(grep -Fxc -- "$expected_clear_line" <<< "$proxy_action_graph_block")" == 1 ]]
+done
 # shellcheck disable=SC2016
 [[ "$(grep -Fc -- 'chmod 600 "$SWIFTBUILD_BAZEL_PROXY_ACTION_GRAPH_PATH"' <<< "$proxy_action_graph_block")" == 1 ]]
 

--- a/test/internal/build_proxy_launcher/build_proxy_launcher_tests.sh
+++ b/test/internal/build_proxy_launcher/build_proxy_launcher_tests.sh
@@ -66,44 +66,52 @@ readonly expected_bep_flag
 
 proxy_execution_log_flags_block="$(sed -n '/# The build service gives every operation/,/^fi$/p' "$adapter_source")"
 readonly proxy_execution_log_flags_block
-# These are literal source fragments whose dollar expressions must not expand in this test shell.
+# This is a literal source fragment whose dollar expression must not expand in this test shell.
 # shellcheck disable=SC2016
-for expected_execution_log_flag in \
-  '--execution_log_json_file=$SWIFTBUILD_BAZEL_PROXY_EXECUTION_LOG_PATH' \
-  '--noexecution_log_sort'; do
-  [[ "$(grep -Fc -- "$expected_execution_log_flag" <<< "$proxy_execution_log_flags_block")" == 1 ]]
-done
+[[ "$(grep -Fc -- '--execution_log_compact_file=$SWIFTBUILD_BAZEL_PROXY_EXECUTION_LOG_PATH' <<< "$proxy_execution_log_flags_block")" == 1 ]]
+[[ "$(grep -Fc -- '--execution_log_json_file=' <<< "$proxy_execution_log_flags_block")" == 0 ]]
+[[ "$(grep -Fc -- '--noexecution_log_sort' <<< "$proxy_execution_log_flags_block")" == 0 ]]
 
 # With no proxy path, the adapter must pass exactly the pre-existing build flags to Bazel.
-build_pre_config_flags=(--existing-build-flag)
+build_pre_config_flags=(--existing-build-flag "--define=ordinary=value with spaces")
+ordinary_build_flags_before="$(declare -p build_pre_config_flags)"
 unset SWIFTBUILD_BAZEL_PROXY_EXECUTION_LOG_PATH
 eval "$proxy_execution_log_flags_block"
-[[ "${build_pre_config_flags[*]}" == "--existing-build-flag" ]]
+[[ "$(declare -p build_pre_config_flags)" == "$ordinary_build_flags_before" ]]
+[[ "${#build_pre_config_flags[@]}" == 2 ]]
+[[ "${build_pre_config_flags[0]}" == "--existing-build-flag" ]]
+[[ "${build_pre_config_flags[1]}" == "--define=ordinary=value with spaces" ]]
 
-# With a proxy path, the two execution-log flags are appended to the actual build flags verbatim.
-readonly expected_execution_log_path="$test_root/execution log.jsonl"
+# With a proxy path, the compact execution-log flag is appended to the actual build flags verbatim.
+build_pre_config_flags=(--existing-build-flag)
+readonly expected_execution_log_path="$test_root/execution log.compact"
 SWIFTBUILD_BAZEL_PROXY_EXECUTION_LOG_PATH="$expected_execution_log_path"
 export SWIFTBUILD_BAZEL_PROXY_EXECUTION_LOG_PATH
 eval "$proxy_execution_log_flags_block"
-[[ "${#build_pre_config_flags[@]}" == 3 ]]
+[[ "${#build_pre_config_flags[@]}" == 2 ]]
 [[ "${build_pre_config_flags[0]}" == "--existing-build-flag" ]]
-[[ "${build_pre_config_flags[1]}" == "--execution_log_json_file=$expected_execution_log_path" ]]
-[[ "${build_pre_config_flags[2]}" == "--noexecution_log_sort" ]]
+[[ "${build_pre_config_flags[1]}" == "--execution_log_compact_file=$expected_execution_log_path" ]]
 unset SWIFTBUILD_BAZEL_PROXY_EXECUTION_LOG_PATH
 
 # Execution-log paths and sorting are proxy-owned evidence plumbing, not invocation policy. Keep
-# the volatile absolute path and its companion option out of the publishable invocation receipt.
+# current and legacy metadata options out of the publishable invocation receipt.
 proxy_receipt_command_options_block="$(sed -n '/for option in .*build_pre_config_flags/,/^  done$/p' "$bazel_build_source")"
 readonly proxy_receipt_command_options_block
 # shellcheck disable=SC2016
+[[ "$(grep -Fc -- '"$option" != --execution_log_compact_file=*' <<< "$proxy_receipt_command_options_block")" == 1 ]]
+# shellcheck disable=SC2016
 [[ "$(grep -Fc -- '"$option" != --execution_log_json_file=*' <<< "$proxy_receipt_command_options_block")" == 1 ]]
+# shellcheck disable=SC2016
+[[ "$(grep -Fc -- '"$option" != --execution_log_binary_file=*' <<< "$proxy_receipt_command_options_block")" == 1 ]]
 # shellcheck disable=SC2016
 [[ "$(grep -Fc -- '"$option" != --noexecution_log_sort' <<< "$proxy_receipt_command_options_block")" == 1 ]]
 # The extracted source fragment consumes this array through `eval` below.
 # shellcheck disable=SC2034
 base_pre_config_flags=(--base-build-flag)
 build_pre_config_flags=(
+  "--execution_log_compact_file=$expected_execution_log_path"
   "--execution_log_json_file=$expected_execution_log_path"
+  "--execution_log_binary_file=$expected_execution_log_path"
   --noexecution_log_sort
   --kept-build-flag
 )
@@ -189,26 +197,49 @@ done
 # shellcheck disable=SC2016
 [[ "$(grep -Fc -- '"$option" != --build_event_json_file=*' <<< "$proxy_action_graph_block")" == 1 ]]
 # shellcheck disable=SC2016
+[[ "$(grep -Fc -- '"$option" != --execution_log_compact_file=*' <<< "$proxy_action_graph_block")" == 1 ]]
+# shellcheck disable=SC2016
 [[ "$(grep -Fc -- '"$option" != --execution_log_json_file=*' <<< "$proxy_action_graph_block")" == 1 ]]
+# shellcheck disable=SC2016
+[[ "$(grep -Fc -- '"$option" != --execution_log_binary_file=*' <<< "$proxy_action_graph_block")" == 1 ]]
 # shellcheck disable=SC2016
 [[ "$(grep -Fc -- '"$option" != --noexecution_log_sort' <<< "$proxy_action_graph_block")" == 1 ]]
 # shellcheck disable=SC2016
 [[ "$(grep -Fc -- 'chmod 600 "$SWIFTBUILD_BAZEL_PROXY_ACTION_GRAPH_PATH"' <<< "$proxy_action_graph_block")" == 1 ]]
 
-proxy_action_graph_flags_block="$(sed -n '/# Collect optional arrays before expansion/,/^  readonly action_graph_flags$/p' "$adapter_source")"
+proxy_action_graph_filter_block="$(sed -n '/  action_graph_pre_config_flags=()/,/^  done$/p' "$adapter_source")"
+readonly proxy_action_graph_filter_block
+base_pre_config_flags=(
+  "--execution_log_compact_file=$expected_execution_log_path"
+  "--execution_log_json_file=$expected_execution_log_path"
+  "--execution_log_binary_file=$expected_execution_log_path"
+  --noexecution_log_sort
+  --kept-base-action-graph-flag
+)
+build_pre_config_flags=(
+  "--execution_log_compact_file=$expected_execution_log_path"
+  "--execution_log_json_file=$expected_execution_log_path"
+  "--execution_log_binary_file=$expected_execution_log_path"
+  --noexecution_log_sort
+  --kept-action-graph-flag
+)
+eval "$proxy_action_graph_filter_block"
+[[ "${#action_graph_pre_config_flags[@]}" == 2 ]]
+[[ "${action_graph_pre_config_flags[0]}" == "--kept-base-action-graph-flag" ]]
+[[ "${action_graph_pre_config_flags[1]}" == "--kept-action-graph-flag" ]]
+
+proxy_action_graph_flags_block="$(sed -n '/  action_graph_flags=(/,/^  readonly action_graph_flags$/p' "$adapter_source")"
 readonly proxy_action_graph_flags_block
 (
   set -u
-  base_pre_config_flags=(--base-flag)
-  action_graph_pre_config_flags=()
+  action_graph_pre_config_flags=(--base-flag)
   toolchain=
   eval "$proxy_action_graph_flags_block"
   [[ "${action_graph_flags[*]}" == "--base-flag" ]]
 )
 (
   set -u
-  base_pre_config_flags=(--base-flag)
-  action_graph_pre_config_flags=(--configured-flag)
+  action_graph_pre_config_flags=(--base-flag --configured-flag)
   toolchain=com.example.toolchain
   eval "$proxy_action_graph_flags_block"
   [[ "${action_graph_flags[*]}" == "--base-flag --configured-flag --action_env=TOOLCHAINS=com.example.toolchain" ]]

--- a/xcodeproj/internal/templates/bazel_build.sh
+++ b/xcodeproj/internal/templates/bazel_build.sh
@@ -195,7 +195,9 @@ if [[ -n "${SWIFTBUILD_BAZEL_PROXY_INVOCATION_RECEIPT:-}" ]]; then
   for option in "${base_pre_config_flags[@]}" "${build_pre_config_flags[@]}"; do
     if [[
       "$option" != --build_event_json_file=* &&
+      "$option" != --execution_log_compact_file=* &&
       "$option" != --execution_log_json_file=* &&
+      "$option" != --execution_log_binary_file=* &&
       "$option" != --noexecution_log_sort
     ]]; then
       receipt_args+=("--command-option=$option")

--- a/xcodeproj/internal/templates/generate_bazel_dependencies.sh
+++ b/xcodeproj/internal/templates/generate_bazel_dependencies.sh
@@ -164,7 +164,9 @@ fi
 # to the build itself; the follow-up aquery is configuration evidence and must not replace it.
 if [[ -n "${SWIFTBUILD_BAZEL_PROXY_EXECUTION_LOG_PATH:-}" ]]; then
   build_pre_config_flags+=(
+    "--execution_log_binary_file="
     "--execution_log_compact_file=$SWIFTBUILD_BAZEL_PROXY_EXECUTION_LOG_PATH"
+    "--execution_log_json_file="
   )
 fi
 
@@ -271,6 +273,9 @@ if [[ -n "${SWIFTBUILD_BAZEL_PROXY_ACTION_GRAPH_PATH:-}" ]]; then
   "${bazel_cmd[@]}" aquery \
     "${action_graph_flags[@]}" \
     "--config=$config" \
+    --execution_log_binary_file= \
+    --execution_log_compact_file= \
+    --execution_log_json_file= \
     "$output_groups_flag" \
     --color=no \
     --output=jsonproto \

--- a/xcodeproj/internal/templates/generate_bazel_dependencies.sh
+++ b/xcodeproj/internal/templates/generate_bazel_dependencies.sh
@@ -164,8 +164,7 @@ fi
 # to the build itself; the follow-up aquery is configuration evidence and must not replace it.
 if [[ -n "${SWIFTBUILD_BAZEL_PROXY_EXECUTION_LOG_PATH:-}" ]]; then
   build_pre_config_flags+=(
-    "--execution_log_json_file=$SWIFTBUILD_BAZEL_PROXY_EXECUTION_LOG_PATH"
-    "--noexecution_log_sort"
+    "--execution_log_compact_file=$SWIFTBUILD_BAZEL_PROXY_EXECUTION_LOG_PATH"
   )
 fi
 
@@ -249,23 +248,20 @@ fi
 # in a fresh output base and omit the requested transitioned product.
 if [[ -n "${SWIFTBUILD_BAZEL_PROXY_ACTION_GRAPH_PATH:-}" ]]; then
   action_graph_pre_config_flags=()
-  for option in "${build_pre_config_flags[@]}"; do
+  for option in "${base_pre_config_flags[@]}" "${build_pre_config_flags[@]}"; do
     if [[
       "$option" != --build_event_publish_all_actions &&
       "$option" != --build_event_json_file=* &&
+      "$option" != --execution_log_compact_file=* &&
       "$option" != --execution_log_json_file=* &&
+      "$option" != --execution_log_binary_file=* &&
       "$option" != --noexecution_log_sort
     ]]; then
       action_graph_pre_config_flags+=("$option")
     fi
   done
   action_graph_query="deps(%generator_label%)"
-  # Collect optional arrays before expansion. macOS Bash 3.2 treats "${empty[@]}" as unbound
-  # under `set -u`, even when the array was explicitly initialized.
-  action_graph_flags=("${base_pre_config_flags[@]}")
-  if ((${#action_graph_pre_config_flags[@]})); then
-    action_graph_flags+=("${action_graph_pre_config_flags[@]}")
-  fi
+  action_graph_flags=("${action_graph_pre_config_flags[@]}")
   if [[ -n "${toolchain:-}" ]]; then
     action_graph_flags+=("--action_env=TOOLCHAINS=$toolchain")
   fi


### PR DESCRIPTION
# Summary

- Capture Bazel's compact execution log for proxy-owned builds instead of the larger JSON execution stream.
- Keep metadata capture opt-in through the existing per-operation private path.
- Neutralize JSON and binary execution-log settings inherited from user, common, and configuration bazelrc sections so the proxy-owned compact path wins deterministically.
- Keep the metadata-only `aquery` from creating or overwriting any execution log, and filter current and legacy execution-log plumbing from the publishable invocation receipt.
- Preserve mode-0600 evidence handling and fail closed when the expected artifact is absent.

# Stack

- Depends on [#3327](https://github.com/MobileNativeFoundation/rules_xcodeproj/pull/3327).
- Companion decoder: [karim-alweheshy/XCBBuildServiceProxyKit#9](https://github.com/karim-alweheshy/XCBBuildServiceProxyKit/pull/9).
- Part of [#1953](https://github.com/MobileNativeFoundation/rules_xcodeproj/issues/1953).

# Validation

- Focused launcher test passes normally and with `--ignore_all_rc_files`.
- Bash syntax, scoped ShellCheck, Buildifier, `git diff --check`, and secret scanning pass.
- A real Bazel 9.2.0 temporary-bazelrc negative control reproduced the multiple execution-log-format error when `common --execution_log_json_file` and `build --execution_log_binary_file` met the proxy compact flag.
- The candidate build passed with explicit JSON/binary clears, produced only the private compact artifact, and did not create either user-specified artifact. The same aquery failed without clears and passed with all three formats explicitly cleared after the named config.
- A same-target smoke test with a path containing spaces produced a mode-0600 zstd compact artifact. Tiny-target observation: compact artifact 0.5 KB versus JSON control 1.8 KB. This is not a production performance claim.
- Xcode 26.5 live acceptance passed with the exact companion proxy binary: the selected report showed 18 Bazel actions—4 executed, 3 completed with unavailable cache status, and 11 up to date—with native-style Compile, Archive, Link, and Assemble rows.

# Review notes

- Only the actual build receives a nonempty `--execution_log_compact_file`; its command-line JSON/binary clears override inherited bazelrc values.
- The follow-up configured-action query filters metadata flags from replayed arrays and passes empty compact, JSON, and binary options after `--config`, so direct bazelrc settings cannot leak into the query.
- Production-scale latency/CPU/RSS remains an explicit release gate. Live Xcode functional acceptance is complete for this slice.

