### PR TITLE
Limit proxy BEP named set events

### DIFF
--- a/test/internal/build_proxy_launcher/build_proxy_launcher_tests.sh
+++ b/test/internal/build_proxy_launcher/build_proxy_launcher_tests.sh
@@ -63,6 +63,7 @@ readonly proxy_bep_block
 expected_bep_flag="--build_event_json_file=\$SWIFTBUILD_BAZEL_PROXY_BEP_PATH"
 readonly expected_bep_flag
 [[ "$(grep -Fc -- "$expected_bep_flag" <<< "$proxy_bep_block")" == 1 ]]
+[[ "$(grep -Fc -- '--build_event_max_named_set_of_file_entries=256' <<< "$proxy_bep_block")" == 1 ]]
 
 proxy_execution_log_flags_block="$(sed -n '/# The build service gives every operation/,/^fi$/p' "$adapter_source")"
 readonly proxy_execution_log_flags_block
@@ -108,6 +109,8 @@ readonly proxy_receipt_command_options_block
 [[ "$(grep -Fc -- '"$option" != --execution_log_binary_file=*' <<< "$proxy_receipt_command_options_block")" == 1 ]]
 # shellcheck disable=SC2016
 [[ "$(grep -Fc -- '"$option" != --noexecution_log_sort' <<< "$proxy_receipt_command_options_block")" == 1 ]]
+# shellcheck disable=SC2016
+[[ "$(grep -Fc -- '"$option" != --build_event_max_named_set_of_file_entries=*' <<< "$proxy_receipt_command_options_block")" == 1 ]]
 # The extracted source fragment consumes this array through `eval` below.
 # shellcheck disable=SC2034
 base_pre_config_flags=(--base-build-flag)
@@ -116,6 +119,7 @@ build_pre_config_flags=(
   "--execution_log_json_file=$expected_execution_log_path"
   "--execution_log_binary_file=$expected_execution_log_path"
   --noexecution_log_sort
+  --build_event_max_named_set_of_file_entries=256
   --kept-build-flag
 )
 receipt_args=()
@@ -199,6 +203,8 @@ done
 [[ "$(grep -Fc -- 'action_graph_query="deps(${labels[0]})"' <<< "$proxy_action_graph_block")" == 0 ]]
 # shellcheck disable=SC2016
 [[ "$(grep -Fc -- '"$option" != --build_event_json_file=*' <<< "$proxy_action_graph_block")" == 1 ]]
+# shellcheck disable=SC2016
+[[ "$(grep -Fc -- '"$option" != --build_event_max_named_set_of_file_entries=*' <<< "$proxy_action_graph_block")" == 1 ]]
 # shellcheck disable=SC2016
 [[ "$(grep -Fc -- '"$option" != --execution_log_compact_file=*' <<< "$proxy_action_graph_block")" == 1 ]]
 # shellcheck disable=SC2016

--- a/xcodeproj/internal/templates/bazel_build.sh
+++ b/xcodeproj/internal/templates/bazel_build.sh
@@ -195,6 +195,7 @@ if [[ -n "${SWIFTBUILD_BAZEL_PROXY_INVOCATION_RECEIPT:-}" ]]; then
   for option in "${base_pre_config_flags[@]}" "${build_pre_config_flags[@]}"; do
     if [[
       "$option" != --build_event_json_file=* &&
+      "$option" != --build_event_max_named_set_of_file_entries=* &&
       "$option" != --execution_log_compact_file=* &&
       "$option" != --execution_log_json_file=* &&
       "$option" != --execution_log_binary_file=* &&

--- a/xcodeproj/internal/templates/generate_bazel_dependencies.sh
+++ b/xcodeproj/internal/templates/generate_bazel_dependencies.sh
@@ -158,6 +158,7 @@ if [[ -n "${SWIFTBUILD_BAZEL_PROXY_BEP_PATH:-}" ]]; then
   build_pre_config_flags+=(
     "--build_event_publish_all_actions"
     "--build_event_json_file=$SWIFTBUILD_BAZEL_PROXY_BEP_PATH"
+    "--build_event_max_named_set_of_file_entries=256"
   )
 fi
 # The build service gives every operation its own private path. Keep execution metadata attached
@@ -254,6 +255,7 @@ if [[ -n "${SWIFTBUILD_BAZEL_PROXY_ACTION_GRAPH_PATH:-}" ]]; then
     if [[
       "$option" != --build_event_publish_all_actions &&
       "$option" != --build_event_json_file=* &&
+      "$option" != --build_event_max_named_set_of_file_entries=* &&
       "$option" != --execution_log_compact_file=* &&
       "$option" != --execution_log_json_file=* &&
       "$option" != --execution_log_binary_file=* &&


### PR DESCRIPTION
# Summary

- Split large BEP named sets at 256 file entries for proxy-enabled builds.
- Filter the transport-only option from aquery replay and publishable invocation receipts.

# Stack

- Depends on #3332.
- Pairs with XCBBuildServiceProxyKit fork PR #12.

# Validation

- Focused launcher test passed uncached on Bazel 9.2.0.
- Bash syntax, scoped ShellCheck, Buildifier, and diff checks passed.
- RedditApp final BEP was 3.4 MB with a maximum line size of 151.2 KB; Xcode build succeeded.

# Testing

Run `bazel --ignore_all_rc_files test //test/internal/build_proxy_launcher:build_proxy_launcher_tests`.