### PR TITLE
Capture operation-scoped Bazel profiles

### DIFF
--- a/test/internal/build_proxy_launcher/build_proxy_launcher_tests.sh
+++ b/test/internal/build_proxy_launcher/build_proxy_launcher_tests.sh
@@ -132,6 +132,12 @@ readonly proxy_receipt_command_options_block
 [[ "$(grep -Fc -- '"$option" != --build_event_max_named_set_of_file_entries=*' <<< "$proxy_receipt_command_options_block")" == 1 ]]
 # shellcheck disable=SC2016
 [[ "$(grep -Fc -- '"$option" != --progress_report_interval=*' <<< "$proxy_receipt_command_options_block")" == 1 ]]
+# shellcheck disable=SC2016
+[[ "$(grep -Fc -- '"$option" != --build_event_publish_all_actions' <<< "$proxy_receipt_command_options_block")" == 1 ]]
+# shellcheck disable=SC2016
+[[ "$(grep -Fc -- '"$option" != --profile=*' <<< "$proxy_receipt_command_options_block")" == 1 ]]
+# shellcheck disable=SC2016
+[[ "$(grep -Fc -- '"$option" != --generate_json_trace_profile=*' <<< "$proxy_receipt_command_options_block")" == 1 ]]
 # The extracted source fragment consumes this array through `eval` below.
 # shellcheck disable=SC2034
 base_pre_config_flags=(--base-build-flag)
@@ -142,6 +148,10 @@ build_pre_config_flags=(
   --noexecution_log_sort
   --build_event_max_named_set_of_file_entries=256
   --progress_report_interval=1
+  --build_event_publish_all_actions
+  "--profile=$test_root/user-profile.json.gz"
+  --generate_json_trace_profile=true
+  --nogenerate_json_trace_profile
   --kept-build-flag
 )
 receipt_args=()
@@ -156,6 +166,45 @@ proxy_action_start_flags_block="$(sed -n '/SWIFTBUILD_BAZEL_PROXY_ACTION_STARTS_
 readonly proxy_action_start_flags_block
 [[ "$(grep -Fc -- 'build_log_cmd+=(--subcommands=pretty_print)' <<< "$proxy_action_start_flags_block")" == 1 ]]
 [[ "$(grep -Fc -- 'receipt_args+=' <<< "$proxy_action_start_flags_block")" == 0 ]]
+
+# The profile is proxy-owned, comes after the named config, and keeps the exact operation-scoped
+# path out of the publishable invocation receipt.
+proxy_profile_flags_block="$(sed -n '/^if \[\[ -n "${SWIFTBUILD_BAZEL_PROXY_PROFILE_PATH:-}" \]\]; then$/,/^fi$/p' "$bazel_build_source")"
+readonly proxy_profile_flags_block
+# shellcheck disable=SC2016
+[[ "$(grep -Fc -- '--profile=$SWIFTBUILD_BAZEL_PROXY_PROFILE_PATH' <<< "$proxy_profile_flags_block")" == 1 ]]
+build_log_cmd=(--existing-build-flag)
+unset SWIFTBUILD_BAZEL_PROXY_PROFILE_PATH
+eval "$proxy_profile_flags_block"
+[[ "${build_log_cmd[*]}" == "--existing-build-flag" ]]
+readonly expected_profile_path="$test_root/bazel profile.json.gz"
+build_log_cmd=(--existing-build-flag)
+SWIFTBUILD_BAZEL_PROXY_PROFILE_PATH="$expected_profile_path"
+export SWIFTBUILD_BAZEL_PROXY_PROFILE_PATH
+eval "$proxy_profile_flags_block"
+[[ "${build_log_cmd[0]}" == "--existing-build-flag" ]]
+[[ "${build_log_cmd[1]}" == "--profile=$expected_profile_path" ]]
+
+# The profile is secured for successful, failed, and interrupted builds. A missing profile is valid
+# when Bazel terminates before creating it; a linked or non-regular result fails closed.
+proxy_profile_permissions_block="$(sed -n '/^secure_build_proxy_profile() {$/,/^}$/p' "$bazel_build_source")"
+readonly proxy_profile_permissions_block
+eval "$proxy_profile_permissions_block"
+printf 'private Bazel trace\n' > "$expected_profile_path"
+chmod 666 "$expected_profile_path"
+secure_build_proxy_profile
+# shellcheck disable=SC2012
+[[ "$(LC_ALL=C ls -l "$expected_profile_path" | cut -c 1-10)" == "-rw-------" ]]
+rm "$expected_profile_path"
+secure_build_proxy_profile
+printf 'outside\n' > "$test_root/outside-profile"
+ln -s "$test_root/outside-profile" "$expected_profile_path"
+if secure_build_proxy_profile 2> /dev/null; then
+  echo >&2 "Expected linked Bazel profile to fail closed"
+  exit 1
+fi
+rm "$expected_profile_path"
+unset SWIFTBUILD_BAZEL_PROXY_PROFILE_PATH
 
 # A proxied adapter is already the inner Xcode invocation. Preserve the generated hermetic Bazel
 # executable (or an explicitly inherited one), and tell workspace wrappers not to regenerate their
