### PR TITLE
Expose Bazel action starts to build proxies

### DIFF
--- a/test/internal/build_proxy_launcher/build_proxy_launcher_tests.sh
+++ b/test/internal/build_proxy_launcher/build_proxy_launcher_tests.sh
@@ -150,6 +150,13 @@ eval "$proxy_receipt_command_options_block"
 [[ "${receipt_args[0]}" == "--command-option=--base-build-flag" ]]
 [[ "${receipt_args[1]}" == "--command-option=--kept-build-flag" ]]
 
+# The action-start signal is proxy-only, comes after the named config so it cannot be disabled by
+# a bazelrc, and remains private orchestration rather than a semantic invocation-receipt option.
+proxy_action_start_flags_block="$(sed -n '/SWIFTBUILD_BAZEL_PROXY_ACTION_STARTS_PATH:-/,/^fi$/p' "$bazel_build_source")"
+readonly proxy_action_start_flags_block
+[[ "$(grep -Fc -- 'build_log_cmd+=(--subcommands=pretty_print)' <<< "$proxy_action_start_flags_block")" == 1 ]]
+[[ "$(grep -Fc -- 'receipt_args+=' <<< "$proxy_action_start_flags_block")" == 0 ]]
+
 # A proxied adapter is already the inner Xcode invocation. Preserve the generated hermetic Bazel
 # executable (or an explicitly inherited one), and tell workspace wrappers not to regenerate their
 # outer rules release inside Xcode's restricted PATH.
@@ -237,6 +244,9 @@ done
 [[ "$(grep -Fc -- '"$option" != --execution_log_binary_file=*' <<< "$proxy_action_graph_block")" == 1 ]]
 # shellcheck disable=SC2016
 [[ "$(grep -Fc -- '"$option" != --noexecution_log_sort' <<< "$proxy_action_graph_block")" == 1 ]]
+# The metadata-only aquery comes after the build and must not inherit command-printing from a
+# common/build/config bazelrc or duplicate action-start events.
+[[ "$(grep -Fxc -- '    --subcommands=false \' <<< "$proxy_action_graph_block")" == 1 ]]
 # Command-line clears come after the named config, so execution-log settings inherited directly
 # from common/build/config bazelrc sections cannot leak into the metadata-only aquery.
 for cleared_execution_log_flag in \

--- a/xcodeproj/internal/bazel_integration_files/process_bazel_build_log.py
+++ b/xcodeproj/internal/bazel_integration_files/process_bazel_build_log.py
@@ -1,11 +1,14 @@
 #!/usr/bin/python3
 
+import json
 import os
 import re
 import signal
+import stat
 import subprocess
 import sys
 import threading
+import time
 from typing import List, Optional
 
 
