### PR TITLE
Report live Bazel progress to build proxies

### DIFF
--- a/test/internal/build_proxy_launcher/build_proxy_launcher_tests.sh
+++ b/test/internal/build_proxy_launcher/build_proxy_launcher_tests.sh
@@ -64,6 +64,25 @@ expected_bep_flag="--build_event_json_file=\$SWIFTBUILD_BAZEL_PROXY_BEP_PATH"
 readonly expected_bep_flag
 [[ "$(grep -Fc -- "$expected_bep_flag" <<< "$proxy_bep_block")" == 1 ]]
 [[ "$(grep -Fc -- '--build_event_max_named_set_of_file_entries=256' <<< "$proxy_bep_block")" == 1 ]]
+[[ "$(grep -Fc -- '--progress_report_interval=1' <<< "$proxy_bep_block")" == 1 ]]
+
+# Live progress cadence is proxy-only and must not alter ordinary generated builds.
+build_pre_config_flags=(--existing-build-flag)
+unset SWIFTBUILD_BAZEL_PROXY_BEP_PATH
+eval "$proxy_bep_block"
+[[ "${#build_pre_config_flags[@]}" == 1 ]]
+[[ "${build_pre_config_flags[0]}" == "--existing-build-flag" ]]
+
+build_pre_config_flags=(--existing-build-flag)
+SWIFTBUILD_BAZEL_PROXY_BEP_PATH="$test_root/build event.jsonl"
+export SWIFTBUILD_BAZEL_PROXY_BEP_PATH
+eval "$proxy_bep_block"
+[[ "${#build_pre_config_flags[@]}" == 5 ]]
+[[ "${build_pre_config_flags[1]}" == "--build_event_publish_all_actions" ]]
+[[ "${build_pre_config_flags[2]}" == "--build_event_json_file=$SWIFTBUILD_BAZEL_PROXY_BEP_PATH" ]]
+[[ "${build_pre_config_flags[3]}" == "--build_event_max_named_set_of_file_entries=256" ]]
+[[ "${build_pre_config_flags[4]}" == "--progress_report_interval=1" ]]
+unset SWIFTBUILD_BAZEL_PROXY_BEP_PATH
 
 proxy_execution_log_flags_block="$(sed -n '/# The build service gives every operation/,/^fi$/p' "$adapter_source")"
 readonly proxy_execution_log_flags_block
@@ -111,6 +130,8 @@ readonly proxy_receipt_command_options_block
 [[ "$(grep -Fc -- '"$option" != --noexecution_log_sort' <<< "$proxy_receipt_command_options_block")" == 1 ]]
 # shellcheck disable=SC2016
 [[ "$(grep -Fc -- '"$option" != --build_event_max_named_set_of_file_entries=*' <<< "$proxy_receipt_command_options_block")" == 1 ]]
+# shellcheck disable=SC2016
+[[ "$(grep -Fc -- '"$option" != --progress_report_interval=*' <<< "$proxy_receipt_command_options_block")" == 1 ]]
 # The extracted source fragment consumes this array through `eval` below.
 # shellcheck disable=SC2034
 base_pre_config_flags=(--base-build-flag)
@@ -120,6 +141,7 @@ build_pre_config_flags=(
   "--execution_log_binary_file=$expected_execution_log_path"
   --noexecution_log_sort
   --build_event_max_named_set_of_file_entries=256
+  --progress_report_interval=1
   --kept-build-flag
 )
 receipt_args=()
@@ -206,6 +228,8 @@ done
 # shellcheck disable=SC2016
 [[ "$(grep -Fc -- '"$option" != --build_event_max_named_set_of_file_entries=*' <<< "$proxy_action_graph_block")" == 1 ]]
 # shellcheck disable=SC2016
