### PR TITLE
Declare generated Bazel environment keys

### DIFF
--- a/test/internal/build_proxy_manifest/BUILD
+++ b/test/internal/build_proxy_manifest/BUILD
@@ -3,5 +3,8 @@ load("@rules_python//python:defs.bzl", "py_test")
 py_test(
     name = "build_proxy_manifest_tests",
     srcs = ["build_proxy_manifest_tests.py"],
-    deps = ["//xcodeproj/internal:build_proxy_manifest_lib"],
+    deps = [
+        "//xcodeproj/internal:build_proxy_manifest",
+        "//xcodeproj/internal:build_proxy_manifest_lib",
+    ],
 )

--- a/test/internal/build_proxy_manifest/build_proxy_manifest_tests.py
+++ b/test/internal/build_proxy_manifest/build_proxy_manifest_tests.py
@@ -1,6 +1,9 @@
 import json
+import tempfile
 import unittest
+from pathlib import Path
 
+from xcodeproj.internal import build_proxy_manifest
 from xcodeproj.internal import build_proxy_manifest_lib
 
 
@@ -39,6 +42,31 @@ def _line(entry):
 
 
 class BuildProxyManifestTests(unittest.TestCase):
+    def test_cli_accepts_environment_options_before_manifest_fragments(self):
+        with tempfile.TemporaryDirectory() as temp_directory:
+            root = Path(temp_directory)
+            output = root / "manifest.json"
+            fragment = root / "fragment.jsonl"
+            fragment.write_text(_line(_entry()) + "\n")
+
+            build_proxy_manifest.main(
+                [
+                    str(output),
+                    "@@//app:project",
+                    "/usr/local/bin/bazel",
+                    "App.xcodeproj",
+                    "--bazel-environment-key=CUSTOM_ENV",
+                    str(fragment),
+                ]
+            )
+
+            manifest = json.loads(output.read_text())
+            self.assertEqual(
+                manifest["invocation"]["bazelEnvironmentKeys"],
+                ["CUSTOM_ENV"],
+            )
+            self.assertEqual(len(manifest["targets"]), 1)
+
     def test_assemble_is_versioned_and_byte_deterministic(self):
         debug = _line(_entry())
         release = _line(_entry(configuration="Release"))

--- a/test/internal/build_proxy_manifest/build_proxy_manifest_tests.py
+++ b/test/internal/build_proxy_manifest/build_proxy_manifest_tests.py
@@ -46,12 +46,14 @@ class BuildProxyManifestTests(unittest.TestCase):
         forward = build_proxy_manifest_lib.assemble(
             [("a", 1, release), ("b", 1, debug)],
             bazel_path="/usr/local/bin/bazel",
+            bazel_environment_keys=["Z_CUSTOM", "CUSTOM_ENV"],
             generator_label="@@//app:project",
             project_container="App.xcodeproj",
         )
         reverse = build_proxy_manifest_lib.assemble(
             [("b", 1, debug), ("a", 1, release)],
             bazel_path="/usr/local/bin/bazel",
+            bazel_environment_keys=["CUSTOM_ENV", "Z_CUSTOM"],
             generator_label="@@//app:project",
             project_container="App.xcodeproj",
         )
@@ -73,6 +75,7 @@ class BuildProxyManifestTests(unittest.TestCase):
                 "adapterPath": "rules_xcodeproj/bazel/generate_bazel_dependencies.sh",
                 "bazelPath": "/usr/local/bin/bazel",
                 "bazelrcPath": "rules_xcodeproj/bazel/xcodeproj.bazelrc",
+                "bazelEnvironmentKeys": ["CUSTOM_ENV", "Z_CUSTOM"],
                 "environmentKeys": build_proxy_manifest_lib.INVOCATION_ENVIRONMENT_KEYS,
                 "generatorLabel": "@@//app:project",
                 "receiptSchemaVersion": 1,
@@ -86,6 +89,19 @@ class BuildProxyManifestTests(unittest.TestCase):
             [entry["configuration"] for entry in manifest["targets"]],
             ["Debug", "Release"],
         )
