### PR TITLE
Support nested project paths in proxy manifests

### DIFF
--- a/test/internal/build_proxy_manifest/build_proxy_manifest_tests.py
+++ b/test/internal/build_proxy_manifest/build_proxy_manifest_tests.py
@@ -170,16 +170,41 @@ class BuildProxyManifestTests(unittest.TestCase):
                 project_container="App.xcodeproj",
             )
 
-    def test_project_container_must_be_a_xcodeproj_basename(self):
+    def test_nested_project_container_records_the_xcodeproj_basename(self):
+        contents = build_proxy_manifest_lib.assemble(
+            [],
+            bazel_path="bazel",
+            generator_label="@@//app:project",
+            project_container="App/App.xcodeproj",
+        )
+
+        self.assertEqual(
+            json.loads(contents)["project"]["containerName"],
+            "App.xcodeproj",
+        )
+
+    def test_project_container_traversal_is_rejected(self):
         with self.assertRaisesRegex(
             build_proxy_manifest_lib.ManifestError,
-            "project container must be a basename",
+            "project container must not contain traversal",
         ):
             build_proxy_manifest_lib.assemble(
                 [],
                 bazel_path="bazel",
                 generator_label="@@//app:project",
                 project_container="../App.xcodeproj",
+            )
+
+    def test_absolute_project_container_is_rejected(self):
+        with self.assertRaisesRegex(
+            build_proxy_manifest_lib.ManifestError,
+            "project container must be a relative path",
+        ):
+            build_proxy_manifest_lib.assemble(
+                [],
+                bazel_path="bazel",
+                generator_label="@@//app:project",
+                project_container="/tmp/App.xcodeproj",
             )
 
 

--- a/xcodeproj/internal/build_proxy_manifest.bzl
+++ b/xcodeproj/internal/build_proxy_manifest.bzl
@@ -17,7 +17,8 @@ def write_build_proxy_manifest(
         entries_files: JSON Lines manifest fragments from target shards.
         generator_label: The `xcodeproj` generator label the proxy must build.
         name: The generator target name.
-        project_container: Basename of the generated `.xcodeproj` bundle.
+        project_container: Workspace-relative path of the generated
+            `.xcodeproj` bundle. The manifest records its basename.
         tool: The executable that validates and assembles the manifest.
 
     Returns:

--- a/xcodeproj/internal/build_proxy_manifest_lib.py
+++ b/xcodeproj/internal/build_proxy_manifest_lib.py
@@ -163,9 +163,13 @@ def assemble(
         raise ManifestError("generator label must not be empty")
     if not bazel_path:
         raise ManifestError("Bazel path must not be empty")
-    if not project_container or Path(project_container).name != project_container:
-        raise ManifestError("project container must be a basename")
-    if not project_container.endswith(".xcodeproj"):
+    project_container_path = Path(project_container)
+    if not project_container or project_container_path.is_absolute():
+        raise ManifestError("project container must be a relative path")
+    if ".." in project_container_path.parts:
+        raise ManifestError("project container must not contain traversal")
+    project_container_name = project_container_path.name
+    if not project_container_name.endswith(".xcodeproj"):
         raise ManifestError("project container must end in .xcodeproj")
 
     entries = []
@@ -203,7 +207,7 @@ def assemble(
             "receiptSchemaVersion": RECEIPT_SCHEMA_VERSION,
         },
         "project": {
-            "containerName": project_container,
+            "containerName": project_container_name,
             "identity": generator_label,
         },
         "schemaVersion": SCHEMA_VERSION,


### PR DESCRIPTION
## Summary

- accept safe workspace-relative project install paths when assembling schema-v2 build-proxy manifests
- record the `.xcodeproj` basename expected by the proxy and Xcode build request
- continue rejecting absolute paths, traversal, and non-`.xcodeproj` containers

This unblocks generated projects installed below a package directory, such as `RedditApp/RedditApp.xcodeproj`.

## Stack

This draft is based on `build-proxy-reddit-consumer-base`, a temporary composed base containing the existing build-proxy rules stack. The review diff is the single nested-project-path commit.

## Validation

- `bazel --ignore_all_rc_files test //:buildifier.check //test/internal/build_proxy_manifest:build_proxy_manifest_tests --cache_test_results=no --test_output=errors`
- generated `//RedditApp:RedditApp_xcodeproj` against Reddit iOS with Bazel 9.1.1rc1 and Xcode 26.5
- audited the installed schema-v2 manifest: 5,744 mappings, `containerName` equal to `RedditApp.xcodeproj`
- verified installed proxy and manifest SHA-256 sidecars and the generated launcher preflight

## Testing

No additional manual QA is required for this path-normalization slice. Live Reddit Xcode build verification is tracked separately from this project-generation fix.