+[[ "$(grep -Fc -- '"$option" != --progress_report_interval=*' <<< "$proxy_action_graph_block")" == 1 ]]
+# shellcheck disable=SC2016
 [[ "$(grep -Fc -- '"$option" != --execution_log_compact_file=*' <<< "$proxy_action_graph_block")" == 1 ]]
 # shellcheck disable=SC2016
 [[ "$(grep -Fc -- '"$option" != --execution_log_json_file=*' <<< "$proxy_action_graph_block")" == 1 ]]
@@ -232,6 +256,7 @@ base_pre_config_flags=(
   "--execution_log_json_file=$expected_execution_log_path"
   "--execution_log_binary_file=$expected_execution_log_path"
   --noexecution_log_sort
+  --progress_report_interval=1
   --kept-base-action-graph-flag
 )
 build_pre_config_flags=(
@@ -239,6 +264,7 @@ build_pre_config_flags=(
   "--execution_log_json_file=$expected_execution_log_path"
   "--execution_log_binary_file=$expected_execution_log_path"
   --noexecution_log_sort
+  --progress_report_interval=1
   --kept-action-graph-flag
 )
 eval "$proxy_action_graph_filter_block"

--- a/test/internal/build_proxy_launcher/build_proxy_launcher_tests.sh
+++ b/test/internal/build_proxy_launcher/build_proxy_launcher_tests.sh
@@ -63,6 +63,7 @@ readonly proxy_bep_block
 expected_bep_flag="--build_event_json_file=\$SWIFTBUILD_BAZEL_PROXY_BEP_PATH"
 readonly expected_bep_flag
 [[ "$(grep -Fc -- "$expected_bep_flag" <<< "$proxy_bep_block")" == 1 ]]
+[[ "$(grep -Fc -- '--build_event_max_named_set_of_file_entries=256' <<< "$proxy_bep_block")" == 1 ]]
 
 proxy_execution_log_flags_block="$(sed -n '/# The build service gives every operation/,/^fi$/p' "$adapter_source")"
 readonly proxy_execution_log_flags_block
@@ -108,6 +109,8 @@ readonly proxy_receipt_command_options_block
 [[ "$(grep -Fc -- '"$option" != --execution_log_binary_file=*' <<< "$proxy_receipt_command_options_block")" == 1 ]]
 # shellcheck disable=SC2016
 [[ "$(grep -Fc -- '"$option" != --noexecution_log_sort' <<< "$proxy_receipt_command_options_block")" == 1 ]]
+# shellcheck disable=SC2016
+[[ "$(grep -Fc -- '"$option" != --build_event_max_named_set_of_file_entries=*' <<< "$proxy_receipt_command_options_block")" == 1 ]]
 # The extracted source fragment consumes this array through `eval` below.
 # shellcheck disable=SC2034
 base_pre_config_flags=(--base-build-flag)
@@ -116,6 +119,7 @@ build_pre_config_flags=(
   "--execution_log_json_file=$expected_execution_log_path"
   "--execution_log_binary_file=$expected_execution_log_path"
   --noexecution_log_sort
+  --build_event_max_named_set_of_file_entries=256
   --kept-build-flag
 )
 receipt_args=()
@@ -199,6 +203,8 @@ done
 [[ "$(grep -Fc -- 'action_graph_query="deps(${labels[0]})"' <<< "$proxy_action_graph_block")" == 0 ]]
 # shellcheck disable=SC2016
 [[ "$(grep -Fc -- '"$option" != --build_event_json_file=*' <<< "$proxy_action_graph_block")" == 1 ]]
+# shellcheck disable=SC2016
+[[ "$(grep -Fc -- '"$option" != --build_event_max_named_set_of_file_entries=*' <<< "$proxy_action_graph_block")" == 1 ]]
 # shellcheck disable=SC2016
 [[ "$(grep -Fc -- '"$option" != --execution_log_compact_file=*' <<< "$proxy_action_graph_block")" == 1 ]]
 # shellcheck disable=SC2016

--- a/test/internal/build_proxy_manifest/BUILD
+++ b/test/internal/build_proxy_manifest/BUILD
@@ -3,5 +3,8 @@ load("@rules_python//python:defs.bzl", "py_test")
 py_test(
     name = "build_proxy_manifest_tests",
     srcs = ["build_proxy_manifest_tests.py"],
-    deps = ["//xcodeproj/internal:build_proxy_manifest_lib"],
+    deps = [
+        "//xcodeproj/internal:build_proxy_manifest",
+        "//xcodeproj/internal:build_proxy_manifest_lib",
+    ],
 )

--- a/test/internal/build_proxy_manifest/build_proxy_manifest_tests.py
+++ b/test/internal/build_proxy_manifest/build_proxy_manifest_tests.py
@@ -1,6 +1,9 @@
 import json
+import tempfile
 import unittest
+from pathlib import Path
 
+from xcodeproj.internal import build_proxy_manifest
 from xcodeproj.internal import build_proxy_manifest_lib
 
 
@@ -39,6 +42,31 @@ def _line(entry):
 
 
 class BuildProxyManifestTests(unittest.TestCase):
+    def test_cli_accepts_environment_options_before_manifest_fragments(self):
+        with tempfile.TemporaryDirectory() as temp_directory:
+            root = Path(temp_directory)
+            output = root / "manifest.json"
+            fragment = root / "fragment.jsonl"
+            fragment.write_text(_line(_entry()) + "\n")
+
+            build_proxy_manifest.main(
+                [
+                    str(output),
+                    "@@//app:project",
+                    "/usr/local/bin/bazel",
+                    "App.xcodeproj",
+                    "--bazel-environment-key=CUSTOM_ENV",
+                    str(fragment),
+                ]
+            )
+
+            manifest = json.loads(output.read_text())
+            self.assertEqual(
+                manifest["invocation"]["bazelEnvironmentKeys"],
+                ["CUSTOM_ENV"],
+            )
+            self.assertEqual(len(manifest["targets"]), 1)
+
     def test_assemble_is_versioned_and_byte_deterministic(self):
         debug = _line(_entry())
         release = _line(_entry(configuration="Release"))

--- a/test/internal/build_proxy_manifest/build_proxy_manifest_tests.py
+++ b/test/internal/build_proxy_manifest/build_proxy_manifest_tests.py
@@ -46,12 +46,14 @@ class BuildProxyManifestTests(unittest.TestCase):
         forward = build_proxy_manifest_lib.assemble(
             [("a", 1, release), ("b", 1, debug)],
             bazel_path="/usr/local/bin/bazel",
+            bazel_environment_keys=["Z_CUSTOM", "CUSTOM_ENV"],
             generator_label="@@//app:project",
             project_container="App.xcodeproj",
         )
         reverse = build_proxy_manifest_lib.assemble(
             [("b", 1, debug), ("a", 1, release)],
             bazel_path="/usr/local/bin/bazel",
+            bazel_environment_keys=["CUSTOM_ENV", "Z_CUSTOM"],
             generator_label="@@//app:project",
             project_container="App.xcodeproj",
         )
@@ -73,6 +75,7 @@ class BuildProxyManifestTests(unittest.TestCase):
                 "adapterPath": "rules_xcodeproj/bazel/generate_bazel_dependencies.sh",
                 "bazelPath": "/usr/local/bin/bazel",
                 "bazelrcPath": "rules_xcodeproj/bazel/xcodeproj.bazelrc",
+                "bazelEnvironmentKeys": ["CUSTOM_ENV", "Z_CUSTOM"],
                 "environmentKeys": build_proxy_manifest_lib.INVOCATION_ENVIRONMENT_KEYS,
                 "generatorLabel": "@@//app:project",
                 "receiptSchemaVersion": 1,
@@ -86,6 +89,19 @@ class BuildProxyManifestTests(unittest.TestCase):
             [entry["configuration"] for entry in manifest["targets"]],
             ["Debug", "Release"],
         )