@@ -20,6 +23,105 @@ RELATIVE_DIAGNOSTICS_RE = re.compile(
     """,
     re.VERBOSE,
 )
+SUBCOMMAND_HEADER_RE = re.compile(
+    r"^SUBCOMMAND: # .* target (?P<label>\S+) "
+    r"\[action '(?P<description>.*)', configuration: (?P<configuration>[^,\]]+), "
+    r"execution platform: (?P<execution_platform>[^,\]]+), "
+    r"mnemonic: (?P<mnemonic>[^\]]+)\]$"
+)
+ACTION_START_STREAM_LEAF = "action-starts.jsonl"
+MAXIMUM_ACTION_START_FIELD_BYTES = 16 * 1024
+MAXIMUM_SUBCOMMAND_BLOCK_BYTES = 16 * 1024 * 1024
+
+
+class _ActionStartStream:
+    def __init__(self, path: str):
+        if not os.path.isabs(path) or os.path.basename(path) != ACTION_START_STREAM_LEAF:
+            raise ValueError("action-start stream path is unsafe")
+        parent = os.path.dirname(path)
+        parent_fd = os.open(parent, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+        try:
+            descriptor = os.open(
+                ACTION_START_STREAM_LEAF,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_CLOEXEC | os.O_NOFOLLOW,
+                0o600,
+                dir_fd=parent_fd,
+            )
+        finally:
+            os.close(parent_fd)
+        file_status = os.fstat(descriptor)
+        if not stat.S_ISREG(file_status.st_mode) or file_status.st_nlink != 1:
+            os.close(descriptor)
+            raise ValueError("action-start stream is not a private regular file")
+        os.fchmod(descriptor, 0o600)
+        self._file = os.fdopen(descriptor, "w", encoding="utf-8", buffering=1)
+        self._sequence = 0
+        self._inside_subcommand = False
+        self._subcommand_bytes = 0
+        self.failed = False
+
+    def close(self) -> None:
+        self._file.close()
+
+    def finish(self) -> None:
+        if self._inside_subcommand:
+            self.failed = True
+
+    def consume(self, line: str) -> bool:
+        """Returns True when a private subcommand line must not reach Xcode."""
+        line_bytes = len(line.encode("utf-8", errors="replace"))
+        if self._inside_subcommand:
+            self._subcommand_bytes += line_bytes
+            if self._subcommand_bytes > MAXIMUM_SUBCOMMAND_BLOCK_BYTES:
+                self.failed = True
+            if line.startswith("SUBCOMMAND:"):
+                # A new header before Bazel's runner trailer means the previous block was not
+                # framed as expected. Keep suppressing bytes and recover only to observe starts.
+                self.failed = True
+                self._begin(line)
+            elif line.startswith("# Runner: "):
+                self._inside_subcommand = False
+                self._subcommand_bytes = 0
+            return True
+
+        if line.startswith("SUBCOMMAND:"):
+            self._begin(line)
+            return True
+        return False
+
+    def _begin(self, line: str) -> None:
+        self._inside_subcommand = True
+        self._subcommand_bytes = len(line.encode("utf-8", errors="replace"))
+        match = SUBCOMMAND_HEADER_RE.fullmatch(line)
+        if not match:
+            self.failed = True
+            return
+        fields = {name: match.group(name).strip() for name in match.groupdict()}
+        if any(not self._is_safe_field(value) for value in fields.values()):
+            self.failed = True
+            return
+        self._sequence += 1
+        record = {
+            "configuration": fields["configuration"],
+            "description": fields["description"],
+            "executionPlatform": fields["execution_platform"],
+            "label": fields["label"],
+            "mnemonic": fields["mnemonic"],
+            "observedTimeUnixMicroseconds": time.time_ns() // 1_000,
+            "schemaVersion": 1,
+            "sequence": self._sequence,
+        }
+        json.dump(record, self._file, ensure_ascii=False, separators=(",", ":"))
+        self._file.write("\n")
+        self._file.flush()
+
+    @staticmethod
+    def _is_safe_field(value: str) -> bool:
+        return (
+            bool(value)
+            and len(value.encode("utf-8")) <= MAXIMUM_ACTION_START_FIELD_BYTES
+            and all(ord(character) >= 0x20 and ord(character) != 0x7F for character in value)
+        )
 
 
 def _uppercase_first_letter(s: str) -> str:
@@ -29,6 +131,13 @@ def _uppercase_first_letter(s: str) -> str:
 def _main(command: List[str]) -> None:
 
     proxy_mode = bool(os.getenv("SWIFTBUILD_BAZEL_PROXY_REQUEST_DIR"))
+    action_start_stream: Optional[_ActionStartStream] = None
+    action_start_stream_path = os.getenv("SWIFTBUILD_BAZEL_PROXY_ACTION_STARTS_PATH")
+    if action_start_stream_path:
+        try:
+            action_start_stream = _ActionStartStream(action_start_stream_path)
+        except (OSError, ValueError):
+            sys.exit("Bazel action-start stream could not be created safely")
     cancel_grace_seconds = float(
         os.getenv("SWIFTBUILD_BAZEL_PROXY_CANCEL_GRACE_SECONDS", "5.0")
     )
@@ -132,6 +241,11 @@ def _main(command: List[str]) -> None:
     def _process_log_line(line: str):
         input_line = line.rstrip()
 
+        if action_start_stream and action_start_stream.consume(
+            STRIP_COLOR_RE.sub("", input_line)
+        ):
+            return
+
         if should_strip_color:
             input_line = STRIP_COLOR_RE.sub("", input_line)
 
@@ -155,6 +269,10 @@ def _main(command: List[str]) -> None:
     if kill_timer is not None:
         kill_timer.cancel()
 
+    if action_start_stream:
+        action_start_stream.finish()
+        action_start_stream.close()
+
     # If the Bazel invocation failed and there was no formatted error found,
     # print a nicer error message instead of a cryptic in Xcode:
     # 'Command PhaseScriptExecution failed with a nonzero exit code'
@@ -162,7 +280,11 @@ def _main(command: List[str]) -> None:
         print("error: The bazel build failed, please check the report navigator, "
             "which may have more context about the failure.")
 
-    sys.exit(process.returncode)
+    if action_start_stream and action_start_stream.failed:
+        print("error: Bazel action-start metadata was malformed; private command details "
+            "were suppressed.")
+
+    sys.exit(process.returncode or (1 if action_start_stream and action_start_stream.failed else 0))
 
 
 if __name__ == "__main__":

--- a/xcodeproj/internal/bazel_integration_files/process_bazel_build_log_tests.py
+++ b/xcodeproj/internal/bazel_integration_files/process_bazel_build_log_tests.py
@@ -1,6 +1,8 @@
+import json
 import os
 from pathlib import Path
 import signal
+import stat
 import subprocess
 import sys
 import tempfile
@@ -9,6 +11,90 @@ import unittest
 
 
 class ProcessBazelBuildLogTests(unittest.TestCase):
+    def test_proxy_publishes_action_start_and_suppresses_private_command_block(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            action_starts = root / "action-starts.jsonl"
+            private_value = "private-action-value-must-not-reach-xcode"
+            helper = "\n".join(
+                [
+                    "import sys",
+                    "print('ordinary output before action', file=sys.stderr, flush=True)",
+                    "print(\"SUBCOMMAND: # swift_library rule target //app:App "
+                    "[action 'Compiling Swift module App', configuration: abc123, "
+                    "execution platform: @@platforms//host:host, mnemonic: SwiftCompile]\", "
+                    "file=sys.stderr, flush=True)",
+                    f"print('(exec env TOKEN={private_value})', file=sys.stderr, flush=True)",
+                    "print('# Configuration: abc123', file=sys.stderr, flush=True)",
+                    "print('# Execution platform: @@platforms//host:host', "
+                    "file=sys.stderr, flush=True)",
+                    "print('# Runner: darwin-sandbox', file=sys.stderr, flush=True)",
+                    "print('Sources/App.swift:12:3: warning: useful diagnostic', "
+                    "file=sys.stderr, flush=True)",
+                ]
+            )
+            result = self._run_wrapper(
+                root,
+                [sys.executable, "-c", helper],
+                action_starts=action_starts,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("ordinary output before action", result.stdout)
+            self.assertIn("warning: Useful diagnostic", result.stdout)
+            self.assertNotIn("SUBCOMMAND", result.stdout)
+            self.assertNotIn(private_value, result.stdout)
+            self.assertNotIn("# Runner:", result.stdout)
+            records = [json.loads(line) for line in action_starts.read_text().splitlines()]
+            self.assertEqual(len(records), 1)
+            self.assertEqual(records[0]["schemaVersion"], 1)
+            self.assertEqual(records[0]["sequence"], 1)
+            self.assertEqual(records[0]["label"], "//app:App")
+            self.assertEqual(records[0]["configuration"], "abc123")
+            self.assertEqual(records[0]["mnemonic"], "SwiftCompile")
+            self.assertEqual(records[0]["description"], "Compiling Swift module App")
+            self.assertGreater(records[0]["observedTimeUnixMicroseconds"], 0)
+            self.assertEqual(stat.S_IMODE(action_starts.stat().st_mode), 0o600)
+
+    def test_proxy_fails_closed_for_malformed_subcommand_header(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            action_starts = root / "action-starts.jsonl"
+            private_value = "malformed-private-action-value"
+            helper = "\n".join(
+                [
+                    "import sys",
+                    "print('SUBCOMMAND: malformed', file=sys.stderr, flush=True)",
+                    f"print('{private_value}', file=sys.stderr, flush=True)",
+                    "print('# Runner: local', file=sys.stderr, flush=True)",
+                ]
+            )
+            result = self._run_wrapper(
+                root,
+                [sys.executable, "-c", helper],
+                action_starts=action_starts,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertNotIn(private_value, result.stdout)
+            self.assertIn("private command details were suppressed", result.stdout)
+            self.assertEqual(action_starts.read_text(), "")
+
+    def test_proxy_rejects_preexisting_action_start_path(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            action_starts = root / "action-starts.jsonl"
+            action_starts.write_text("foreign")
+            result = self._run_wrapper(
+                root,
+                [sys.executable, "-c", "pass"],
+                action_starts=action_starts,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("could not be created safely", result.stderr)
+            self.assertEqual(action_starts.read_text(), "foreign")
+
     def test_proxy_cancellation_terminates_the_bazel_process_group(self):
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory)
@@ -95,6 +181,29 @@ class ProcessBazelBuildLogTests(unittest.TestCase):
             self.assertNotEqual(process.returncode, 0)
             with self.assertRaises(ProcessLookupError):
                 os.kill(child_pid, 0)
+
+    def _run_wrapper(self, root, command, action_starts=None):
+        environment = os.environ.copy()
+        environment.update(
+            {
+                "BAZEL_EXTERNAL": str(root / "external"),
+                "BAZEL_OUT": str(root / "bazel-out"),
+                "PROJECT_DIR": str(root),
+                "SRCROOT": str(root),
+                "SWIFTBUILD_BAZEL_PROXY_REQUEST_DIR": str(root / "request"),
+            }
+        )
+        if action_starts:
+            environment["SWIFTBUILD_BAZEL_PROXY_ACTION_STARTS_PATH"] = str(action_starts)
+        wrapper = Path(__file__).with_name("process_bazel_build_log.py")
+        return subprocess.run(
+            [sys.executable, str(wrapper), *command],
+            env=environment,
+            stderr=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            text=True,
+            timeout=5,
+        )
 
 
 if __name__ == "__main__":

--- a/xcodeproj/internal/templates/bazel_build.sh
+++ b/xcodeproj/internal/templates/bazel_build.sh
@@ -241,6 +241,13 @@ build_log_cmd=(
   --config="$config"
   --color=yes
 )
+if [[ -n "${SWIFTBUILD_BAZEL_PROXY_ACTION_STARTS_PATH:-}" ]]; then
+  # Bazel's structured build-event protocol reports actions only after they complete. In proxy
+  # mode, request its execution-start header as a private input to process_bazel_build_log.py.
+  # The processor suppresses the following environment/command block and publishes only a
+  # bounded, allowlisted JSON record to the per-operation path.
+  build_log_cmd+=(--subcommands=pretty_print)
+fi
 if [[ -n "${toolchain:-}" ]]; then
   build_log_cmd+=("--action_env=TOOLCHAINS=$toolchain")
 fi

--- a/xcodeproj/internal/templates/generate_bazel_dependencies.sh
+++ b/xcodeproj/internal/templates/generate_bazel_dependencies.sh
@@ -283,6 +283,7 @@ if [[ -n "${SWIFTBUILD_BAZEL_PROXY_ACTION_GRAPH_PATH:-}" ]]; then
     --execution_log_binary_file= \
     --execution_log_compact_file= \
     --execution_log_json_file= \
+    --subcommands=false \
     "$output_groups_flag" \
     --color=no \
     --output=jsonproto \


### PR DESCRIPTION
## Summary

- request Bazel's pretty-printed subcommand lifecycle only for build-proxy invocations
- consume each action-start header immediately while suppressing the entire environment and command block from Xcode output
- publish only bounded allowlisted action identity fields to a private mode-0600 JSONL stream
- fail closed on malformed, nested, oversized, unterminated, linked, or pre-existing stream state and disable inherited subcommand output for metadata-only aquery

## Stack

- Base: https://github.com/MobileNativeFoundation/rules_xcodeproj/pull/3335
- Paired proxy slice: https://github.com/karim-alweheshy/XCBBuildServiceProxyKit/pull/19

## Validation

- focused launcher and log-processor Bazel tests passed uncached with `--ignore_all_rc_files`
- direct Python suite: 5 tests, 0 failures
- `bash -n`, scoped ShellCheck, Buildifier, `git diff --check`, and TruffleHog passed
- real Bazel 9.2 reduced smoke observed the first start record while the wrapper remained alive; two sequential four-second actions produced two contiguous records at mode 0600 while command/environment bytes remained suppressed
- exact RedditApp project generation succeeded and embedded the paired release proxy and candidate adapter
- PID-bound Xcode 26.5 RedditApp build observed an individual link action in progress, then succeeded with real compile/link durations and no wrapper or errors

## Testing

Generate a project with a build proxy, change a source file, and build from Xcode. Confirm the generated adapter contains the proxy-only start option, individual Bazel actions appear before completion, and the publishable build log contains neither the raw `SUBCOMMAND:` header nor its environment/command/runner block. Generate without a proxy and confirm the option and sidecar are absent.