@@ -244,9 +293,15 @@ done
 [[ "$(grep -Fc -- '"$option" != --execution_log_binary_file=*' <<< "$proxy_action_graph_block")" == 1 ]]
 # shellcheck disable=SC2016
 [[ "$(grep -Fc -- '"$option" != --noexecution_log_sort' <<< "$proxy_action_graph_block")" == 1 ]]
+# shellcheck disable=SC2016
+[[ "$(grep -Fc -- '"$option" != --profile=*' <<< "$proxy_action_graph_block")" == 1 ]]
+# shellcheck disable=SC2016
+[[ "$(grep -Fc -- '"$option" != --generate_json_trace_profile=*' <<< "$proxy_action_graph_block")" == 1 ]]
 # The metadata-only aquery comes after the build and must not inherit command-printing from a
 # common/build/config bazelrc or duplicate action-start events.
 [[ "$(grep -Fxc -- '    --subcommands=false \' <<< "$proxy_action_graph_block")" == 1 ]]
+[[ "$(grep -Fxc -- '    --profile= \' <<< "$proxy_action_graph_block")" == 1 ]]
+[[ "$(grep -Fxc -- '    --generate_json_trace_profile=false \' <<< "$proxy_action_graph_block")" == 1 ]]
 # Command-line clears come after the named config, so execution-log settings inherited directly
 # from common/build/config bazelrc sections cannot leak into the metadata-only aquery.
 for cleared_execution_log_flag in \