+
+    def test_sensitive_bazel_environment_key_is_rejected(self):
+        with self.assertRaisesRegex(
+            build_proxy_manifest_lib.ManifestError,
+            "sensitive Bazel environment key",
+        ):
+            build_proxy_manifest_lib.assemble(
+                [],
+                bazel_path="bazel",
+                bazel_environment_keys=["PRIVATE_TOKEN"],
+                generator_label="@@//app:project",
+                project_container="App.xcodeproj",
+            )
 
     def test_missing_required_key_is_rejected(self):
         entry = _entry()

--- a/xcodeproj/internal/build_proxy_manifest.bzl
+++ b/xcodeproj/internal/build_proxy_manifest.bzl
@@ -3,6 +3,7 @@
 def write_build_proxy_manifest(
         *,
         actions,
+        bazel_environment_keys,
         bazel_path,
         entries_files,
         generator_label,
@@ -13,6 +14,7 @@ def write_build_proxy_manifest(
 
     Args:
         actions: `ctx.actions`.
+        bazel_environment_keys: Names supplied by the generated Bazel environment.
         bazel_path: The Bazel executable path recorded for proxy invocation.
         entries_files: JSON Lines manifest fragments from target shards.
         generator_label: The `xcodeproj` generator label the proxy must build.
@@ -33,6 +35,8 @@ def write_build_proxy_manifest(
     args.add(str(generator_label))
     args.add(bazel_path)
     args.add(project_container)
+    for key in bazel_environment_keys:
+        args.add("--bazel-environment-key={}".format(key))
     args.add_all(entries_files)
 
     actions.run(

--- a/xcodeproj/internal/build_proxy_manifest.py
+++ b/xcodeproj/internal/build_proxy_manifest.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from xcodeproj.internal import build_proxy_manifest_lib
 
 
-def main() -> None:
+def main(argv=None) -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("output", type=Path)
     parser.add_argument("generator_label")
@@ -15,7 +15,7 @@ def main() -> None:
     parser.add_argument("project_container")
     parser.add_argument("--bazel-environment-key", action="append", default=[])
     parser.add_argument("fragments", nargs="*", type=Path)
-    args = parser.parse_args()
+    args = parser.parse_intermixed_args(argv)
     build_proxy_manifest_lib.write(
         args.output,
         args.fragments,

--- a/xcodeproj/internal/build_proxy_manifest.py
+++ b/xcodeproj/internal/build_proxy_manifest.py
@@ -13,12 +13,14 @@ def main() -> None:
     parser.add_argument("generator_label")
     parser.add_argument("bazel_path")
     parser.add_argument("project_container")
+    parser.add_argument("--bazel-environment-key", action="append", default=[])
     parser.add_argument("fragments", nargs="*", type=Path)
     args = parser.parse_args()
     build_proxy_manifest_lib.write(
         args.output,
         args.fragments,
         bazel_path=args.bazel_path,
+        bazel_environment_keys=args.bazel_environment_key,
         generator_label=args.generator_label,
         project_container=args.project_container,
     )

--- a/xcodeproj/internal/build_proxy_manifest_lib.py
+++ b/xcodeproj/internal/build_proxy_manifest_lib.py
@@ -1,6 +1,7 @@
 """Deterministically assembles version 2 build-proxy manifest fragments."""
 
 import json
+import re
 from pathlib import Path
 from typing import Iterable, Mapping, Sequence
 
@@ -155,6 +156,7 @@ def assemble(
     fragment_lines: Iterable[tuple[str, int, str]],
     *,
     bazel_path: str,
+    bazel_environment_keys: Sequence[str] = (),
     generator_label: str,
     project_container: str,
 ) -> bytes:
@@ -163,6 +165,25 @@ def assemble(
         raise ManifestError("generator label must not be empty")
     if not bazel_path:
         raise ManifestError("Bazel path must not be empty")
+    normalized_bazel_environment_keys = sorted(set(bazel_environment_keys))
+    for key in normalized_bazel_environment_keys:
+        if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", key):
+            raise ManifestError(f"invalid Bazel environment key: {key!r}")
+        normalized_key = key.upper().replace("-", "_")
+        if any(
+            marker in normalized_key
+            for marker in (
+                "TOKEN",
+                "PASSWORD",
+                "SECRET",
+                "CREDENTIAL",
+                "API_KEY",
+                "AUTHORIZATION",
+                "COOKIE",
+                "HEADER",
+            )
+        ):
+            raise ManifestError(f"sensitive Bazel environment key: {key!r}")
     project_container_path = Path(project_container)
     if not project_container or project_container_path.is_absolute():
         raise ManifestError("project container must be a relative path")
@@ -202,6 +223,7 @@ def assemble(
             "adapterPath": ADAPTER_PATH,
             "bazelPath": bazel_path,
             "bazelrcPath": BAZELRC_PATH,
+            "bazelEnvironmentKeys": normalized_bazel_environment_keys,
             "environmentKeys": INVOCATION_ENVIRONMENT_KEYS,
             "generatorLabel": generator_label,
             "receiptSchemaVersion": RECEIPT_SCHEMA_VERSION,
@@ -228,6 +250,7 @@ def assemble_files(
     paths: Sequence[Path],
     *,
     bazel_path: str,
+    bazel_environment_keys: Sequence[str] = (),
     generator_label: str,
     project_container: str,
 ) -> bytes:
@@ -241,6 +264,7 @@ def assemble_files(
     return assemble(
         lines,
         bazel_path=bazel_path,
+        bazel_environment_keys=bazel_environment_keys,
         generator_label=generator_label,
         project_container=project_container,
     )
@@ -251,6 +275,7 @@ def write(
     fragments: Sequence[Path],
     *,
     bazel_path: str,
+    bazel_environment_keys: Sequence[str] = (),
     generator_label: str,
     project_container: str,
 ) -> None:
@@ -258,6 +283,7 @@ def write(
         assemble_files(
             fragments,
             bazel_path=bazel_path,
+            bazel_environment_keys=bazel_environment_keys,
             generator_label=generator_label,
             project_container=project_container,
         )

--- a/xcodeproj/internal/templates/bazel_build.sh
+++ b/xcodeproj/internal/templates/bazel_build.sh
@@ -196,6 +196,7 @@ if [[ -n "${SWIFTBUILD_BAZEL_PROXY_INVOCATION_RECEIPT:-}" ]]; then
     if [[
       "$option" != --build_event_json_file=* &&
       "$option" != --build_event_max_named_set_of_file_entries=* &&
+      "$option" != --progress_report_interval=* &&
       "$option" != --execution_log_compact_file=* &&
       "$option" != --execution_log_json_file=* &&
       "$option" != --execution_log_binary_file=* &&

--- a/xcodeproj/internal/templates/bazel_build.sh
+++ b/xcodeproj/internal/templates/bazel_build.sh
@@ -195,6 +195,7 @@ if [[ -n "${SWIFTBUILD_BAZEL_PROXY_INVOCATION_RECEIPT:-}" ]]; then
   for option in "${base_pre_config_flags[@]}" "${build_pre_config_flags[@]}"; do
     if [[
       "$option" != --build_event_json_file=* &&
+      "$option" != --build_event_max_named_set_of_file_entries=* &&
       "$option" != --execution_log_compact_file=* &&
       "$option" != --execution_log_json_file=* &&
       "$option" != --execution_log_binary_file=* &&

--- a/xcodeproj/internal/templates/generate_bazel_dependencies.sh
+++ b/xcodeproj/internal/templates/generate_bazel_dependencies.sh
@@ -159,6 +159,10 @@ if [[ -n "${SWIFTBUILD_BAZEL_PROXY_BEP_PATH:-}" ]]; then
     "--build_event_publish_all_actions"
     "--build_event_json_file=$SWIFTBUILD_BAZEL_PROXY_BEP_PATH"
     "--build_event_max_named_set_of_file_entries=256"
+    # Bazel's default non-curses cadence waits 10 seconds before reporting a running action. The
+    # proxy consumes this BEP status as a presentation hint only; completion/cache truth still
+    # comes from ActionExecuted and the execution log.
+    "--progress_report_interval=1"
   )
 fi
 # The build service gives every operation its own private path. Keep execution metadata attached
@@ -256,6 +260,7 @@ if [[ -n "${SWIFTBUILD_BAZEL_PROXY_ACTION_GRAPH_PATH:-}" ]]; then
       "$option" != --build_event_publish_all_actions &&
       "$option" != --build_event_json_file=* &&
       "$option" != --build_event_max_named_set_of_file_entries=* &&
+      "$option" != --progress_report_interval=* &&
       "$option" != --execution_log_compact_file=* &&
       "$option" != --execution_log_json_file=* &&
       "$option" != --execution_log_binary_file=* &&

--- a/xcodeproj/internal/templates/generate_bazel_dependencies.sh
+++ b/xcodeproj/internal/templates/generate_bazel_dependencies.sh
@@ -158,6 +158,7 @@ if [[ -n "${SWIFTBUILD_BAZEL_PROXY_BEP_PATH:-}" ]]; then
   build_pre_config_flags+=(
     "--build_event_publish_all_actions"
     "--build_event_json_file=$SWIFTBUILD_BAZEL_PROXY_BEP_PATH"
+    "--build_event_max_named_set_of_file_entries=256"
   )
 fi
 # The build service gives every operation its own private path. Keep execution metadata attached
@@ -254,6 +255,7 @@ if [[ -n "${SWIFTBUILD_BAZEL_PROXY_ACTION_GRAPH_PATH:-}" ]]; then
     if [[
       "$option" != --build_event_publish_all_actions &&
       "$option" != --build_event_json_file=* &&
+      "$option" != --build_event_max_named_set_of_file_entries=* &&
       "$option" != --execution_log_compact_file=* &&
       "$option" != --execution_log_json_file=* &&
       "$option" != --execution_log_binary_file=* &&

--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -316,6 +316,7 @@ def _write_installer(
 def _write_project_contents(
         *,
         actions,
+        bazel_environment_keys,
         bazel_path,
         bin_dir_path,
         build_proxy_manifest_generator,
@@ -426,6 +427,7 @@ def _write_project_contents(
 
     build_proxy_manifest = write_build_proxy_manifest(
         actions = actions,
+        bazel_environment_keys = bazel_environment_keys,
         bazel_path = bazel_path,
         entries_files = build_proxy_manifest_entries_files,
         generator_label = generator_label,
@@ -663,6 +665,7 @@ Are you using an `alias`? `xcodeproj.focused_targets` and \
         target_ids_list,
     ) = _write_project_contents(
         actions = actions,
+        bazel_environment_keys = sorted(ctx.attr.bazel_env.keys()),
         bazel_path = ctx.attr.bazel_path,
         bin_dir_path = ctx.bin_dir.path,
         build_proxy_manifest_generator = (


### PR DESCRIPTION
## Summary\n\n- stream bounded Bazel build-event progress to an opted-in build proxy\n- keep existing generated-project behavior unchanged when the proxy contract is absent\n- make large named-set events compatible with incremental proxy consumption\n\n## Stack\n\n- Base: #3332\n- This PR is the first live-presentation slice after the consumer path contract\n\n## Validation\n\n- focused build-proxy launcher tests\n- Buildifier and shell syntax checks\n- live Reddit consumer evidence is tracked separately from this rules-owned slice\n\n## Testing\n\nGenerate a proxy-enabled project, build through Xcode, and confirm progress changes before the Bazel process exits.