+
+    def test_sensitive_bazel_environment_key_is_rejected(self):
+        with self.assertRaisesRegex(
+            build_proxy_manifest_lib.ManifestError,
+            "sensitive Bazel environment key",
+        ):
+            build_proxy_manifest_lib.assemble(
+                [],
+                bazel_path="bazel",
+                bazel_environment_keys=["PRIVATE_TOKEN"],
+                generator_label="@@//app:project",
+                project_container="App.xcodeproj",
+            )
 
     def test_missing_required_key_is_rejected(self):
         entry = _entry()

--- a/xcodeproj/internal/build_proxy_manifest.bzl
+++ b/xcodeproj/internal/build_proxy_manifest.bzl
@@ -3,6 +3,7 @@
 def write_build_proxy_manifest(
         *,
         actions,
+        bazel_environment_keys,
         bazel_path,
         entries_files,
         generator_label,
@@ -13,6 +14,7 @@ def write_build_proxy_manifest(
 
     Args:
         actions: `ctx.actions`.
+        bazel_environment_keys: Names supplied by the generated Bazel environment.
         bazel_path: The Bazel executable path recorded for proxy invocation.
         entries_files: JSON Lines manifest fragments from target shards.
         generator_label: The `xcodeproj` generator label the proxy must build.
@@ -33,6 +35,8 @@ def write_build_proxy_manifest(
     args.add(str(generator_label))
     args.add(bazel_path)
     args.add(project_container)
+    for key in bazel_environment_keys:
+        args.add("--bazel-environment-key={}".format(key))
     args.add_all(entries_files)
 
     actions.run(

--- a/xcodeproj/internal/build_proxy_manifest.py
+++ b/xcodeproj/internal/build_proxy_manifest.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from xcodeproj.internal import build_proxy_manifest_lib
 
 
-def main() -> None:
+def main(argv=None) -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("output", type=Path)
     parser.add_argument("generator_label")
@@ -15,7 +15,7 @@ def main() -> None:
     parser.add_argument("project_container")
     parser.add_argument("--bazel-environment-key", action="append", default=[])
     parser.add_argument("fragments", nargs="*", type=Path)
-    args = parser.parse_args()
+    args = parser.parse_intermixed_args(argv)
     build_proxy_manifest_lib.write(
         args.output,
         args.fragments,

--- a/xcodeproj/internal/build_proxy_manifest.py
+++ b/xcodeproj/internal/build_proxy_manifest.py
@@ -13,12 +13,14 @@ def main() -> None:
     parser.add_argument("generator_label")
     parser.add_argument("bazel_path")
     parser.add_argument("project_container")
+    parser.add_argument("--bazel-environment-key", action="append", default=[])
     parser.add_argument("fragments", nargs="*", type=Path)
     args = parser.parse_args()
     build_proxy_manifest_lib.write(
         args.output,
         args.fragments,
         bazel_path=args.bazel_path,
+        bazel_environment_keys=args.bazel_environment_key,
         generator_label=args.generator_label,
         project_container=args.project_container,
     )

--- a/xcodeproj/internal/build_proxy_manifest_lib.py
+++ b/xcodeproj/internal/build_proxy_manifest_lib.py
@@ -1,6 +1,7 @@
 """Deterministically assembles version 2 build-proxy manifest fragments."""
 
 import json
+import re
 from pathlib import Path
 from typing import Iterable, Mapping, Sequence
 
@@ -155,6 +156,7 @@ def assemble(
     fragment_lines: Iterable[tuple[str, int, str]],
     *,
     bazel_path: str,
+    bazel_environment_keys: Sequence[str] = (),
     generator_label: str,
     project_container: str,
 ) -> bytes:
@@ -163,6 +165,25 @@ def assemble(
         raise ManifestError("generator label must not be empty")
     if not bazel_path:
         raise ManifestError("Bazel path must not be empty")
+    normalized_bazel_environment_keys = sorted(set(bazel_environment_keys))
+    for key in normalized_bazel_environment_keys:
+        if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", key):
+            raise ManifestError(f"invalid Bazel environment key: {key!r}")
+        normalized_key = key.upper().replace("-", "_")
+        if any(
+            marker in normalized_key
+            for marker in (
+                "TOKEN",
+                "PASSWORD",
+                "SECRET",
+                "CREDENTIAL",
+                "API_KEY",
+                "AUTHORIZATION",
+                "COOKIE",
+                "HEADER",
+            )
+        ):
+            raise ManifestError(f"sensitive Bazel environment key: {key!r}")
     project_container_path = Path(project_container)
     if not project_container or project_container_path.is_absolute():
         raise ManifestError("project container must be a relative path")
@@ -202,6 +223,7 @@ def assemble(
             "adapterPath": ADAPTER_PATH,
             "bazelPath": bazel_path,
             "bazelrcPath": BAZELRC_PATH,
+            "bazelEnvironmentKeys": normalized_bazel_environment_keys,
             "environmentKeys": INVOCATION_ENVIRONMENT_KEYS,
             "generatorLabel": generator_label,
             "receiptSchemaVersion": RECEIPT_SCHEMA_VERSION,
@@ -228,6 +250,7 @@ def assemble_files(
     paths: Sequence[Path],
     *,
     bazel_path: str,
+    bazel_environment_keys: Sequence[str] = (),
     generator_label: str,
     project_container: str,
 ) -> bytes:
@@ -241,6 +264,7 @@ def assemble_files(
     return assemble(
         lines,
         bazel_path=bazel_path,
+        bazel_environment_keys=bazel_environment_keys,
         generator_label=generator_label,
         project_container=project_container,
     )
@@ -251,6 +275,7 @@ def write(
     fragments: Sequence[Path],
     *,
     bazel_path: str,
+    bazel_environment_keys: Sequence[str] = (),
     generator_label: str,
     project_container: str,
 ) -> None:
@@ -258,6 +283,7 @@ def write(
         assemble_files(
             fragments,
             bazel_path=bazel_path,
+            bazel_environment_keys=bazel_environment_keys,
             generator_label=generator_label,
             project_container=project_container,
         )

--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -316,6 +316,7 @@ def _write_installer(
 def _write_project_contents(
         *,
         actions,
+        bazel_environment_keys,
         bazel_path,
         bin_dir_path,
         build_proxy_manifest_generator,
@@ -426,6 +427,7 @@ def _write_project_contents(
 
     build_proxy_manifest = write_build_proxy_manifest(
         actions = actions,
+        bazel_environment_keys = bazel_environment_keys,
         bazel_path = bazel_path,
         entries_files = build_proxy_manifest_entries_files,
         generator_label = generator_label,
@@ -663,6 +665,7 @@ Are you using an `alias`? `xcodeproj.focused_targets` and \
         target_ids_list,
     ) = _write_project_contents(
         actions = actions,
+        bazel_environment_keys = sorted(ctx.attr.bazel_env.keys()),
         bazel_path = ctx.attr.bazel_path,
         bin_dir_path = ctx.bin_dir.path,
         build_proxy_manifest_generator = (


### PR DESCRIPTION
# Summary

- Publish the names of generated Bazel environment entries in the proxy manifest.
- Sort and validate names deterministically.
- Reject invalid and credential-shaped names; no environment values are published.

# Stack

- Depends on the bounded BEP PR.
- Pairs with XCBBuildServiceProxyKit fork PR #14.

# Validation

- Manifest unit test passed uncached.
- Buildifier and diff checks passed.
- RedditApp manifest declares its custom Bazel environment names, the receipt validates, and Xcode reports Build succeeded.

# Testing

Run `bazel --ignore_all_rc_files test //test/internal/build_proxy_manifest:build_proxy_manifest_tests`.

## Follow-up validation

- Reproduced the integration failure as an argparse positional/option intermixing bug.
- Added a CLI regression with an environment option before a real manifest fragment.
- Bazel 8.7 and 9.2 focused tests pass uncached.
- The exact examples/integration project-generation command succeeds locally after changing only the repository’s Xcode 26.1.1 transition to the installed Xcode 26.5 as a local test control; that transition change is not committed.
- The subsequent //... build reached platform compilation and stopped only because this host has no tvOS Simulator runtime; this is independent of the manifest action.