@@ -267,6 +322,9 @@ base_pre_config_flags=(
   "--execution_log_binary_file=$expected_execution_log_path"
   --noexecution_log_sort
   --progress_report_interval=1
+  "--profile=$test_root/user-profile.json.gz"
+  --generate_json_trace_profile=true
+  --nogenerate_json_trace_profile
   --kept-base-action-graph-flag
 )
 build_pre_config_flags=(
@@ -275,6 +333,8 @@ build_pre_config_flags=(
   "--execution_log_binary_file=$expected_execution_log_path"
   --noexecution_log_sort
   --progress_report_interval=1
+  "--profile=$test_root/user-profile.json.gz"
+  --generate_json_trace_profile=false
   --kept-action-graph-flag
 )
 eval "$proxy_action_graph_filter_block"

--- a/xcodeproj/internal/templates/bazel_build.sh
+++ b/xcodeproj/internal/templates/bazel_build.sh
@@ -195,12 +195,17 @@ if [[ -n "${SWIFTBUILD_BAZEL_PROXY_INVOCATION_RECEIPT:-}" ]]; then
   for option in "${base_pre_config_flags[@]}" "${build_pre_config_flags[@]}"; do
     if [[
       "$option" != --build_event_json_file=* &&
+      "$option" != --build_event_publish_all_actions &&
       "$option" != --build_event_max_named_set_of_file_entries=* &&
       "$option" != --progress_report_interval=* &&
       "$option" != --execution_log_compact_file=* &&
       "$option" != --execution_log_json_file=* &&
       "$option" != --execution_log_binary_file=* &&
-      "$option" != --noexecution_log_sort
+      "$option" != --noexecution_log_sort &&
+      "$option" != --profile=* &&
+      "$option" != --generate_json_trace_profile=* &&
+      "$option" != --generate_json_trace_profile &&
+      "$option" != --nogenerate_json_trace_profile
     ]]; then
       receipt_args+=("--command-option=$option")
     fi
@@ -248,6 +253,11 @@ if [[ -n "${SWIFTBUILD_BAZEL_PROXY_ACTION_STARTS_PATH:-}" ]]; then
   # bounded, allowlisted JSON record to the per-operation path.
   build_log_cmd+=(--subcommands=pretty_print)
 fi
+if [[ -n "${SWIFTBUILD_BAZEL_PROXY_PROFILE_PATH:-}" ]]; then
+  # Keep the Bazel trace bound to this Xcode operation. This comes after the named config so a
+  # user/common/config bazelrc cannot redirect private profiling data elsewhere.
+  build_log_cmd+=("--profile=$SWIFTBUILD_BAZEL_PROXY_PROFILE_PATH")
+fi
 if [[ -n "${toolchain:-}" ]]; then
   build_log_cmd+=("--action_env=TOOLCHAINS=$toolchain")
 fi
@@ -260,12 +270,26 @@ if [[ -n "${labels:-}" ]]; then
 fi
 readonly build_log_cmd
 
+secure_build_proxy_profile() {
+  local profile_path="${SWIFTBUILD_BAZEL_PROXY_PROFILE_PATH:-}"
+  [[ -n "$profile_path" ]] || return 0
+  if [[ ! -e "$profile_path" && ! -L "$profile_path" ]]; then
+    return 0
+  fi
+  if [[ -L "$profile_path" || ! -f "$profile_path" ]]; then
+    echo "error: Bazel build profile is not a regular file." >&2
+    return 1
+  fi
+  chmod 600 "$profile_path"
+}
+
 if [[ -n "${SWIFTBUILD_BAZEL_PROXY_REQUEST_DIR:-}" ]]; then
   "${build_log_cmd[@]}" 2>&1 &
   readonly proxy_build_pid=$!
   cancel_proxy_build() {
     kill -TERM "$proxy_build_pid" 2>/dev/null || true
     wait "$proxy_build_pid" 2>/dev/null || true
+    secure_build_proxy_profile
     exit 143
   }
   trap cancel_proxy_build TERM INT
@@ -274,11 +298,19 @@ if [[ -n "${SWIFTBUILD_BAZEL_PROXY_REQUEST_DIR:-}" ]]; then
   proxy_build_status=$?
   set -e
   trap - TERM INT
+  secure_build_proxy_profile
   if [[ $proxy_build_status -ne 0 ]]; then
     exit "$proxy_build_status"
   fi
 else
+  set +e
   "${build_log_cmd[@]}" 2>&1
+  proxy_direct_build_status=$?
+  set -e
+  secure_build_proxy_profile
+  if [[ $proxy_direct_build_status -ne 0 ]]; then
+    exit "$proxy_direct_build_status"
+  fi
 fi
 
 # Verify that we actually built what we requested

--- a/xcodeproj/internal/templates/generate_bazel_dependencies.sh
+++ b/xcodeproj/internal/templates/generate_bazel_dependencies.sh
@@ -264,7 +264,11 @@ if [[ -n "${SWIFTBUILD_BAZEL_PROXY_ACTION_GRAPH_PATH:-}" ]]; then
       "$option" != --execution_log_compact_file=* &&
       "$option" != --execution_log_json_file=* &&
       "$option" != --execution_log_binary_file=* &&
-      "$option" != --noexecution_log_sort
+      "$option" != --noexecution_log_sort &&
+      "$option" != --profile=* &&
+      "$option" != --generate_json_trace_profile=* &&
+      "$option" != --generate_json_trace_profile &&
+      "$option" != --nogenerate_json_trace_profile
     ]]; then
       action_graph_pre_config_flags+=("$option")
     fi
@@ -283,6 +287,8 @@ if [[ -n "${SWIFTBUILD_BAZEL_PROXY_ACTION_GRAPH_PATH:-}" ]]; then
     --execution_log_binary_file= \
     --execution_log_compact_file= \
     --execution_log_json_file= \
+    --profile= \
+    --generate_json_trace_profile=false \
     --subcommands=false \
     "$output_groups_flag" \
     --color=no \


### PR DESCRIPTION
## Summary\n\n- force Bazel JSON trace output into the proxy operation directory\n- prevent bazelrc settings from redirecting the private operation profile\n- filter diagnostic-only profile and all-action options from publishable receipts and aquery replays\n- secure the finished profile as a regular mode-0600 file on success, failure, or interruption\n\n## Stack\n\n- Base: the live action lifecycle PR\n- This PR is diagnostic plumbing only; profile summarization and presentation remain separate slices\n\n## Validation\n\n- uncached focused launcher test with ignore-all-rc-files\n- bash syntax, ShellCheck, and Buildifier\n- negative coverage for unset profile paths and receipt filtering\n\n## Testing\n\nRun a proxy-enabled operation, verify bazel-profile.json.gz is private to that operation, then bind its invocation UUID to the matching BEP before analysis.